### PR TITLE
Add joining call buttons with and w/o video (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All user visible changes to this project will be documented in this file. This p
         - Language selection ([#23], [#29]).
     - Media panel:
         - Reorderable buttons dock on desktop ([#9], [#6]).
+    - Chats tab:
+        - Button joining call with video ([#56], [#51]).
 
 ### Changed
 
@@ -59,7 +61,9 @@ All user visible changes to this project will be documented in this file. This p
 [#44]: /../../issues/44
 [#45]: /../../pull/45
 [#47]: /../../pull/47
+[#51]: /../../issues/51
 [#53]: /../../pull/53
+[#56]: /../../pull/56
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -124,7 +124,6 @@ btn_call_video_on_desc =
     video on
 btn_change_contact_name = Rename contact
 btn_change_password = Change password
-btn_chat_join_call = Join the call
 btn_close = Close
 btn_confirm = Confirm
 btn_copy_text = Copy text

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -124,7 +124,6 @@ btn_call_video_on_desc =
     камеру
 btn_change_contact_name = Переименовать контакт
 btn_change_password = Сменить пароль
-btn_chat_join_call = Присоединиться к звонку
 btn_close = Закрыть
 btn_confirm = Подтвердить
 btn_copy_text = Скопировать текст

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -122,8 +122,8 @@ class ChatsTabController extends GetxController {
     super.onClose();
   }
 
-  /// Joins the call in the [Chat] identified by the provided [id]
-  /// and the presence of video [withVideo]
+  /// Joins the call in the [Chat] identified by the provided [id] [withVideo]
+  /// or without.
   Future<void> joinCall(ChatId id, {bool withVideo = false}) async {
     try {
       await _callService.join(id, withVideo: withVideo);

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -122,10 +122,11 @@ class ChatsTabController extends GetxController {
     super.onClose();
   }
 
-  /// Joins the call in the [Chat] identified by the provided [id] and the presence of video [withVideo]
-  Future<void> joinCall(ChatId id, {bool? withVideo}) async {
+  /// Joins the call in the [Chat] identified by the provided [id]
+  /// and the presence of video [withVideo]
+  Future<void> joinCall(ChatId id, {bool withVideo = false}) async {
     try {
-      await _callService.join(id, withVideo: withVideo ?? false);
+      await _callService.join(id, withVideo: withVideo);
     } on CallAlreadyJoinedException catch (e) {
       MessagePopup.error(e);
     } on CallDoesNotExistException catch (e) {

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -122,17 +122,10 @@ class ChatsTabController extends GetxController {
     super.onClose();
   }
 
-  /// Call [_joinCall] with flag withVideo true
-  void joinCallWithVideo(ChatId id) => _joinCall(id,true);
-
-  /// Call [_joinCall] without flag withVideo
-  void joinCallWithoutVideo(ChatId id) => _joinCall(id);
-
   /// Joins the call in the [Chat] identified by the provided [id] and the presence of video [withVideo]
-  /// with default value false.
-  Future<void> _joinCall(ChatId id, [bool withVideo = false]) async {
+  Future<void> joinCall(ChatId id, {bool? withVideo}) async {
     try {
-      await _callService.join(id, withVideo: withVideo);
+      await _callService.join(id, withVideo: withVideo ?? false);
     } on CallAlreadyJoinedException catch (e) {
       MessagePopup.error(e);
     } on CallDoesNotExistException catch (e) {

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -122,10 +122,17 @@ class ChatsTabController extends GetxController {
     super.onClose();
   }
 
-  /// Joins the call in the [Chat] identified by the provided [id].
-  Future<void> joinCall(ChatId id) async {
+  /// Call [_joinCall] with flag withVideo true
+  void joinCallWithVideo(ChatId id) => _joinCall(id,true);
+
+  /// Call [_joinCall] without flag withVideo
+  void joinCallWithoutVideo(ChatId id) => _joinCall(id);
+
+  /// Joins the call in the [Chat] identified by the provided [id] and the presence of video [withVideo]
+  /// with default value false.
+  Future<void> _joinCall(ChatId id, [bool withVideo = false]) async {
     try {
-      await _callService.join(id, withVideo: false);
+      await _callService.join(id, withVideo: withVideo);
     } on CallAlreadyJoinedException catch (e) {
       MessagePopup.error(e);
     } on CallDoesNotExistException catch (e) {

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -76,7 +76,10 @@ class ChatsTabView extends StatelessWidget {
                               .map(
                                 (e) => KeyedSubtree(
                                   key: Key('Chat_${e.chat.value.id}'),
-                                  child: buildChatTile(c, e, context),
+                                  child: buildChatTile(
+                                    c,
+                                    e,
+                                  ),
                                 ),
                               )
                               .toList(),
@@ -91,7 +94,9 @@ class ChatsTabView extends StatelessWidget {
 
   /// Reactive [ListTile] with [chat]'s information.
   Widget buildChatTile(
-          ChatsTabController c, RxChat rxChat, BuildContext context) =>
+    ChatsTabController c,
+    RxChat rxChat,
+  ) =>
       Obx(() {
         Chat chat = rxChat.chat.value;
 
@@ -136,7 +141,7 @@ class ChatsTabView extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                     child: ElevatedButton(
-                      onPressed: () => c.joinCallWithoutVideo(chat.id),
+                      onPressed: () => c.joinCall(chat.id, withVideo: false),
                       child: Text('btn_join_call'.l10n),
                     ),
                   ),
@@ -204,7 +209,7 @@ class ChatsTabView extends StatelessWidget {
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                 child: ElevatedButton(
-                  onPressed: () => c.joinCallWithoutVideo(chat.id),
+                  onPressed: () => c.joinCall(chat.id, withVideo: false),
                   child: Row(mainAxisSize: MainAxisSize.min, children: [
                     const Icon(
                       Icons.call,
@@ -228,7 +233,7 @@ class ChatsTabView extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.fromLTRB(10, 4, 0, 4),
               child: ElevatedButton(
-                onPressed: () => c.joinCallWithVideo(chat.id),
+                onPressed: () => c.joinCall(chat.id, withVideo: true),
                 child: const Icon(
                   Icons.video_call,
                   size: 22,

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -76,7 +76,7 @@ class ChatsTabView extends StatelessWidget {
                               .map(
                                 (e) => KeyedSubtree(
                                   key: Key('Chat_${e.chat.value.id}'),
-                                  child: buildChatTile(c, e),
+                                  child: buildChatTile(c, e, context),
                                 ),
                               )
                               .toList(),
@@ -90,7 +90,9 @@ class ChatsTabView extends StatelessWidget {
   }
 
   /// Reactive [ListTile] with [chat]'s information.
-  Widget buildChatTile(ChatsTabController c, RxChat rxChat) => Obx(() {
+  Widget buildChatTile(
+          ChatsTabController c, RxChat rxChat, BuildContext context) =>
+      Obx(() {
         Chat chat = rxChat.chat.value;
 
         const Color subtitleColor = Color(0xFF666666);
@@ -100,7 +102,7 @@ class ChatsTabView extends StatelessWidget {
             .where((e) => e.id != c.me)
             .map((e) => e.name?.val ?? e.num.val);
 
-        if (chat.currentCall == null) {
+        if (chat.currentCall != null) {
           if (typings.isNotEmpty) {
             subtitle = [
               Expanded(
@@ -135,7 +137,7 @@ class ChatsTabView extends StatelessWidget {
                     padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                     child: ElevatedButton(
                       onPressed: () => c.joinCall(chat.id),
-                      child: Text('btn_chat_join_call'.l10n),
+                      child: Text('btn_join_call'.l10n),
                     ),
                   ),
                 ];
@@ -203,15 +205,37 @@ class ChatsTabView extends StatelessWidget {
                 padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                 child: ElevatedButton(
                   onPressed: () => c.joinCall(chat.id),
-                  child: Text(
-                    'btn_chat_join_call'.l10n,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
+                  child: Row(mainAxisSize: MainAxisSize.min, children: [
+                    const Icon(
+                      Icons.call,
+                      size: 21,
+                      color: Colors.white,
+                    ),
+                    Flexible(
+                      child: Padding(
+                        padding: const EdgeInsets.only(left: 5.0),
+                        child: Text(
+                          'btn_join_call'.l10n,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ),
+                  ]),
                 ),
               ),
             ),
-            // TODO: Implement join call button with video
+            Padding(
+              padding: const EdgeInsets.fromLTRB(10, 4, 0, 4),
+              child: ElevatedButton(
+                onPressed: () {},
+                child: const Icon(
+                  Icons.video_call,
+                  size: 22,
+                  color: Colors.white,
+                ),
+              ),
+            )
           ];
         }
 

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -76,10 +76,7 @@ class ChatsTabView extends StatelessWidget {
                               .map(
                                 (e) => KeyedSubtree(
                                   key: Key('Chat_${e.chat.value.id}'),
-                                  child: buildChatTile(
-                                    c,
-                                    e,
-                                  ),
+                                  child: buildChatTile(c, e),
                                 ),
                               )
                               .toList(),
@@ -93,11 +90,7 @@ class ChatsTabView extends StatelessWidget {
   }
 
   /// Reactive [ListTile] with [chat]'s information.
-  Widget buildChatTile(
-    ChatsTabController c,
-    RxChat rxChat,
-  ) =>
-      Obx(() {
+  Widget buildChatTile(ChatsTabController c, RxChat rxChat) => Obx(() {
         Chat chat = rxChat.chat.value;
 
         const Color subtitleColor = Color(0xFF666666);
@@ -141,9 +134,7 @@ class ChatsTabView extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                     child: ElevatedButton(
-                      onPressed: () => c.joinCall(
-                        chat.id,
-                      ),
+                      onPressed: () => c.joinCall(chat.id),
                       child: Text('btn_join_call'.l10n),
                     ),
                   ),

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -211,6 +211,7 @@ class ChatsTabView extends StatelessWidget {
                 ),
               ),
             ),
+            // TODO: Implement join call button with video
           ];
         }
 

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -203,23 +203,20 @@ class ChatsTabView extends StatelessWidget {
                 padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                 child: ElevatedButton(
                   onPressed: () => c.joinCall(chat.id),
-                  child: Row(mainAxisSize: MainAxisSize.min, children: [
-                    const Icon(
-                      Icons.call,
-                      size: 21,
-                      color: Colors.white,
-                    ),
-                    Flexible(
-                      child: Padding(
-                        padding: const EdgeInsets.only(left: 5.0),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.call, size: 21, color: Colors.white),
+                      const SizedBox(width: 5),
+                      Flexible(
                         child: Text(
                           'btn_join_call'.l10n,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),
-                    ),
-                  ]),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -227,13 +224,10 @@ class ChatsTabView extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(10, 4, 0, 4),
               child: ElevatedButton(
                 onPressed: () => c.joinCall(chat.id, withVideo: true),
-                child: const Icon(
-                  Icons.video_call,
-                  size: 22,
-                  color: Colors.white,
-                ),
+                child:
+                    const Icon(Icons.video_call, size: 22, color: Colors.white),
               ),
-            )
+            ),
           ];
         }
 

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -141,7 +141,9 @@ class ChatsTabView extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                     child: ElevatedButton(
-                      onPressed: () => c.joinCall(chat.id, withVideo: false),
+                      onPressed: () => c.joinCall(
+                        chat.id,
+                      ),
                       child: Text('btn_join_call'.l10n),
                     ),
                   ),
@@ -209,7 +211,9 @@ class ChatsTabView extends StatelessWidget {
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                 child: ElevatedButton(
-                  onPressed: () => c.joinCall(chat.id, withVideo: false),
+                  onPressed: () => c.joinCall(
+                    chat.id,
+                  ),
                   child: Row(mainAxisSize: MainAxisSize.min, children: [
                     const Icon(
                       Icons.call,

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -102,7 +102,7 @@ class ChatsTabView extends StatelessWidget {
             .where((e) => e.id != c.me)
             .map((e) => e.name?.val ?? e.num.val);
 
-        if (chat.currentCall != null) {
+        if (chat.currentCall == null) {
           if (typings.isNotEmpty) {
             subtitle = [
               Expanded(
@@ -136,7 +136,7 @@ class ChatsTabView extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                     child: ElevatedButton(
-                      onPressed: () => c.joinCall(chat.id),
+                      onPressed: () => c.joinCallWithoutVideo(chat.id),
                       child: Text('btn_join_call'.l10n),
                     ),
                   ),
@@ -204,7 +204,7 @@ class ChatsTabView extends StatelessWidget {
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                 child: ElevatedButton(
-                  onPressed: () => c.joinCall(chat.id),
+                  onPressed: () => c.joinCallWithoutVideo(chat.id),
                   child: Row(mainAxisSize: MainAxisSize.min, children: [
                     const Icon(
                       Icons.call,
@@ -228,7 +228,7 @@ class ChatsTabView extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.fromLTRB(10, 4, 0, 4),
               child: ElevatedButton(
-                onPressed: () {},
+                onPressed: () => c.joinCallWithVideo(chat.id),
                 child: const Icon(
                   Icons.video_call,
                   size: 22,

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -202,9 +202,7 @@ class ChatsTabView extends StatelessWidget {
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
                 child: ElevatedButton(
-                  onPressed: () => c.joinCall(
-                    chat.id,
-                  ),
+                  onPressed: () => c.joinCall(chat.id),
                   child: Row(mainAxisSize: MainAxisSize.min, children: [
                     const Icon(
                       Icons.call,


### PR DESCRIPTION
Resolves #51 




## Synopsis

Нужно было добавить кнопку в сабтайтл чата в табе ,которая позволяет присоединиться к звонку сразу с видео, без проведения операции включения видео в самом чате



## Solution

Добавление дополнительной кнопки с иконкой камеры по нажатию которой будет происходить присоединения к звонку вместе с видео, так же изменения дизайна первоначальной кнопки "Присоединиться к звонку", в котором в кнопке будет иконка телефонной трубки а так же надпить "Присоединиться"


## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
