### PR TITLE
Fix mobile bottom dock on minimizing (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Media panel:
         - Redesigned desktop interface ([#26], [#34], [#9]);
-        - Redesigned mobile interface ([#31], [#34]).
+        - Redesigned mobile interface ([#31], [#34], [#53]).
     - Redesigned login interface ([#35]);
     - Redesigned auth page ([#29]).
 
@@ -58,6 +58,7 @@ All user visible changes to this project will be documented in this file. This p
 [#42]: /../../pull/42
 [#44]: /../../issues/44
 [#45]: /../../pull/45
+[#53]: /../../pull/53
 
 
 

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -15,7 +15,6 @@
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
 import 'dart:math';
-import 'dart:ui' show lerpDouble;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
@@ -596,8 +595,6 @@ Widget mobileCall(CallController c, BuildContext context) {
 
     return Obx(() {
       return MinimizableView(
-        minimizedWidth: CallController.minimizedWidth,
-        minimizedHeight: CallController.minimizedHeight,
         minimizationEnabled: !c.secondaryManipulated.value,
         onInit: (animation) {
           c.minimizedAnimation = animation;
@@ -616,16 +613,14 @@ Widget mobileCall(CallController c, BuildContext context) {
               } else {
                 c.minimizing.value = true;
               }
-
-              Size size = router.context!.mediaQuerySize;
-              c.width.value = lerpDouble(
-                  size.width, CallController.minimizedWidth, animation.value)!;
-              c.height.value = lerpDouble(size.height,
-                  CallController.minimizedHeight, animation.value)!;
             }
           });
         },
         onDispose: () => c.minimizedAnimation = null,
+        onSizeChanged: (s) {
+          c.width.value = s.width;
+          c.height.value = s.height;
+        },
         child: Obx(() {
           return IgnorePointer(
             ignoring: c.minimized.value,

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -15,6 +15,7 @@
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
 import 'dart:math';
+import 'dart:ui' show lerpDouble;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
@@ -593,13 +594,10 @@ Widget mobileCall(CallController c, BuildContext context) {
       c.applySecondaryConstraints();
     }
 
-    double minimizedWidth = CallController.mobileMinimizedWidth;
-    double minimizedHeight = CallController.mobileMinimizedHeight;
-
     return Obx(() {
       return MinimizableView(
-        minimizedWidth: minimizedWidth,
-        minimizedHeight: minimizedHeight,
+        minimizedWidth: CallController.minimizedWidth,
+        minimizedHeight: CallController.minimizedHeight,
         minimizationEnabled: !c.secondaryManipulated.value,
         onInit: (animation) {
           c.minimizedAnimation = animation;
@@ -609,8 +607,8 @@ Widget mobileCall(CallController c, BuildContext context) {
               c.minimized.value = animation.value != 0;
             } else {
               if (animation.value != 0) {
-                c.keepUi(false);
                 c.hoveredRenderer.value = null;
+                c.keepUi(false);
               }
               c.minimized.value = animation.value == 1;
               if (animation.value == 1 || animation.value == 0) {
@@ -619,11 +617,11 @@ Widget mobileCall(CallController c, BuildContext context) {
                 c.minimizing.value = true;
               }
 
-              var mediaQuerySize = router.context!.mediaQuerySize;
-              c.width.value = mediaQuerySize.width -
-                  (mediaQuerySize.width - minimizedWidth) * animation.value;
-              c.height.value = mediaQuerySize.height -
-                  (mediaQuerySize.height - minimizedHeight) * animation.value;
+              Size size = router.context!.mediaQuerySize;
+              c.width.value = lerpDouble(
+                  size.width, CallController.minimizedWidth, animation.value)!;
+              c.height.value = lerpDouble(size.height,
+                  CallController.minimizedHeight, animation.value)!;
             }
           });
         },

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -457,7 +457,8 @@ Widget mobileCall(CallController c, BuildContext context) {
                   curve: Curves.easeOutQuad,
                   reverseCurve: Curves.easeOutQuad,
                   child: MediaQuery(
-                    data: MediaQuery.of(context).copyWith(size: c.size),
+                    data: MediaQuery.of(context)
+                        .copyWith(size: c.size),
                     child: SlidingUpPanel(
                       controller: c.panelController,
                       boxShadow: null,
@@ -579,7 +580,12 @@ Widget mobileCall(CallController c, BuildContext context) {
       c.applySecondaryConstraints();
     }
 
+    double minimizedWidth = CallController.mobileMinimizedWidth;
+    double minimizedHeight = CallController.mobileMinimizedHeight;
+
     return MinimizableView(
+      minimizedWidth: minimizedWidth,
+      minimizedHeight: minimizedHeight,
       onInit: (animation) {
         c.minimizedAnimation = animation;
         animation.addListener(() {
@@ -589,11 +595,20 @@ Widget mobileCall(CallController c, BuildContext context) {
           } else {
             if (animation.value != 0) {
               c.keepUi(false);
-            }
-            c.minimized.value = animation.value == 1;
-            if (c.minimized.value) {
               c.hoveredRenderer.value = null;
             }
+            c.minimized.value = animation.value == 1;
+            if(animation.value == 1 || animation.value == 0) {
+              c.minimizing.value = false;
+            } else {
+              c.minimizing.value = true;
+            }
+
+            var mediaQuerySize = router.context!.mediaQuerySize;
+            c.width.value = mediaQuerySize.width -
+                (mediaQuerySize.width - minimizedWidth) * animation.value;
+            c.height.value = mediaQuerySize.height -
+                (mediaQuerySize.height - minimizedHeight) * animation.value;
           }
         });
       },

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -457,8 +457,7 @@ Widget mobileCall(CallController c, BuildContext context) {
                   curve: Curves.easeOutQuad,
                   reverseCurve: Curves.easeOutQuad,
                   child: MediaQuery(
-                    data: MediaQuery.of(context)
-                        .copyWith(size: c.size),
+                    data: MediaQuery.of(context).copyWith(size: c.size),
                     child: SlidingUpPanel(
                       controller: c.panelController,
                       boxShadow: null,
@@ -598,7 +597,7 @@ Widget mobileCall(CallController c, BuildContext context) {
               c.hoveredRenderer.value = null;
             }
             c.minimized.value = animation.value == 1;
-            if(animation.value == 1 || animation.value == 0) {
+            if (animation.value == 1 || animation.value == 0) {
               c.minimizing.value = false;
             } else {
               c.minimizing.value = true;

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -442,7 +442,7 @@ class CallController extends GetxController {
     minimized = RxBool(!router.context!.isMobile);
     isMobile = router.context!.isMobile;
 
-    if(isMobile) {
+    if (isMobile) {
       var mediaQuerySize = router.context!.mediaQuerySize;
       width = RxDouble(mediaQuerySize.width);
       height = RxDouble(mediaQuerySize.height);

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -261,12 +261,6 @@ class CallController extends GetxController {
   /// Indicator whether the [MinimizableView] is being minimized.
   final RxBool minimizing = RxBool(false);
 
-  /// Width of the [MinimizableView] in pixels.
-  static const double minimizedWidth = 150;
-
-  /// Height of the [MinimizableView] in pixels.
-  static const double minimizedHeight = 150;
-
   /// Max width of the minimized view in percentage of the screen width.
   static const double _maxWidth = 0.99;
 
@@ -400,7 +394,7 @@ class CallController extends GetxController {
 
   /// Returns actual size of the call view.
   Size get size {
-    if (!fullscreen.value && minimized.value || minimizing.isTrue) {
+    if ((!fullscreen.value && minimized.value) || minimizing.value) {
       return Size(width.value, height.value - (isMobile ? 0 : titleHeight));
     } else if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       // TODO: Account [BuildContext.mediaQueryPadding].

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -62,9 +62,6 @@ class CallController extends GetxController {
   /// Reactive [Chat] that this [OngoingCall] is happening in.
   final Rx<RxChat?> chat = Rx<RxChat?>(null);
 
-  /// Indicator whether the view is being minimized.
-  final RxBool minimizing = RxBool(false);
-
   /// Indicator whether the view is minimized or maximized.
   late final RxBool minimized;
 
@@ -261,11 +258,14 @@ class CallController extends GetxController {
   /// Height of the title bar.
   static const double titleHeight = 30;
 
-  /// Width of the mobile minimized view in pixels.
-  static const double mobileMinimizedWidth = 150;
+  /// Indicator whether the [MinimizableView] is being minimized.
+  final RxBool minimizing = RxBool(false);
 
-  /// Height of the mobile minimized view in pixels.
-  static const double mobileMinimizedHeight = 150;
+  /// Width of the [MinimizableView] in pixels.
+  static const double minimizedWidth = 150;
+
+  /// Height of the [MinimizableView] in pixels.
+  static const double minimizedHeight = 150;
 
   /// Max width of the minimized view in percentage of the screen width.
   static const double _maxWidth = 0.99;
@@ -454,9 +454,9 @@ class CallController extends GetxController {
     isMobile = router.context!.isMobile;
 
     if (isMobile) {
-      var mediaQuerySize = router.context!.mediaQuerySize;
-      width = RxDouble(mediaQuerySize.width);
-      height = RxDouble(mediaQuerySize.height);
+      Size size = router.context!.mediaQuerySize;
+      width = RxDouble(size.width);
+      height = RxDouble(size.height);
     } else {
       width = RxDouble(
         min(

--- a/lib/ui/page/call/widget/minimizable_view.dart
+++ b/lib/ui/page/call/widget/minimizable_view.dart
@@ -45,10 +45,10 @@ class MinimizableView extends StatefulWidget {
   /// minimization gesture.
   final double minimizationDelta;
 
-  /// Minimized width of this view.
+  /// Width of this [MinimizableView] in its minimized state.
   final double minimizedWidth;
 
-  /// Minimized height of this view.
+  /// Height of this [MinimizableView] in its minimized state.
   final double minimizedHeight;
 
   /// [Widget] to minimize.

--- a/lib/ui/page/call/widget/minimizable_view.dart
+++ b/lib/ui/page/call/widget/minimizable_view.dart
@@ -24,10 +24,9 @@ class MinimizableView extends StatefulWidget {
     Key? key,
     this.onInit,
     this.onDispose,
+    this.onSizeChanged,
     this.minimizationEnabled = true,
     this.minimizationDelta = 50,
-    this.minimizedWidth = 150,
-    this.minimizedHeight = 150,
     required this.child,
   }) : super(key: key);
 
@@ -38,18 +37,15 @@ class MinimizableView extends StatefulWidget {
   /// Callback, called when the state of this [MinimizableView] is disposed.
   final void Function()? onDispose;
 
+  /// Callback, called when [Size] of this [MinimizableView] is changed.
+  final void Function(Size)? onSizeChanged;
+
   /// Indicator whether the minimizing gesture is enabled.
   final bool minimizationEnabled;
 
   /// Distance to travel in order for the panning to be recognized as a
   /// minimization gesture.
   final double minimizationDelta;
-
-  /// Width of this [MinimizableView] in its minimized state.
-  final double minimizedWidth;
-
-  /// Height of this [MinimizableView] in its minimized state.
-  final double minimizedHeight;
 
   /// [Widget] to minimize.
   final Widget child;
@@ -61,6 +57,9 @@ class MinimizableView extends StatefulWidget {
 /// State of a [MinimizableView] used to animate its child.
 class _MinimizableViewState extends State<MinimizableView>
     with SingleTickerProviderStateMixin {
+  /// [Size] of this [MinimizableView] in its minimized state.
+  static const Size _size = Size(150, 150);
+
   /// [AnimationController] of this view.
   late final AnimationController _controller;
 
@@ -147,13 +146,10 @@ class _MinimizableViewState extends State<MinimizableView>
                 begin: RelativeRect.fill,
                 end: RelativeRect.fromSize(
                   Rect.fromLTWH(
-                    biggest.width - widget.minimizedWidth - _right,
-                    biggest.height -
-                        widget.minimizedHeight -
-                        _bottom -
-                        _padding.bottom,
-                    widget.minimizedWidth,
-                    widget.minimizedHeight,
+                    biggest.width - _size.width - _right,
+                    biggest.height - _size.height - _bottom - _padding.bottom,
+                    _size.width,
+                    _size.height,
                   ),
                   biggest,
                 ),
@@ -229,6 +225,9 @@ class _MinimizableViewState extends State<MinimizableView>
       begin: BorderRadius.zero,
       end: BorderRadius.circular(10),
     ).evaluate(_controller);
+
+    widget.onSizeChanged?.call(
+        SizeTween(begin: _lastBiggest, end: _size).evaluate(_controller)!);
 
     setState(() {});
   }

--- a/lib/ui/page/call/widget/minimizable_view.dart
+++ b/lib/ui/page/call/widget/minimizable_view.dart
@@ -144,7 +144,10 @@ class _MinimizableViewState extends State<MinimizableView>
                 end: RelativeRect.fromSize(
                   Rect.fromLTWH(
                     biggest.width - widget.minimizedWidth - _right,
-                    biggest.height - widget.minimizedHeight - _bottom - _padding.bottom,
+                    biggest.height -
+                        widget.minimizedHeight -
+                        _bottom -
+                        _padding.bottom,
                     widget.minimizedWidth,
                     widget.minimizedHeight,
                   ),

--- a/lib/ui/page/call/widget/minimizable_view.dart
+++ b/lib/ui/page/call/widget/minimizable_view.dart
@@ -25,6 +25,8 @@ class MinimizableView extends StatefulWidget {
     this.onInit,
     this.onDispose,
     this.minimizationDelta = 50,
+    this.minimizedWidth = 150,
+    this.minimizedHeight = 150,
     required this.child,
   }) : super(key: key);
 
@@ -39,6 +41,12 @@ class MinimizableView extends StatefulWidget {
   /// minimization gesture.
   final double minimizationDelta;
 
+  /// Minimized width of this view.
+  final double minimizedWidth;
+
+  /// Minimized height of this view.
+  final double minimizedHeight;
+
   /// [Widget] to minimize.
   final Widget child;
 
@@ -49,12 +57,6 @@ class MinimizableView extends StatefulWidget {
 /// State of a [MinimizableView] used to animate its child.
 class _MinimizableViewState extends State<MinimizableView>
     with SingleTickerProviderStateMixin {
-  /// Minimized width of this view.
-  static const double _width = 150;
-
-  /// Minimized height of this view.
-  static const double _height = 150;
-
   /// [AnimationController] of this view.
   late final AnimationController _controller;
 
@@ -141,10 +143,10 @@ class _MinimizableViewState extends State<MinimizableView>
                 begin: RelativeRect.fill,
                 end: RelativeRect.fromSize(
                   Rect.fromLTWH(
-                    biggest.width - _width - _right,
-                    biggest.height - _height - _bottom - _padding.bottom,
-                    _width,
-                    _height,
+                    biggest.width - widget.minimizedWidth - _right,
+                    biggest.height - widget.minimizedHeight - _bottom - _padding.bottom,
+                    widget.minimizedWidth,
+                    widget.minimizedHeight,
                   ),
                   biggest,
                 ),


### PR DESCRIPTION
Resolves #50




## Synopsis

При уменьшении мобильного дизайна звонка, панель с кнопками разъезжается.




## Solution

Размер панели с кнопками будет ограничен размерами окошка звонка.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
