### PR TITLE
Fix android native notification on incoming call (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All user visible changes to this project will be documented in this file. This p
 ### Fixed
 
 - Android:
-    - [ConnectionService] displaying call when application is in foreground (#10).
+    - [ConnectionService] displaying call when application is in foreground (#13).
 
 
 [Semantic Versioning 2.0.0]: https://semver.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All user visible changes to this project will be documented in this file. This p
 [Diff](/../../compare/3aa35d5bf8ba9728f54db7bf4e21425711097cda...v0.1.0-alpha.6)
 
 
+### Fixed
+
+- Android:
+    - [ConnectionService] displaying call when application is in foreground (#10).
 
 
 [Semantic Versioning 2.0.0]: https://semver.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All user visible changes to this project will be documented in this file. This p
 ## [0.1.0-alpha.6] · 2022-??-??
 [0.1.0-alpha.6]: /../../tree/v0.1.0-alpha.6
 
-[Diff](/../../compare/3aa35d5bf8ba9728f54db7bf4e21425711097cda...v0.1.0-alpha.6) | [Milestone] (/../../milestone/1)
+[Diff](/../../compare/3aa35d5bf8ba9728f54db7bf4e21425711097cda...v0.1.0-alpha.6) | [Milestone](/../../milestone/1)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ All user visible changes to this project will be documented in this file. This p
 ## [0.1.0-alpha.6] · 2022-??-??
 [0.1.0-alpha.6]: /../../tree/v0.1.0-alpha.6
 
-[Diff](/../../compare/3aa35d5bf8ba9728f54db7bf4e21425711097cda...v0.1.0-alpha.6)
-
+[Diff](/../../compare/3aa35d5bf8ba9728f54db7bf4e21425711097cda...v0.1.0-alpha.6) | [Milestone] (/../../milestone/1)
 
 ### Fixed
 
 - Android:
-    - [ConnectionService] displaying call when application is in foreground (#13).
+    - [ConnectionService] displaying call when application is in foreground ([#14]).
+
+[#14]: /../../pull/14
 
 
+
+
+[ConnectionService]: https://developer.android.com/reference/android/telecom/ConnectionService
 [Semantic Versioning 2.0.0]: https://semver.org

--- a/lib/ui/worker/background/src/main.dart
+++ b/lib/ui/worker/background/src/main.dart
@@ -272,6 +272,10 @@ class _BackgroundService {
       _initL10n(event!['locale']);
     });
 
+    _service.on('ka').listen((_) {
+      _resetConnectionTimer();
+    });
+
     _service.invoke('requireToken');
 
     _setForegroundNotificationInfo(


### PR DESCRIPTION
Resolves #13



## Synopsis

На мобильном устройстве под ОС Android не должно приходить уведомление о входящем звонке в том случае, если приложение открыто и находится в foreground'е.




## Solution

Ранее эта логика была реализована с помощью передачи флажков о lifecycle'е приложения, но что-то её сломало.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
