### PR TITLE
Add macOS `.app` building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,11 @@ jobs:
       - run: make flutter.pub
 
       - run: make flutter.build platform=${{ matrix.platform }}
+        if: ${{ matrix.platform == 'web' }}
+      - run: make flutter.build platform=${{ matrix.platform }}
+                                dart-env=SOCAPP_HTTP_URL=${{ secrets.BACKEND_URL }},SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }},SOCAPP_WS_URL=${{ secrets.BACKEND_WS }},SOCAPP_WS_PORT=${{ secrets.BACKEND_PORT }}
                                 split-per-abi=yes
+        if: ${{ matrix.platform != 'web' }}
 
       - name: Parse application name from Git repository name
         id: app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       # the executable into the temporary folder and archive it instead.
       - run: |
           mkdir archive/
-          mv ${{ steps.app.outputs.group1 }}.app archive/${{ steps.app.outputs.group1 }}.app
+          mv Gapopa.app archive/Gapopa.app
         working-directory: build/macos/Build/Products/Release
         if: ${{ matrix.platform == 'macos' }}
       - uses: thedoctor0/zip-release@0.6.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,11 @@ jobs:
       - run: make flutter.build platform=${{ matrix.platform }}
         if: ${{ matrix.platform == 'web' }}
       - run: make flutter.build platform=${{ matrix.platform }}
-                                dart-env=SOCAPP_HTTP_URL=${{ secrets.BACKEND_URL }},SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }},SOCAPP_WS_URL=${{ secrets.BACKEND_WS }},SOCAPP_WS_PORT=${{ secrets.BACKEND_PORT }}
-                                split-per-abi=yes
+                  split-per-abi=yes
+                  dart-env='SOCAPP_HTTP_URL=${{ secrets.BACKEND_URL }}
+                            SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }}
+                            SOCAPP_WS_URL=${{ secrets.BACKEND_WS }}
+                            SOCAPP_WS_PORT=${{ secrets.BACKEND_PORT }}'
         if: ${{ matrix.platform != 'web' }}
 
       - name: Parse application name from Git repository name
@@ -170,12 +173,8 @@ jobs:
       - run: mv build/app/outputs/bundle/release/app-release.aab
                 artifacts/${{ steps.app.outputs.group1 }}-android.aab
         if: ${{ matrix.platform == 'appbundle' }}
-      # `.app` executable is a folder needed to be put into the archive, so move
-      # the executable into the temporary folder and archive it instead.
-      - run: |
-          mkdir archive/
-          mv Gapopa.app archive/Gapopa.app
-        working-directory: build/macos/Build/Products/Release
+      - run: mkdir -p dist/ && mv *.app dist/  # `.app` executable is a folder itself
+        working-directory: build/macos/Build/Products/Release/
         if: ${{ matrix.platform == 'macos' }}
       - uses: thedoctor0/zip-release@0.6.2
         with:
@@ -183,7 +182,7 @@ jobs:
           directory: ${{ (matrix.platform == 'linux'
                           && 'build/linux/x64/release/bundle')
                       || (matrix.platform == 'macos'
-                          && 'build/macos/Build/Products/Release/archive')
+                          && 'build/macos/Build/Products/Release/dist')
                       || (matrix.platform == 'windows'
                           && 'build/windows/runner/Release')
                       ||     'build/web'}}
@@ -262,11 +261,11 @@ jobs:
           path: build/web/artifacts/
       - uses: actions/download-artifact@v3
         with:
-          name: build-windows-${{ github.run_number }}
+          name: build-macos-${{ github.run_number }}
           path: build/web/artifacts/
       - uses: actions/download-artifact@v3
         with:
-          name: build-macos-${{ github.run_number }}
+          name: build-windows-${{ github.run_number }}
           path: build/web/artifacts/
 
       - run: make docker.image no-cache=yes
@@ -518,15 +517,15 @@ jobs:
           path: artifacts/
       - uses: actions/download-artifact@v3
         with:
+          name: build-macos-${{ github.run_number }}
+          path: artifacts/
+      - uses: actions/download-artifact@v3
+        with:
           name: build-web-${{ github.run_number }}
           path: artifacts/
       - uses: actions/download-artifact@v3
         with:
           name: build-windows-${{ github.run_number }}
-          path: artifacts/
-      - uses: actions/download-artifact@v3
-        with:
-          name: build-macos-${{ github.run_number }}
           path: artifacts/
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,7 @@ jobs:
           # TODO: Uncomment once `flutter_webrtc` supports iOS platform.
           #- ios
           - linux
-          # TODO: Uncomment once `flutter_webrtc` supports macOS platform.
-          #- macos
+          - macos
           - web
           - windows
     # TODO: Change `linux` platform to `ubuntu-latest` when 22.04 is out of beta.
@@ -167,13 +166,20 @@ jobs:
       - run: mv build/app/outputs/bundle/release/app-release.aab
                 artifacts/${{ steps.app.outputs.group1 }}-android.aab
         if: ${{ matrix.platform == 'appbundle' }}
+      # `.app` executable is a folder needed to be put into the archive, so move
+      # the executable into the temporary folder and archive it instead.
+      - run: |
+          mkdir archive/
+          mv ${{ steps.app.outputs.group1 }}.app archive/${{ steps.app.outputs.group1 }}.app
+        working-directory: build/macos/Build/Products/Release
+        if: ${{ matrix.platform == 'macos' }}
       - uses: thedoctor0/zip-release@0.6.2
         with:
           filename: ${{ github.workspace }}/artifacts/${{ steps.app.outputs.group1 }}-${{ matrix.platform }}.zip
           directory: ${{ (matrix.platform == 'linux'
                           && 'build/linux/x64/release/bundle')
                       || (matrix.platform == 'macos'
-                          && 'build/macos/Build/Products/Release/messenger.app')
+                          && 'build/macos/Build/Products/Release/archive')
                       || (matrix.platform == 'windows'
                           && 'build/windows/runner/Release')
                       ||     'build/web'}}
@@ -185,6 +191,8 @@ jobs:
       - name: Generate SHA256 checksums
         run: ${{ (runner.os == 'Windows'
                   && 'forfiles /M *.zip /C "cmd /c sha256sum @file > @file.sha256sum"')
+              || (runner.os == 'macOS'
+                  && 'ls -1 | xargs -I {} sh -c "shasum -a 256 {} > {}.sha256sum"')
               ||     'ls -1 | xargs -I {} sh -c "sha256sum {} > {}.sha256sum"' }}
         working-directory: artifacts/
       - name: Show generated SHA256 checksums
@@ -251,6 +259,10 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: build-windows-${{ github.run_number }}
+          path: build/web/artifacts/
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-macos-${{ github.run_number }}
           path: build/web/artifacts/
 
       - run: make docker.image no-cache=yes
@@ -507,6 +519,10 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: build-windows-${{ github.run_number }}
+          path: artifacts/
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-macos-${{ github.run_number }}
           path: artifacts/
 
       - uses: actions/download-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@
 
 comma := ,
 
-space := $(subst ,, )
-
 # Checks two given strings for equality.
 eq = $(if $(or $(1),$(2)),$(and $(findstring $(1),$(2)),\
                                 $(findstring $(2),$(1))),1)
@@ -141,7 +139,7 @@ else
 		    --split-debug-info=symbols \
 		    $(if $(call eq,$(split-per-abi),yes),--split-per-abi,), \
 		) \
-		$(foreach v,$(subst $(comma),$(space),$(dart-env)),--dart-define=$(v)) \
+		$(foreach v,$(subst $(comma), ,$(dart-env)),--dart-define=$(v)) \
 		$(if $(call eq,$(platform),ios),--no-codesign,)
 endif
 
@@ -227,7 +225,7 @@ ifeq ($(wildcard lib/api/backend/*.graphql.dart),)
 endif
 	flutter run $(if $(call eq,$(debug),no),--release,) \
 		$(if $(call eq,$(device),),,-d $(device)) \
-		$(foreach v,$(subst $(comma),$(space),$(dart-env)),--dart-define=$(v))
+		$(foreach v,$(subst $(comma), ,$(dart-env)),--dart-define=$(v))
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 
 comma := ,
 
+space := $(subst ,, )
+
 # Checks two given strings for equality.
 eq = $(if $(or $(1),$(2)),$(and $(findstring $(1),$(2)),\
                                 $(findstring $(2),$(1))),1)
@@ -139,7 +141,7 @@ else
 		    --split-debug-info=symbols \
 		    $(if $(call eq,$(split-per-abi),yes),--split-per-abi,), \
 		) \
-		$(if $(call eq,$(dart-env),),,--dart-define=$(dart-env)) \
+		$(foreach v,$(subst $(comma),$(space),$(dart-env)),--dart-define=$(v)) \
 		$(if $(call eq,$(platform),ios),--no-codesign,)
 endif
 
@@ -225,7 +227,7 @@ ifeq ($(wildcard lib/api/backend/*.graphql.dart),)
 endif
 	flutter run $(if $(call eq,$(debug),no),--release,) \
 		$(if $(call eq,$(device),),,-d $(device)) \
-		$(if $(call eq,$(dart-env),),,--dart-define=$(dart-env))
+		$(foreach v,$(subst $(comma),$(space),$(dart-env)),--dart-define=$(v))
 
 
 

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -25,6 +25,10 @@ PODS:
     - Flutter
     - FlutterMacOS
     - Sentry (~> 7.11.0)
+  - share_plus_macos (0.0.1):
+    - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
   - wakelock_macos (0.0.1):
     - FlutterMacOS
   - window_manager (0.2.0):
@@ -41,6 +45,8 @@ DEPENDENCIES:
   - package_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
   - sentry_flutter (from `Flutter/ephemeral/.symlinks/plugins/sentry_flutter/macos`)
+  - share_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/share_plus_macos/macos`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - wakelock_macos (from `Flutter/ephemeral/.symlinks/plugins/wakelock_macos/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
@@ -70,6 +76,10 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
   sentry_flutter:
     :path: Flutter/ephemeral/.symlinks/plugins/sentry_flutter/macos
+  share_plus_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus_macos/macos
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   wakelock_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/wakelock_macos/macos
   window_manager:
@@ -88,6 +98,8 @@ SPEC CHECKSUMS:
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
   sentry_flutter: efb3df2c203cd03aad255892a8d628a458656d14
+  share_plus_macos: 853ee48e7dce06b633998ca0735d482dd671ade4
+  url_launcher_macos: 597e05b8e514239626bcf4a850fcf9ef5c856ec3
   wakelock_macos: bc3f2a9bd8d2e6c89fee1e1822e7ddac3bd004a9
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
 


### PR DESCRIPTION
## Synopsis

CI doesn't build macOS build as `medea_flutter_webrtc` doesn't support it.




## Solution

Now `medea_flutter_webrtc` does, so add macOS building and account the built executable in the `docker` and GitHub release CI stages.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
