### PR TITLE
Fix macOS linking issues

### DIFF
--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -91,7 +91,7 @@ SPEC CHECKSUMS:
   desktop_drop: 69eeff437544aa619c8db7f4481b3a65f7696898
   flutter_local_notifications: 3805ca215b2fb7f397d78b66db91f6a747af52e4
   FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
-  medea_flutter_webrtc: d7cbc985e30264348ed767e0e9c2d033f6ecc62a
+  medea_flutter_webrtc: 028a81d72434f27a0004d2847055dfbb3be11d19
   medea_jason: 074d7303ba539375fde3b3bdb98069b456a5ed0a
   package_info_plus_macos: f010621b07802a241d96d01876d6705f15e77c1c
   path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -425,6 +425,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.team113.messenger;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -573,6 +574,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.team113.messenger;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,12 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -28,5 +28,9 @@
   <string>MainMenu</string>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
+  <key>NSCameraUsageDescription</key>
+  <string>We need access to your camera to take photos/videos</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>We need access to your microphone to record it</string>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,6 +4,12 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -894,13 +894,13 @@ packages:
       name: medea_flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0-dev+rev.fe4d3b9cd21a390870d5390393300371fe5f1bb2"
+    version: "0.8.0-dev+rev.1c0c2769afb29a76f4e6b7c4707ab3526ceab937"
   medea_jason:
     dependency: "direct main"
     description:
       path: flutter
       ref: HEAD
-      resolved-ref: a8b809bd58f53566989eff86ce15a2996848bf93
+      resolved-ref: "3755b0da240f2f0fb089c6fb6dacb64710ec7a97"
       url: "https://github.com/instrumentisto/medea-jason.git"
     source: git
     version: "0.3.0-dev"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -899,8 +899,8 @@ packages:
     dependency: "direct main"
     description:
       path: flutter
-      ref: HEAD
-      resolved-ref: "3755b0da240f2f0fb089c6fb6dacb64710ec7a97"
+      ref: fix-macos-linking
+      resolved-ref: "31037504bd740a08f39338daa6062e86fbf5db06"
       url: "https://github.com/instrumentisto/medea-jason.git"
     source: git
     version: "0.3.0-dev"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -899,8 +899,8 @@ packages:
     dependency: "direct main"
     description:
       path: flutter
-      ref: fix-macos-linking
-      resolved-ref: "31037504bd740a08f39338daa6062e86fbf5db06"
+      ref: HEAD
+      resolved-ref: "89a4dfb062c7928fc6b9fce63534b12534f5d747"
       url: "https://github.com/instrumentisto/medea-jason.git"
     source: git
     version: "0.3.0-dev"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   intl: ^0.17.0
   js: ^0.6.4
   material_floating_search_bar: ^0.3.7
-  medea_flutter_webrtc: ^0.8.0-dev+rev.fe4d3b9cd21a390870d5390393300371fe5f1bb2
+  medea_flutter_webrtc: 0.8.0-dev+rev.1c0c2769afb29a76f4e6b7c4707ab3526ceab937
   medea_jason:
     git:
       url: https://github.com/instrumentisto/medea-jason.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   medea_jason:
     git:
       url: https://github.com/instrumentisto/medea-jason.git
+      ref: fix-macos-linking
       path: flutter/
   mime: ^1.0.2
   mutex: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,6 @@ dependencies:
   medea_jason:
     git:
       url: https://github.com/instrumentisto/medea-jason.git
-      ref: fix-macos-linking
       path: flutter/
   mime: ^1.0.2
   mutex: ^3.0.0


### PR DESCRIPTION
## Synopsis

macOS application currently throws the missing symbol exceptions when trying to initiate a media call.




## Solution

Update to the latest `medea_jason` and add some required fields to the macOS project.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
