### PR TITLE
Add mobile call minimizing on back button (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ All user visible changes to this project will be documented in this file. This p
 
 - Android:
     - [ConnectionService] displaying call when application is in foreground ([#14]);
-    - Back button not minimizing Call ([#80], [#76]).
+    - Back button not minimizing call ([#80], [#76]).
 - Web:
     - UI not hiding on window focus loses ([#60]).
 - UI:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ All user visible changes to this project will be documented in this file. This p
 ### Fixed
 
 - Android:
-    - [ConnectionService] displaying call when application is in foreground ([#14]).
+    - [ConnectionService] displaying call when application is in foreground ([#14]);
+    - Back button not minimizing Call ([#80], [#76]).
 - Web:
     - UI not hiding on window focus loses ([#60]).
 - UI:
@@ -69,6 +70,8 @@ All user visible changes to this project will be documented in this file. This p
 [#53]: /../../pull/53
 [#56]: /../../pull/56
 [#60]: /../../pull/60
+[#76]: /../../issues/76
+[#80]: /../../pull/80
 
 
 

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -217,26 +217,29 @@ Widget mobileCall(CallController c, BuildContext context) {
     // If there's any error to show, display it.
     overlay.add(
       Obx(() {
-        if (c.errorTimeout.value != 0) {
-          return SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.only(top: 10, right: 10),
-              child: Align(
-                alignment: Alignment.topRight,
-                child: SizedBox(
-                  width: 280,
-                  child: HintWidget(
-                    text: '${c.error}.',
-                    onTap: () => c.errorTimeout.value = 0,
-                    isError: true,
+        return AnimatedSwitcher(
+          duration: 200.milliseconds,
+          child: c.errorTimeout.value != 0 &&
+                  c.minimizing.isFalse &&
+                  c.minimized.isFalse
+              ? SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 10, right: 10),
+                    child: Align(
+                      alignment: Alignment.topRight,
+                      child: SizedBox(
+                        width: 280,
+                        child: HintWidget(
+                          text: '${c.error}.',
+                          onTap: () => c.errorTimeout.value = 0,
+                          isError: true,
+                        ),
+                      ),
+                    ),
                   ),
-                ),
-              ),
-            ),
-          );
-        }
-
-        return Container();
+                )
+              : Container(),
+        );
       }),
     );
 

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -218,13 +218,19 @@ Widget mobileCall(CallController c, BuildContext context) {
     overlay.add(
       Obx(() {
         if (c.errorTimeout.value != 0) {
-          return Align(
-            alignment: Alignment.topRight,
-            child: SizedBox(
-              width: 280,
-              child: HintWidget(
-                text: '${c.error}.',
-                onTap: () => c.errorTimeout.value = 0,
+          return SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 10, right: 10),
+              child: Align(
+                alignment: Alignment.topRight,
+                child: SizedBox(
+                  width: 280,
+                  child: HintWidget(
+                    text: '${c.error}.',
+                    onTap: () => c.errorTimeout.value = 0,
+                    isError: true,
+                  ),
+                ),
               ),
             ),
           );

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -17,6 +17,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:get/get.dart';
@@ -455,6 +456,7 @@ class CallController extends GetxController {
     if (router.context!.isMobile) {
       secondaryWidth = RxDouble(150);
       secondaryHeight = RxDouble(151);
+      BackButtonInterceptor.add(_onBack);
     } else {
       secondaryWidth = RxDouble(200);
       secondaryHeight = RxDouble(200);
@@ -761,6 +763,10 @@ class CallController extends GetxController {
 
     if (fullscreen.value) {
       PlatformUtils.exitFullscreen();
+    }
+
+    if(router.context!.isMobile) {
+      BackButtonInterceptor.remove(_onBack);
     }
 
     Future.delayed(Duration.zero, ContextMenuOverlay.of(router.context!).hide);
@@ -1618,6 +1624,17 @@ class CallController extends GetxController {
       return 0;
     }
     return top;
+  }
+
+  /// Minimizes call view if not minimized.
+  ///
+  /// Used to minimize call view on back button.
+  bool _onBack(bool _, RouteInfo __) {
+    if(minimized.isFalse) {
+      minimize();
+      return true;
+    }
+    return false;
   }
 
   /// Puts [participant] from its `default` group to [list].

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -456,10 +456,13 @@ class CallController extends GetxController {
     if (router.context!.isMobile) {
       secondaryWidth = RxDouble(150);
       secondaryHeight = RxDouble(151);
-      BackButtonInterceptor.add(_onBack);
     } else {
       secondaryWidth = RxDouble(200);
       secondaryHeight = RxDouble(200);
+    }
+
+    if (PlatformUtils.isAndroid) {
+      BackButtonInterceptor.add(_onBack);
     }
 
     fullscreen = RxBool(false);
@@ -765,7 +768,7 @@ class CallController extends GetxController {
       PlatformUtils.exitFullscreen();
     }
 
-    if (router.context!.isMobile) {
+    if (PlatformUtils.isAndroid) {
       BackButtonInterceptor.remove(_onBack);
     }
 
@@ -1626,14 +1629,17 @@ class CallController extends GetxController {
     return top;
   }
 
-  /// Minimizes call view if not minimized.
+  /// Invokes [minimize], if not [minimized] already.
   ///
-  /// Used to minimize call view on back button.
+  /// Intended to be used as a [BackButtonInterceptor] callback, thus returns
+  /// `true`, if back button should be intercepted, or otherwise returns
+  /// `false`.
   bool _onBack(bool _, RouteInfo __) {
     if (minimized.isFalse) {
       minimize();
       return true;
     }
+
     return false;
   }
 

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -765,7 +765,7 @@ class CallController extends GetxController {
       PlatformUtils.exitFullscreen();
     }
 
-    if(router.context!.isMobile) {
+    if (router.context!.isMobile) {
       BackButtonInterceptor.remove(_onBack);
     }
 
@@ -1630,7 +1630,7 @@ class CallController extends GetxController {
   ///
   /// Used to minimize call view on back button.
   bool _onBack(bool _, RouteInfo __) {
-    if(minimized.isFalse) {
+    if (minimized.isFalse) {
       minimize();
       return true;
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,6 +106,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  back_button_interceptor:
+    dependency: "direct main"
+    description:
+      name: back_button_interceptor
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.1"
   badges:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   animated_size_and_fade: ^3.0.0
   async: ^2.8.2
   audioplayers: ^1.0.1
+  back_button_interceptor: ^6.0.1
   badges: ^2.0.2
   callkeep: ^0.3.2
   carousel_slider: ^4.1.1


### PR DESCRIPTION
Resolves #76




## Synopsis

На мобильных устройствах, если звонок открыт на весь экран, при нажатии кнопки назад, звонок не сворачивается.




## Solution

В начале звонка будет добавлен слушатель кнопки «назад», при нажатии на которую, звонок будет сворачитаться.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
