### PR TITLE
Fix horizontal scroll on `Home` page when vertical is going on (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All user visible changes to this project will be documented in this file. This p
     - Chat page:
         - Missing avatars in group creation popup ([#15], [#2]).
     - Home page:
-        - Horizontal scroll when vertical is going on ([#42], [#41]).
+        - Horizontal scroll overlapping with vertical ([#42], [#41]).
 
 [#2]: /../../issues/2
 [#4]: /../../issues/4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Chat page:
         - Missing avatars in group creation popup ([#15], [#2]).
+    - Home page:
+        - Horizontal scroll when vertical is going on ([#42], [#41]).
 
 [#2]: /../../issues/2
 [#4]: /../../issues/4
@@ -41,6 +43,8 @@ All user visible changes to this project will be documented in this file. This p
 [#23]: /../../pull/23
 [#26]: /../../pull/26
 [#31]: /../../pull/31
+[#41]: /../../issues/41
+[#42]: /../../pull/42
 
 
 

--- a/lib/ui/page/home/controller.dart
+++ b/lib/ui/page/home/controller.dart
@@ -45,8 +45,8 @@ class HomeController extends GetxController {
   /// Reactive [MyUser.unreadChatsCount] value.
   final Rx<int> unreadChatsCount = Rx<int>(0);
 
-  /// [Timer] for discarding any horizontal movement in a [PageView] of pages
-  /// when non-`null`.
+  /// [Timer] for discarding any horizontal movement in a [PageView] when
+  /// non-`null`.
   ///
   /// Indicates currently ongoing vertical scroll of a view.
   final Rx<Timer?> verticalScrollTimer = Rx(null);

--- a/lib/ui/page/home/controller.dart
+++ b/lib/ui/page/home/controller.dart
@@ -45,11 +45,15 @@ class HomeController extends GetxController {
   /// Reactive [MyUser.unreadChatsCount] value.
   final Rx<int> unreadChatsCount = Rx<int>(0);
 
+  final Rx<Timer?> horizontalScrollTimer = Rx(null);
+
   /// Authentication service to determine auth status.
   final AuthService _auth;
 
   /// [MyUserService] to listen to the [MyUser] changes.
   final MyUserService _myUser;
+
+  bool isScrolling = false;
 
   /// Subscription to the [MyUser] changes.
   late final StreamSubscription _myUserSubscription;

--- a/lib/ui/page/home/controller.dart
+++ b/lib/ui/page/home/controller.dart
@@ -45,15 +45,17 @@ class HomeController extends GetxController {
   /// Reactive [MyUser.unreadChatsCount] value.
   final Rx<int> unreadChatsCount = Rx<int>(0);
 
-  final Rx<Timer?> horizontalScrollTimer = Rx(null);
+  /// [Timer] for discarding any horizontal movement in a [PageView] of pages
+  /// when non-`null`.
+  ///
+  /// Indicates currently ongoing vertical scroll of a view.
+  final Rx<Timer?> verticalScrollTimer = Rx(null);
 
   /// Authentication service to determine auth status.
   final AuthService _auth;
 
   /// [MyUserService] to listen to the [MyUser] changes.
   final MyUserService _myUser;
-
-  bool isScrolling = false;
 
   /// Subscription to the [MyUser] changes.
   late final StreamSubscription _myUserSubscription;

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -59,18 +59,10 @@ class _HomeViewState extends State<HomeView>
   /// [ChildBackButtonDispatcher] to get "Back" button in the nested [Router].
   late ChildBackButtonDispatcher _backButtonDispatcher;
 
-  late final AnimationController _animation;
-
-  int i = 0;
-
   @override
   void initState() {
     super.initState();
     widget._depsFactory().then((v) => setState(() => _deps = v));
-    _animation = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 200),
-    );
   }
 
   @override
@@ -129,49 +121,29 @@ class _HomeViewState extends State<HomeView>
                 body: Listener(
                   onPointerSignal: (s) {
                     if (s is PointerScrollEvent) {
-                      if (s.scrollDelta.dy.abs() < 3 &&
-                          (s.scrollDelta.dx.abs() > 3 ||
-                              c.horizontalScrollTimer.value != null)) {
-                        double value =
-                            _animation.value + s.scrollDelta.dx / 100;
-                        _animation.value = value.clamp(0, 1);
-                        if (_animation.value == 0 || _animation.value == 1) {
-                          _resetHorizontalScroll(c, 100.milliseconds);
-                        } else {
-                          _resetHorizontalScroll(c);
-                        }
+                      if (s.scrollDelta.dx.abs() < 3 &&
+                          (s.scrollDelta.dy.abs() > 3 ||
+                              c.verticalScrollTimer.value != null)) {
+                        _resetVerticalScroll(c);
                       }
                     }
                   },
-                  child: GestureDetector(
-                      behavior: HitTestBehavior.translucent,
-                      onHorizontalDragUpdate: (d) {
-                        double value = _animation.value - d.delta.dx / 100;
-                        _animation.value = value.clamp(0, 1);
-                      },
-                      onHorizontalDragEnd: (d) {
-                        if (_animation.value >= 0.5) {
-                          _animation.forward();
-                        } else {
-                          _animation.reverse();
-                        }
-                      },
-                      child: Obx(() {
-                        return PageView(
-                          physics: c.horizontalScrollTimer.value != null
-                              ? null
-                              : const NeverScrollableScrollPhysics(),
-                          controller: c.pages,
-                          onPageChanged: (i) => router.tab = HomeTab.values[i],
+                  child: Obx(() {
+                    return PageView(
+                      physics: c.verticalScrollTimer.value == null
+                          ? null
+                          : const NeverScrollableScrollPhysics(),
+                      controller: c.pages,
+                      onPageChanged: (i) => router.tab = HomeTab.values[i],
 
-                          /// [KeepAlivePage] used to keep the tabs' states.
-                          children: const [
-                            KeepAlivePage(child: ContactsTabView()),
-                            KeepAlivePage(child: ChatsTabView()),
-                            KeepAlivePage(child: MenuTabView()),
-                          ],
-                        );
-                      })),
+                      /// [KeepAlivePage] used to keep the tabs' states.
+                      children: const [
+                        KeepAlivePage(child: ContactsTabView()),
+                        KeepAlivePage(child: ChatsTabView()),
+                        KeepAlivePage(child: MenuTabView()),
+                      ],
+                    );
+                  }),
                 ),
                 bottomNavigationBar: SafeArea(
                   child: Obx(
@@ -269,19 +241,14 @@ class _HomeViewState extends State<HomeView>
     );
   }
 
-  /// Cancels a [_horizontalScrollTimer] and starts it again with the provided
+  /// Cancels a [_verticalScrollTimer] and starts it again with the provided
   /// [duration].
   ///
   /// Defaults to 150 milliseconds if no [duration] is provided.
-  void _resetHorizontalScroll(HomeController c, [Duration? duration]) {
-    c.horizontalScrollTimer.value?.cancel();
-    c.horizontalScrollTimer.value = Timer(duration ?? 150.milliseconds, () {
-      if (_animation.value >= 0.5) {
-        _animation.forward();
-      } else {
-        _animation.reverse();
-      }
-      c.horizontalScrollTimer.value = null;
+  void _resetVerticalScroll(HomeController c, [Duration? duration]) {
+    c.verticalScrollTimer.value?.cancel();
+    c.verticalScrollTimer.value = Timer(duration ?? 150.milliseconds, () {
+      c.verticalScrollTimer.value = null;
     });
   }
 }

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -223,19 +223,17 @@ class _HomeViewState extends State<HomeView>
         /// Otherwise, [Stack] widget will be updated, which will lead its
         /// children to be updated as well.
         return CallOverlayView(
-          child: Obx(() {
-            return c.authStatus.value.isSuccess
-                ? Stack(
-                    key: const Key('HomeView'),
-                    children: [
-                      Container(child: context.isMobile ? null : navigation),
-                      sideBar,
-                      Container(child: context.isMobile ? navigation : null),
-                    ],
-                  )
-                : const Scaffold(
-                    body: Center(child: CircularProgressIndicator()));
-          }),
+          child: Obx(() => c.authStatus.value.isSuccess
+              ? Stack(
+                  key: const Key('HomeView'),
+                  children: [
+                    Container(child: context.isMobile ? null : navigation),
+                    sideBar,
+                    Container(child: context.isMobile ? navigation : null),
+                  ],
+                )
+              : const Scaffold(
+                  body: Center(child: CircularProgressIndicator()))),
         );
       },
     );

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -48,8 +48,7 @@ class HomeView extends StatefulWidget {
 /// State of the [Routes.home] page.
 ///
 /// State is required for [BuildContext] to be acquired.
-class _HomeViewState extends State<HomeView>
-    with SingleTickerProviderStateMixin {
+class _HomeViewState extends State<HomeView> {
   /// [HomeRouterDelegate] for the nested [Router].
   final HomeRouterDelegate _routerDelegate = HomeRouterDelegate(router);
 

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -139,7 +139,7 @@ class _HomeViewState extends State<HomeView> {
                       controller: c.pages,
                       onPageChanged: (i) => router.tab = HomeTab.values[i],
 
-                      /// [KeepAlivePage] used to keep the tabs' states.
+                      // [KeepAlivePage] used to keep the tabs' states.
                       children: const [
                         KeepAlivePage(child: ContactsTabView()),
                         KeepAlivePage(child: ChatsTabView()),

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -227,17 +227,19 @@ class _HomeViewState extends State<HomeView>
         /// Otherwise, [Stack] widget will be updated, which will lead its
         /// children to be updated as well.
         return CallOverlayView(
-          child: Obx(() => c.authStatus.value.isSuccess
-              ? Stack(
-                  key: const Key('HomeView'),
-                  children: [
-                    Container(child: context.isMobile ? null : navigation),
-                    sideBar,
-                    Container(child: context.isMobile ? navigation : null),
-                  ],
-                )
-              : const Scaffold(
-                  body: Center(child: CircularProgressIndicator()))),
+          child: Obx(
+            () => c.authStatus.value.isSuccess
+                ? Stack(
+                    key: const Key('HomeView'),
+                    children: [
+                      Container(child: context.isMobile ? null : navigation),
+                      sideBar,
+                      Container(child: context.isMobile ? navigation : null),
+                    ],
+                  )
+                : const Scaffold(
+                    body: Center(child: CircularProgressIndicator())),
+          ),
         );
       },
     );

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -124,7 +124,11 @@ class _HomeViewState extends State<HomeView>
                       if (s.scrollDelta.dx.abs() < 3 &&
                           (s.scrollDelta.dy.abs() > 3 ||
                               c.verticalScrollTimer.value != null)) {
-                        _resetVerticalScroll(c);
+                        c.verticalScrollTimer.value?.cancel();
+                        c.verticalScrollTimer.value =
+                            Timer(150.milliseconds, () {
+                          c.verticalScrollTimer.value = null;
+                        });
                       }
                     }
                   },
@@ -237,16 +241,5 @@ class _HomeViewState extends State<HomeView>
         );
       },
     );
-  }
-
-  /// Cancels a [_verticalScrollTimer] and starts it again with the provided
-  /// [duration].
-  ///
-  /// Defaults to 150 milliseconds if no [duration] is provided.
-  void _resetVerticalScroll(HomeController c, [Duration? duration]) {
-    c.verticalScrollTimer.value?.cancel();
-    c.verticalScrollTimer.value = Timer(duration ?? 150.milliseconds, () {
-      c.verticalScrollTimer.value = null;
-    });
   }
 }

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -128,8 +128,8 @@ class _HomeViewState extends State<HomeView>
                       }
                     }
                   },
-                  child: Obx(() {
-                    return PageView(
+                  child: Obx(
+                    () => PageView(
                       physics: c.verticalScrollTimer.value == null
                           ? null
                           : const NeverScrollableScrollPhysics(),
@@ -142,8 +142,8 @@ class _HomeViewState extends State<HomeView>
                         KeepAlivePage(child: ChatsTabView()),
                         KeepAlivePage(child: MenuTabView()),
                       ],
-                    );
-                  }),
+                    ),
+                  ),
                 ),
                 bottomNavigationBar: SafeArea(
                   child: Obx(

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -14,6 +14,9 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:get/get.dart';
@@ -45,7 +48,8 @@ class HomeView extends StatefulWidget {
 /// State of the [Routes.home] page.
 ///
 /// State is required for [BuildContext] to be acquired.
-class _HomeViewState extends State<HomeView> {
+class _HomeViewState extends State<HomeView>
+    with SingleTickerProviderStateMixin {
   /// [HomeRouterDelegate] for the nested [Router].
   final HomeRouterDelegate _routerDelegate = HomeRouterDelegate(router);
 
@@ -55,10 +59,18 @@ class _HomeViewState extends State<HomeView> {
   /// [ChildBackButtonDispatcher] to get "Back" button in the nested [Router].
   late ChildBackButtonDispatcher _backButtonDispatcher;
 
+  late final AnimationController _animation;
+
+  int i = 0;
+
   @override
   void initState() {
     super.initState();
     widget._depsFactory().then((v) => setState(() => _deps = v));
+    _animation = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
   }
 
   @override
@@ -114,16 +126,52 @@ class _HomeViewState extends State<HomeView> {
                         : context.width * HomeController.sideBarWidthPercentage,
               ),
               child: Scaffold(
-                body: PageView(
-                  controller: c.pages,
-                  onPageChanged: (i) => router.tab = HomeTab.values[i],
+                body: Listener(
+                  onPointerSignal: (s) {
+                    if (s is PointerScrollEvent) {
+                      if (s.scrollDelta.dy.abs() < 3 &&
+                          (s.scrollDelta.dx.abs() > 3 ||
+                              c.horizontalScrollTimer.value != null)) {
+                        double value =
+                            _animation.value + s.scrollDelta.dx / 100;
+                        _animation.value = value.clamp(0, 1);
+                        if (_animation.value == 0 || _animation.value == 1) {
+                          _resetHorizontalScroll(c, 100.milliseconds);
+                        } else {
+                          _resetHorizontalScroll(c);
+                        }
+                      }
+                    }
+                  },
+                  child: GestureDetector(
+                      behavior: HitTestBehavior.translucent,
+                      onHorizontalDragUpdate: (d) {
+                        double value = _animation.value - d.delta.dx / 100;
+                        _animation.value = value.clamp(0, 1);
+                      },
+                      onHorizontalDragEnd: (d) {
+                        if (_animation.value >= 0.5) {
+                          _animation.forward();
+                        } else {
+                          _animation.reverse();
+                        }
+                      },
+                      child: Obx(() {
+                        return PageView(
+                          physics: c.horizontalScrollTimer.value != null
+                              ? null
+                              : const NeverScrollableScrollPhysics(),
+                          controller: c.pages,
+                          onPageChanged: (i) => router.tab = HomeTab.values[i],
 
-                  /// [KeepAlivePage] used to keep the tabs' states.
-                  children: const [
-                    KeepAlivePage(child: ContactsTabView()),
-                    KeepAlivePage(child: ChatsTabView()),
-                    KeepAlivePage(child: MenuTabView()),
-                  ],
+                          /// [KeepAlivePage] used to keep the tabs' states.
+                          children: const [
+                            KeepAlivePage(child: ContactsTabView()),
+                            KeepAlivePage(child: ChatsTabView()),
+                            KeepAlivePage(child: MenuTabView()),
+                          ],
+                        );
+                      })),
                 ),
                 bottomNavigationBar: SafeArea(
                   child: Obx(
@@ -203,8 +251,8 @@ class _HomeViewState extends State<HomeView> {
         /// Otherwise, [Stack] widget will be updated, which will lead its
         /// children to be updated as well.
         return CallOverlayView(
-          child: Obx(
-            () => c.authStatus.value.isSuccess
+          child: Obx(() {
+            return c.authStatus.value.isSuccess
                 ? Stack(
                     key: const Key('HomeView'),
                     children: [
@@ -214,10 +262,26 @@ class _HomeViewState extends State<HomeView> {
                     ],
                   )
                 : const Scaffold(
-                    body: Center(child: CircularProgressIndicator())),
-          ),
+                    body: Center(child: CircularProgressIndicator()));
+          }),
         );
       },
     );
+  }
+
+  /// Cancels a [_horizontalScrollTimer] and starts it again with the provided
+  /// [duration].
+  ///
+  /// Defaults to 150 milliseconds if no [duration] is provided.
+  void _resetHorizontalScroll(HomeController c, [Duration? duration]) {
+    c.horizontalScrollTimer.value?.cancel();
+    c.horizontalScrollTimer.value = Timer(duration ?? 150.milliseconds, () {
+      if (_animation.value >= 0.5) {
+        _animation.forward();
+      } else {
+        _animation.reverse();
+      }
+      c.horizontalScrollTimer.value = null;
+    });
   }
 }


### PR DESCRIPTION
Resolves #41 

## Synopsis

В виджете PageView при наличии вертикального скролла, горизонтальный остаётся активным, следовательно есть возможность скролла в любом направлении. 




## Solution

Нужно добавить приоритет вертикального скролла над горизонтальным.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
