### PR TITLE
Implement `PubspecBuilder` instead of including `pubspec.yaml`

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -16,257 +16,259 @@ targets:
               naming_scheme: pathedWithFields
           scalar_mapping:
             - graphql_type: AccessToken
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/session.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/session.dart"
               dart_type:
                 name: AccessToken
                 imports:
-                  - 'package:messenger/domain/model/session.dart'
+                  - "package:messenger/domain/model/session.dart"
             - graphql_type: AttachmentId
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/chat.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/chat.dart"
               dart_type:
                 name: AttachmentId
                 imports:
-                  - 'package:messenger/domain/model/attachment.dart'
+                  - "package:messenger/domain/model/attachment.dart"
             - graphql_type: ChatCallCredentials
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/call.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/call.dart"
               dart_type:
                 name: ChatCallCredentials
                 imports:
-                  - 'package:messenger/domain/model/chat_call.dart'
+                  - "package:messenger/domain/model/chat_call.dart"
             - graphql_type: ChatCallDeviceId
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/call.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/call.dart"
               dart_type:
                 name: ChatCallDeviceId
                 imports:
-                  - 'package:messenger/domain/model/chat_call.dart'
+                  - "package:messenger/domain/model/chat_call.dart"
             - graphql_type: ChatCallRoomJoinLink
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/call.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/call.dart"
               dart_type:
                 name: ChatCallRoomJoinLink
                 imports:
-                  - 'package:messenger/store/event/chat_call.dart'
+                  - "package:messenger/store/event/chat_call.dart"
             - graphql_type: ChatContactId
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/contact.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/contact.dart"
               dart_type:
                 name: ChatContactId
                 imports:
-                  - 'package:messenger/domain/model/contact.dart'
+                  - "package:messenger/domain/model/contact.dart"
             - graphql_type: ChatContactPosition
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/contact.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/contact.dart"
               dart_type:
                 name: ChatContactPosition
                 imports:
-                  - 'package:messenger/domain/model/contact.dart'
+                  - "package:messenger/domain/model/contact.dart"
             - graphql_type: ChatContactsCursor
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/contact.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/contact.dart"
               dart_type:
                 name: ChatContactsCursor
                 imports:
-                  - 'package:messenger/store/model/contact.dart'
+                  - "package:messenger/store/model/contact.dart"
             - graphql_type: ChatContactsListVersion
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/contact.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/contact.dart"
               dart_type:
                 name: ChatContactsListVersion
                 imports:
-                  - 'package:messenger/store/model/contact.dart'
+                  - "package:messenger/store/model/contact.dart"
             - graphql_type: ChatContactVersion
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/contact.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/contact.dart"
               dart_type:
                 name: ChatContactVersion
                 imports:
-                  - 'package:messenger/store/model/contact.dart'
+                  - "package:messenger/store/model/contact.dart"
             - graphql_type: ChatDirectLinkSlug
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: ChatDirectLinkSlug
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: ChatDirectLinkVersion
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: ChatDirectLinkVersion
                 imports:
-                  - 'package:messenger/store/model/my_user.dart'
+                  - "package:messenger/store/model/my_user.dart"
             - graphql_type: ChatId
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/chat.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/chat.dart"
               dart_type:
                 name: ChatId
                 imports:
-                  - 'package:messenger/domain/model/chat.dart'
+                  - "package:messenger/domain/model/chat.dart"
             - graphql_type: ChatItemId
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/chat.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/chat.dart"
               dart_type:
                 name: ChatItemId
                 imports:
-                  - 'package:messenger/domain/model/chat_item.dart'
+                  - "package:messenger/domain/model/chat_item.dart"
             - graphql_type: ChatItemsCursor
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/chat.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/chat.dart"
               dart_type:
                 name: ChatItemsCursor
                 imports:
-                  - 'package:messenger/store/model/chat_item.dart'
+                  - "package:messenger/store/model/chat_item.dart"
             - graphql_type: ChatItemVersion
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/chat.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/chat.dart"
               dart_type:
                 name: ChatItemVersion
                 imports:
-                  - 'package:messenger/store/model/chat_item.dart'
+                  - "package:messenger/store/model/chat_item.dart"
             - graphql_type: ChatMessageText
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/chat.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/chat.dart"
               dart_type:
                 name: ChatMessageText
                 imports:
-                  - 'package:messenger/domain/model/chat_item.dart'
+                  - "package:messenger/domain/model/chat_item.dart"
             - graphql_type: ChatName
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/chat.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/chat.dart"
               dart_type:
                 name: ChatName
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: ChatVersion
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/chat.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/chat.dart"
               dart_type:
                 name: ChatVersion
                 imports:
-                  - 'package:messenger/store/model/chat.dart'
+                  - "package:messenger/store/model/chat.dart"
             - graphql_type: ConfirmationCode
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: ConfirmationCode
                 imports:
-                  - 'package:messenger/domain/model/my_user.dart'
+                  - "package:messenger/domain/model/my_user.dart"
             - graphql_type: DateTime
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/precise_date_time.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/precise_date_time.dart"
               dart_type:
                 name: PreciseDateTime
                 imports:
-                  - 'package:messenger/domain/model/precise_date_time/precise_date_time.dart'
+                  - "package:messenger/domain/model/precise_date_time/precise_date_time.dart"
             - graphql_type: GalleryItemId
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/gallery.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/gallery.dart"
               dart_type:
                 name: GalleryItemId
                 imports:
-                  - 'package:messenger/domain/model/gallery_item.dart'
+                  - "package:messenger/domain/model/gallery_item.dart"
             - graphql_type: ImageGalleryItem
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: ImageGalleryItem
                 imports:
-                  - 'package:messenger/domain/model/image_gallery_item.dart'
+                  - "package:messenger/domain/model/image_gallery_item.dart"
             - graphql_type: IncomingChatCallsCursor
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/call.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/call.dart"
               dart_type:
                 name: IncomingChatCallsCursor
                 imports:
-                  - 'package:messenger/store/model/chat_call.dart'
+                  - "package:messenger/store/model/chat_call.dart"
             - graphql_type: MyUserVersion
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: MyUserVersion
                 imports:
-                  - 'package:messenger/store/model/my_user.dart'
+                  - "package:messenger/store/model/my_user.dart"
             - graphql_type: RecentChatsCursor
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/chat.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/chat.dart"
               dart_type:
                 name: RecentChatsCursor
                 imports:
-                  - 'package:messenger/store/model/chat.dart'
+                  - "package:messenger/store/model/chat.dart"
             - graphql_type: RememberToken
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/session.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/session.dart"
               dart_type:
                 name: RememberToken
                 imports:
-                  - 'package:messenger/domain/model/session.dart'
+                  - "package:messenger/domain/model/session.dart"
             - graphql_type: RememberedSessionVersion
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/session.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/session.dart"
               dart_type:
                 name: RememberedSessionVersion
                 imports:
-                  - 'package:messenger/store/model/session_data.dart'
+                  - "package:messenger/store/model/session_data.dart"
             - graphql_type: SessionVersion
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/session.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/session.dart"
               dart_type:
                 name: SessionVersion
                 imports:
-                  - 'package:messenger/store/model/session_data.dart'
+                  - "package:messenger/store/model/session_data.dart"
             - graphql_type: Upload
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/upload.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/upload.dart"
               dart_type:
                 name: MultipartFile
                 imports:
-                  - 'package:http/http.dart'
+                  - "package:http/http.dart"
             - graphql_type: UserBio
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserBio
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: UserEmail
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserEmail
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: UserId
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserId
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: UserLogin
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserLogin
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: UserName
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserName
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: UserNum
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserNum
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: UserPassword
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserPassword
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: UserPhone
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserPhone
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: UsersCursor
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UsersCursor
                 imports:
-                  - 'package:messenger/store/model/user.dart'
+                  - "package:messenger/store/model/user.dart"
             - graphql_type: UserTextStatus
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserTextStatus
                 imports:
-                  - 'package:messenger/domain/model/user.dart'
+                  - "package:messenger/domain/model/user.dart"
             - graphql_type: UserVersion
-              custom_parser_import: 'package:messenger/api/backend/graphql/parsers/user.dart'
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/user.dart"
               dart_type:
                 name: UserVersion
                 imports:
-                  - 'package:messenger/store/model/user.dart'
+                  - "package:messenger/store/model/user.dart"
       messenger|pubspec_builder:
         enabled: true
+
 builders:
   pubspec_builder:
     import: "package:messenger/util/pubspec_builder.dart"
     builder_factories: ["pubspecBuilder"]
-    build_extensions: {"$package$": [".g.dart"]}
+    build_extensions:
+      "$package$": [".g.dart"]
     auto_apply: dependents
     build_to: source

--- a/build.yaml
+++ b/build.yaml
@@ -261,3 +261,12 @@ targets:
                 name: UserVersion
                 imports:
                   - 'package:messenger/store/model/user.dart'
+      messenger|pubspec_builder:
+        enabled: true
+builders:
+  pubspec_builder:
+    import: "package:messenger/util/pubspec_builder.dart"
+    builder_factories: ["pubspecBuilder"]
+    build_extensions: {"$package$": [".g.dart"]}
+    auto_apply: dependents
+    build_to: source

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     show NotificationResponse;
 import 'package:get/get.dart';
@@ -33,7 +32,6 @@ import 'package:path_provider/path_provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:universal_io/io.dart';
 import 'package:window_manager/window_manager.dart';
-import 'package:yaml/yaml.dart';
 
 import 'config.dart';
 import 'domain/repository/auth.dart';
@@ -42,6 +40,7 @@ import 'domain/service/notification.dart';
 import 'l10n/_l10n.dart';
 import 'provider/gql/graphql.dart';
 import 'provider/hive/session.dart';
+import 'pubspec.g.dart';
 import 'routes.dart';
 import 'store/auth.dart';
 import 'themes.dart';
@@ -53,7 +52,6 @@ import 'util/web/web_utils.dart';
 /// Entry point of this application.
 void main() async {
   await Config.init();
-  YamlMap pubspec = loadYaml(await rootBundle.loadString('pubspec.yaml'));
 
   // Initializes and runs the [App].
   Future<void> _appRunner() async {
@@ -62,7 +60,7 @@ void main() async {
       await windowManager.ensureInitialized();
     }
 
-    await _initHive(pubspec);
+    await _initHive();
 
     Get.put(NotificationService())
         .init(onNotificationResponse: onNotificationResponse);
@@ -100,7 +98,7 @@ void main() async {
     (options) => {
       options.dsn = Config.sentryDsn,
       options.tracesSampleRate = 1.0,
-      options.release = '${pubspec['name']}@${pubspec['version']}',
+      options.release = '${Pubspec.name}@${Pubspec.version}',
       options.debug = true,
       options.diagnosticLevel = SentryLevel.info,
       options.enablePrintBreadcrumbs = true,
@@ -161,14 +159,12 @@ class App extends StatelessWidget {
 
 /// Initializes a [Hive] storage and registers a [SessionDataHiveProvider] in
 /// the [Get]'s context.
-Future<void> _initHive([YamlMap? pubspec]) async {
+Future<void> _initHive() async {
   await Hive.initFlutter('hive');
 
   // Load and compare application version.
-  YamlMap document =
-      pubspec ?? loadYaml(await rootBundle.loadString('pubspec.yaml'));
   Box box = await Hive.openBox('version');
-  String? version = document['version'];
+  String version = Pubspec.version;
   String? stored = box.get(0);
 
   // If mismatch is detected, then clean the existing [Hive] cache.

--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -14,6 +14,8 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+// ignore_for_file: depend_on_referenced_packages
+
 import 'dart:async';
 
 import 'package:build/build.dart';

--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:universal_io/io.dart';
+import 'package:yaml/yaml.dart';
+
+/// Returns the [PubspecBuilder].
+Builder pubspecBuilder(BuilderOptions options) {
+  return PubspecBuilder(options);
+}
+
+/// [Builder] generating a `lib/pubspec.g.dart` file containg the package's name
+/// and version.
+class PubspecBuilder implements Builder {
+  PubspecBuilder(this.builderOptions);
+
+  /// Configuration of this [PubspecBuilder].
+  final BuilderOptions builderOptions;
+
+  @override
+  Map<String, List<String>> get buildExtensions => {
+        r'$package$': ['lib/pubspec.g.dart'],
+      };
+
+  @override
+  FutureOr<void> build(BuildStep buildStep) async {
+    YamlMap pubspec = loadYaml(File('pubspec.yaml').readAsStringSync());
+
+    final outputId = AssetId(buildStep.inputId.package, 'lib/pubspec.g.dart');
+    await buildStep.writeAsString(
+      outputId,
+      'class Pubspec {\n'
+      '\tstatic const name = \'${pubspec['name']}\';\n'
+      '\tstatic const version = \'${pubspec['version']}\';\n'
+      '}\n',
+    );
+  }
+}

--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -1,3 +1,19 @@
+// Copyright © 2022 IT ENGINEERING MANAGEMENT INC, <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
 import 'dart:async';
 
 import 'package:build/build.dart';
@@ -9,10 +25,10 @@ Builder pubspecBuilder(BuilderOptions options) {
   return PubspecBuilder(options);
 }
 
-/// [Builder] generating a `lib/pubspec.g.dart` file containg the package's name
-/// and version.
+/// [Builder] generating a `lib/pubspec.g.dart` file containing the package's
+/// name and version.
 class PubspecBuilder implements Builder {
-  PubspecBuilder(this.builderOptions);
+  const PubspecBuilder(this.builderOptions);
 
   /// Configuration of this [PubspecBuilder].
   final BuilderOptions builderOptions;

--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -20,7 +20,7 @@ import 'package:build/build.dart';
 import 'package:universal_io/io.dart';
 import 'package:yaml/yaml.dart';
 
-/// Returns the [PubspecBuilder].
+/// Creates a new [PubspecBuilder] with the provided [BuilderOptions].
 Builder pubspecBuilder(BuilderOptions options) {
   return PubspecBuilder(options);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -114,7 +114,7 @@ packages:
     source: hosted
     version: "2.1.0"
   build:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: build
       url: "https://pub.dartlang.org"
@@ -1503,7 +1503,7 @@ packages:
     source: hosted
     version: "5.3.1"
   yaml:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: yaml
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -114,7 +114,7 @@ packages:
     source: hosted
     version: "2.1.0"
   build:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: build
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   async: ^2.8.2
   audioplayers: ^1.0.0-rc.4
   badges: ^2.0.2
-  build: ^2.3.0
   callkeep: ^0.3.2
   carousel_slider: ^4.1.1
   chewie: ^1.3.2
@@ -77,10 +76,10 @@ dependencies:
   visibility_detector: ^0.3.3
   web_socket_channel: ^2.2.0
   window_manager: ^0.2.3
-  yaml: ^3.1.0
 
 dev_dependencies:
   artemis: ^7.7.0-beta
+  build: ^2.3.0
   build_runner: ^2.1.10
   dartdoc: ^5.0.1
   flutter_driver:
@@ -100,6 +99,7 @@ dev_dependencies:
   mockito: ^5.1.0
   network_image_mock: ^2.1.0
   sentry_dart_plugin: ^1.0.0-beta.2
+  yaml: ^3.1.0
 
 dependency_overrides:
   # TODO: Remove when `flutter_gherkin` updates.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   async: ^2.8.2
   audioplayers: ^1.0.0-rc.4
   badges: ^2.0.2
+  build: ^2.3.0
   callkeep: ^0.3.2
   carousel_slider: ^4.1.1
   chewie: ^1.3.2
@@ -112,7 +113,6 @@ flutter:
     - assets/images/logo/
     - assets/icons/
     - assets/audio/
-    - pubspec.yaml
 
 sentry:
   upload_native_symbols: true


### PR DESCRIPTION
## Synopsis

При добавлении в `assets` любого файла из рута проекта (например, сейчас происходит импорт `pubspec.yaml`) `Flutter` может сойти с ума в бесконечной рекурсии, если добавить в зависимости какой-нибудь толстый проект по релятивному или абсолютному импорту (по гиту и по pub.dev'у всё ок).

Кроме того, `pubspec.yaml` торчит наружу и доступен на вебе по адресу `host/assets/pubspec.yaml`, что тоже вызывает вопросы.




## Solution

Реализовать `PubspecBuilder`а, который будет генерить файлик `lib/pubspec.g.dart` следующего содержания:
```dart
class Pubspec {
   static const name = 'messenger';
   static const version = '0.1.0-alpha.5';
}
```




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
