### PR TITLE
Make `GraphQlProvider` exceptions const

### DIFF
--- a/lib/domain/service/call.dart
+++ b/lib/domain/service/call.dart
@@ -276,7 +276,7 @@ class CallService extends DisposableService {
         groupName,
       );
     } else {
-      throw TransformDialogCallIntoGroupCallException(
+      throw const TransformDialogCallIntoGroupCallException(
         TransformDialogCallIntoGroupCallErrorCode.noCall,
       );
     }

--- a/lib/domain/service/chat.dart
+++ b/lib/domain/service/chat.dart
@@ -143,15 +143,18 @@ class ChatService extends DisposableService {
   Future<void> deleteChatMessage(ChatMessage item) async {
     UserId me = _myUser.myUser.value!.id;
     if (item.authorId != me) {
-      throw DeleteChatMessageException(DeleteChatMessageErrorCode.notAuthor);
+      throw const DeleteChatMessageException(
+        DeleteChatMessageErrorCode.notAuthor,
+      );
     }
     Chat? chat = chats[item.chatId]?.chat.value;
     if (chat == null) {
-      throw DeleteChatMessageException(
-          DeleteChatMessageErrorCode.unknownChatItem);
+      throw const DeleteChatMessageException(
+        DeleteChatMessageErrorCode.unknownChatItem,
+      );
     } else {
       if (chat.isRead(item, me)) {
-        throw DeleteChatMessageException(DeleteChatMessageErrorCode.read);
+        throw const DeleteChatMessageException(DeleteChatMessageErrorCode.read);
       }
       await _chatRepository.deleteChatMessage(item);
     }
@@ -161,15 +164,18 @@ class ChatService extends DisposableService {
   Future<void> deleteChatForward(ChatForward item) async {
     UserId me = _myUser.myUser.value!.id;
     if (item.authorId != me) {
-      throw DeleteChatForwardException(DeleteChatForwardErrorCode.notAuthor);
+      throw const DeleteChatForwardException(
+        DeleteChatForwardErrorCode.notAuthor,
+      );
     }
     Chat? chat = chats[item.chatId]?.chat.value;
     if (chat == null) {
-      throw DeleteChatForwardException(
-          DeleteChatForwardErrorCode.unknownChatItem);
+      throw const DeleteChatForwardException(
+        DeleteChatForwardErrorCode.unknownChatItem,
+      );
     } else {
       if (chat.isRead(item, me)) {
-        throw DeleteChatForwardException(DeleteChatForwardErrorCode.read);
+        throw const DeleteChatForwardException(DeleteChatForwardErrorCode.read);
       }
       await _chatRepository.deleteChatForward(item.chatId, item.id);
     }
@@ -178,7 +184,7 @@ class ChatService extends DisposableService {
   /// Hides the specified [ChatItem] for the authenticated [MyUser].
   Future<void> hideChatItem(ChatItem item) async {
     if (!chats.containsKey(item.chatId)) {
-      throw HideChatItemException(HideChatItemErrorCode.unknownChatItem);
+      throw const HideChatItemException(HideChatItemErrorCode.unknownChatItem);
     }
     await _chatRepository.hideChatItem(item.chatId, item.id);
   }

--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -338,7 +338,7 @@ class GraphQlClient {
     for (SubscriptionConnection s in List.from(_subscriptions)) {
       if (s.hasListener) {
         Future.delayed(Duration.zero, () {
-          s.addError(ResubscriptionRequiredException());
+          s.addError(const ResubscriptionRequiredException());
         });
       }
     }

--- a/lib/provider/gql/components/chat.dart
+++ b/lib/provider/gql/components/chat.dart
@@ -709,7 +709,9 @@ abstract class ChatGraphQlMixin {
           as UploadAttachment$Mutation$UploadAttachment$UploadAttachmentOk;
     } on dio.DioError catch (e) {
       if (e.response?.statusCode == 413) {
-        throw UploadAttachmentException(UploadAttachmentErrorCode.tooBigSize);
+        throw const UploadAttachmentException(
+          UploadAttachmentErrorCode.tooBigSize,
+        );
       }
 
       rethrow;

--- a/lib/provider/gql/components/user.dart
+++ b/lib/provider/gql/components/user.dart
@@ -882,8 +882,9 @@ abstract class UserGraphQlMixin {
           .uploadUserGalleryItem as MyUserEventsVersionedMixin?);
     } on dio.DioError catch (e) {
       if (e.response?.statusCode == 413) {
-        throw UploadUserGalleryItemException(
-            UploadUserGalleryItemErrorCode.tooBigSize);
+        throw const UploadUserGalleryItemException(
+          UploadUserGalleryItemErrorCode.tooBigSize,
+        );
       }
 
       rethrow;

--- a/lib/provider/gql/exceptions.dart
+++ b/lib/provider/gql/exceptions.dart
@@ -72,7 +72,7 @@ class GraphQlProviderExceptions {
                 e.extensions?['code'] == 'AUTHENTICATION_REQUIRED' ||
                 e.extensions?['code'] == 'AUTHENTICATION_FAILED') !=
             null) {
-          return AuthorizationException();
+          return const AuthorizationException();
         }
 
         return GraphQlException(result.exception!.graphqlErrors);
@@ -84,7 +84,7 @@ class GraphQlProviderExceptions {
         // If the original exception is "Failed to parse header value", then
         // it's `AuthorizationException`.
         if (e.originalException.toString() == 'Failed to parse header value') {
-          return AuthorizationException();
+          return const AuthorizationException();
         }
 
         // If it's `SocketException` or "XMLHttpRequest error." then it's
@@ -99,7 +99,7 @@ class GraphQlProviderExceptions {
         if (e.parsedResponse?.errors != null) {
           var found = e.parsedResponse!.errors!.firstWhereOrNull(
               (v) => v.extensions != null && (v.extensions!['status'] == 401));
-          if (found != null) throw AuthorizationException();
+          if (found != null) throw const AuthorizationException();
           return GraphQlException(e.parsedResponse!.errors!);
         }
 
@@ -130,7 +130,7 @@ class GraphQlException with LocalizedExceptionMixin implements Exception {
       : graphqlErrors = graphqlErrors.toList();
 
   /// Any GraphQL errors returned from the operation.
-  List<GraphQLError> graphqlErrors = [];
+  final List<GraphQLError> graphqlErrors;
 
   @override
   String toString() => 'GraphQlException($graphqlErrors)';
@@ -163,6 +163,8 @@ class ConnectionException with LocalizedExceptionMixin implements Exception {
 ///
 /// Thrown on header parsing errors or on 401 response status.
 class AuthorizationException with LocalizedExceptionMixin implements Exception {
+  const AuthorizationException();
+
   @override
   String toString() => 'AuthException()';
 
@@ -199,16 +201,18 @@ class StaleVersionException extends GraphQlException {
 /// Thrown on a GraphQL subscription timeout or on [AuthorizationException].
 /// It's required to re-subscribe whenever this exception is thrown.
 class ResubscriptionRequiredException implements Exception {
+  const ResubscriptionRequiredException();
+
   @override
   String toString() => 'ResubscriptionRequiredException()';
 }
 
 /// Exception of `Mutation.createSession` described in the [code].
 class CreateSessionException with LocalizedExceptionMixin implements Exception {
-  CreateSessionException(this.code);
+  const CreateSessionException(this.code);
 
   /// Reason of why the mutation has failed.
-  CreateSessionErrorCode code;
+  final CreateSessionErrorCode code;
 
   @override
   String toString() => 'CreateSessionException($code)';
@@ -239,10 +243,10 @@ class RenewSessionException implements Exception {
 
 /// Exception of `Mutation.createChatDialog` described in the [code].
 class CreateDialogException with LocalizedExceptionMixin implements Exception {
-  CreateDialogException(this.code);
+  const CreateDialogException(this.code);
 
   /// Reason of why the mutation has failed.
-  CreateDialogChatErrorCode code;
+  final CreateDialogChatErrorCode code;
 
   @override
   String toString() => 'CreateDialogException($code)';
@@ -264,10 +268,10 @@ class CreateDialogException with LocalizedExceptionMixin implements Exception {
 class CreateGroupChatException
     with LocalizedExceptionMixin
     implements Exception {
-  CreateGroupChatException(this.code);
+  const CreateGroupChatException(this.code);
 
   /// Reason of why the mutation has failed.
-  CreateGroupChatErrorCode code;
+  final CreateGroupChatErrorCode code;
 
   @override
   String toString() => 'CreateGroupException($code)';
@@ -291,10 +295,10 @@ class CreateGroupChatException
 class RemoveChatMemberException
     with LocalizedExceptionMixin
     implements Exception {
-  RemoveChatMemberException(this.code);
+  const RemoveChatMemberException(this.code);
 
   /// Reason of why the mutation has failed.
-  RemoveChatMemberErrorCode code;
+  final RemoveChatMemberErrorCode code;
 
   @override
   String toString() => 'RemoveChatMemberException($code)';
@@ -314,10 +318,10 @@ class RemoveChatMemberException
 
 /// Exception of `Mutation.startChatCall` described in the [code].
 class StartChatCallException with LocalizedExceptionMixin implements Exception {
-  StartChatCallException(this.code);
+  const StartChatCallException(this.code);
 
   /// Reason of why the mutation has failed.
-  StartChatCallErrorCode code;
+  final StartChatCallErrorCode code;
 
   @override
   String toString() => 'StartChatCallException($code)';
@@ -339,10 +343,10 @@ class StartChatCallException with LocalizedExceptionMixin implements Exception {
 
 /// Exception of `Mutation.joinChatCall` described in the [code].
 class JoinChatCallException with LocalizedExceptionMixin implements Exception {
-  JoinChatCallException(this.code);
+  const JoinChatCallException(this.code);
 
   /// Reason of why the mutation has failed.
-  JoinChatCallErrorCode code;
+  final JoinChatCallErrorCode code;
 
   @override
   String toString() => 'JoinChatCallException($code)';
@@ -362,10 +366,10 @@ class JoinChatCallException with LocalizedExceptionMixin implements Exception {
 
 /// Exception of `Mutation.leaveChatCall` described in the [code].
 class LeaveChatCallException with LocalizedExceptionMixin implements Exception {
-  LeaveChatCallException(this.code);
+  const LeaveChatCallException(this.code);
 
   /// Reason of why the mutation has failed.
-  LeaveChatCallErrorCode code;
+  final LeaveChatCallErrorCode code;
 
   @override
   String toString() => 'LeaveChatCallException($code)';
@@ -387,10 +391,10 @@ class LeaveChatCallException with LocalizedExceptionMixin implements Exception {
 class DeclineChatCallException
     with LocalizedExceptionMixin
     implements Exception {
-  DeclineChatCallException(this.code);
+  const DeclineChatCallException(this.code);
 
   /// Reason of why the mutation has failed.
-  DeclineChatCallErrorCode code;
+  final DeclineChatCallErrorCode code;
 
   @override
   String toString() => 'LeaveChatCallException($code)';
@@ -412,10 +416,10 @@ class DeclineChatCallException
 class UpdateUserLoginException
     with LocalizedExceptionMixin
     implements Exception {
-  UpdateUserLoginException(this.code);
+  const UpdateUserLoginException(this.code);
 
   /// Reason of why the mutation has failed.
-  UpdateUserLoginErrorCode code;
+  final UpdateUserLoginErrorCode code;
 
   @override
   String toString() => 'UpdateUserLoginException($code)';
@@ -435,10 +439,10 @@ class UpdateUserLoginException
 class UploadAttachmentException
     with LocalizedExceptionMixin
     implements Exception {
-  UploadAttachmentException(this.code);
+  const UploadAttachmentException(this.code);
 
   /// Reason of why the mutation has failed.
-  UploadAttachmentErrorCode code;
+  final UploadAttachmentErrorCode code;
 
   @override
   String toString() => 'UploadAttachmentException($code)';
@@ -462,10 +466,10 @@ class UploadAttachmentException
 class UpdateUserPasswordException
     with LocalizedExceptionMixin
     implements Exception {
-  UpdateUserPasswordException(this.code);
+  const UpdateUserPasswordException(this.code);
 
   /// Reason of why the mutation has failed.
-  UpdateUserPasswordErrorCode code;
+  final UpdateUserPasswordErrorCode code;
 
   @override
   String toString() => 'UpdateUserPasswordException($code)';
@@ -485,10 +489,10 @@ class UpdateUserPasswordException
 class CreateChatContactException
     with LocalizedExceptionMixin
     implements Exception {
-  CreateChatContactException(this.code);
+  const CreateChatContactException(this.code);
 
   /// Reason of why the mutation has failed.
-  CreateChatContactErrorCode code;
+  final CreateChatContactErrorCode code;
 
   @override
   String toString() => 'CreateChatContactException($code)';
@@ -514,10 +518,10 @@ class CreateChatContactException
 class RecoverUserPasswordException
     with LocalizedExceptionMixin
     implements Exception {
-  RecoverUserPasswordException(this.code);
+  const RecoverUserPasswordException(this.code);
 
   /// Reason of why the mutation has failed.
-  RecoverUserPasswordErrorCode code;
+  final RecoverUserPasswordErrorCode code;
 
   @override
   String toString() => 'RecoverUserPasswordException($code)';
@@ -542,10 +546,10 @@ class RecoverUserPasswordException
 class ValidateUserPasswordRecoveryCodeException
     with LocalizedExceptionMixin
     implements Exception {
-  ValidateUserPasswordRecoveryCodeException(this.code);
+  const ValidateUserPasswordRecoveryCodeException(this.code);
 
   /// Reason of why the mutation has failed.
-  ValidateUserPasswordRecoveryErrorCode code;
+  final ValidateUserPasswordRecoveryErrorCode code;
 
   @override
   String toString() => 'ValidateUserPasswordRecoveryCodeException($code)';
@@ -567,10 +571,10 @@ class ValidateUserPasswordRecoveryCodeException
 class ResetUserPasswordException
     with LocalizedExceptionMixin
     implements Exception {
-  ResetUserPasswordException(this.code);
+  const ResetUserPasswordException(this.code);
 
   /// Reason of why the mutation has failed.
-  ResetUserPasswordErrorCode code;
+  final ResetUserPasswordErrorCode code;
 
   @override
   String toString() => 'ResetUserPasswordException($code)';
@@ -590,10 +594,10 @@ class ResetUserPasswordException
 
 /// Exception of `Mutation.addChatMember` described in the [code].
 class AddChatMemberException with LocalizedExceptionMixin implements Exception {
-  AddChatMemberException(this.code);
+  const AddChatMemberException(this.code);
 
   /// Reason of why the mutation has failed.
-  AddChatMemberErrorCode code;
+  final AddChatMemberErrorCode code;
 
   @override
   String toString() => 'AddChatMemberException($code)';
@@ -617,10 +621,10 @@ class AddChatMemberException with LocalizedExceptionMixin implements Exception {
 
 /// Exception of `Mutation.renameChat` described in the [code].
 class RenameChatException with LocalizedExceptionMixin implements Exception {
-  RenameChatException(this.code);
+  const RenameChatException(this.code);
 
   /// Reason of why the mutation has failed.
-  RenameChatErrorCode code;
+  final RenameChatErrorCode code;
 
   @override
   String toString() => 'RenameChatException($code)';
@@ -642,10 +646,10 @@ class RenameChatException with LocalizedExceptionMixin implements Exception {
 class PostChatMessageException
     with LocalizedExceptionMixin
     implements Exception {
-  PostChatMessageException(this.code);
+  const PostChatMessageException(this.code);
 
   /// Reason of why the mutation has failed.
-  PostChatMessageErrorCode code;
+  final PostChatMessageErrorCode code;
 
   @override
   String toString() => 'PostChatMessageException($code)';
@@ -671,10 +675,10 @@ class PostChatMessageException
 
 /// Exception of `Mutation.hideChat` described in the [code].
 class HideChatException with LocalizedExceptionMixin implements Exception {
-  HideChatException(this.code);
+  const HideChatException(this.code);
 
   /// Reason of why the mutation has failed.
-  HideChatErrorCode code;
+  final HideChatErrorCode code;
 
   @override
   String toString() => 'HideChatException($code)';
@@ -694,10 +698,10 @@ class HideChatException with LocalizedExceptionMixin implements Exception {
 class UpdateChatContactNameException
     with LocalizedExceptionMixin
     implements Exception {
-  UpdateChatContactNameException(this.code);
+  const UpdateChatContactNameException(this.code);
 
   /// Reason of why the mutation has failed.
-  UpdateChatContactNameErrorCode code;
+  final UpdateChatContactNameErrorCode code;
 
   @override
   String toString() => 'UpdateChatContactNameException($code)';
@@ -715,10 +719,10 @@ class UpdateChatContactNameException
 
 /// Exception of `Mutation.addUserEmail` described in the [code].
 class AddUserEmailException with LocalizedExceptionMixin implements Exception {
-  AddUserEmailException(this.code);
+  const AddUserEmailException(this.code);
 
   /// Reason of why the mutation has failed.
-  AddUserEmailErrorCode code;
+  final AddUserEmailErrorCode code;
 
   @override
   String toString() => 'AddUserEmailException($code)';
@@ -742,10 +746,10 @@ class AddUserEmailException with LocalizedExceptionMixin implements Exception {
 class ResendUserEmailConfirmationException
     with LocalizedExceptionMixin
     implements Exception {
-  ResendUserEmailConfirmationException(this.code);
+  const ResendUserEmailConfirmationException(this.code);
 
   /// Reason of why the mutation has failed.
-  ResendUserEmailConfirmationErrorCode code;
+  final ResendUserEmailConfirmationErrorCode code;
 
   @override
   String toString() => 'ResendUserEmailConfirmationException($code)';
@@ -767,10 +771,10 @@ class ResendUserEmailConfirmationException
 class ResendUserPhoneConfirmationException
     with LocalizedExceptionMixin
     implements Exception {
-  ResendUserPhoneConfirmationException(this.code);
+  const ResendUserPhoneConfirmationException(this.code);
 
   /// Reason of why the mutation has failed.
-  ResendUserPhoneConfirmationErrorCode code;
+  final ResendUserPhoneConfirmationErrorCode code;
 
   @override
   String toString() => 'ResendUserPhoneConfirmationException($code)';
@@ -792,10 +796,10 @@ class ResendUserPhoneConfirmationException
 class ConfirmUserEmailException
     with LocalizedExceptionMixin
     implements Exception {
-  ConfirmUserEmailException(this.code);
+  const ConfirmUserEmailException(this.code);
 
   /// Reason of why the mutation has failed.
-  ConfirmUserEmailErrorCode code;
+  final ConfirmUserEmailErrorCode code;
 
   @override
   String toString() => 'ConfirmUserEmailException($code)';
@@ -817,10 +821,10 @@ class ConfirmUserEmailException
 class ConfirmUserPhoneException
     with LocalizedExceptionMixin
     implements Exception {
-  ConfirmUserPhoneException(this.code);
+  const ConfirmUserPhoneException(this.code);
 
   /// Reason of why the mutation has failed.
-  ConfirmUserPhoneErrorCode code;
+  final ConfirmUserPhoneErrorCode code;
 
   @override
   String toString() => 'ConfirmUserPhoneException($code)';
@@ -840,10 +844,10 @@ class ConfirmUserPhoneException
 
 /// Exception of `Mutation.addUserPhone` described in the [code].
 class AddUserPhoneException with LocalizedExceptionMixin implements Exception {
-  AddUserPhoneException(this.code);
+  const AddUserPhoneException(this.code);
 
   /// Reason of why the mutation has failed.
-  AddUserPhoneErrorCode code;
+  final AddUserPhoneErrorCode code;
 
   @override
   String toString() => 'AddUserPhoneException($code)';
@@ -865,10 +869,10 @@ class AddUserPhoneException with LocalizedExceptionMixin implements Exception {
 
 /// Exception of `Mutation.readChat` described in the [code].
 class ReadChatException with LocalizedExceptionMixin implements Exception {
-  ReadChatException(this.code);
+  const ReadChatException(this.code);
 
   /// Reason of why the mutation has failed.
-  ReadChatErrorCode code;
+  final ReadChatErrorCode code;
 
   @override
   String toString() => 'ReadChatException($code)';
@@ -888,10 +892,10 @@ class ReadChatException with LocalizedExceptionMixin implements Exception {
 
 /// Exception of `Mutation.hideChatItem` described in the [code].
 class HideChatItemException with LocalizedExceptionMixin implements Exception {
-  HideChatItemException(this.code);
+  const HideChatItemException(this.code);
 
   /// Reason of why the mutation has failed.
-  HideChatItemErrorCode code;
+  final HideChatItemErrorCode code;
 
   @override
   String toString() => 'HideChatItemException($code)';
@@ -911,10 +915,10 @@ class HideChatItemException with LocalizedExceptionMixin implements Exception {
 class DeleteChatMessageException
     with LocalizedExceptionMixin
     implements Exception {
-  DeleteChatMessageException(this.code);
+  const DeleteChatMessageException(this.code);
 
   /// Reason of why the mutation has failed.
-  DeleteChatMessageErrorCode code;
+  final DeleteChatMessageErrorCode code;
 
   @override
   String toString() => 'DeleteChatMessageException($code)';
@@ -940,10 +944,10 @@ class DeleteChatMessageException
 class DeleteChatForwardException
     with LocalizedExceptionMixin
     implements Exception {
-  DeleteChatForwardException(this.code);
+  const DeleteChatForwardException(this.code);
 
   /// Reason of why the mutation has failed.
-  DeleteChatForwardErrorCode code;
+  final DeleteChatForwardErrorCode code;
 
   @override
   String toString() => 'DeleteChatForwardException($code)';
@@ -969,10 +973,10 @@ class DeleteChatForwardException
 class ToggleChatCallHandException
     with LocalizedExceptionMixin
     implements Exception {
-  ToggleChatCallHandException(this.code);
+  const ToggleChatCallHandException(this.code);
 
   /// Reason of why the mutation has failed.
-  ToggleChatCallHandErrorCode code;
+  final ToggleChatCallHandErrorCode code;
 
   @override
   String toString() => 'ToggleChatCallHandException($code)';
@@ -996,10 +1000,10 @@ class ToggleChatCallHandException
 class CreateChatDirectLinkException
     with LocalizedExceptionMixin
     implements Exception {
-  CreateChatDirectLinkException(this.code);
+  const CreateChatDirectLinkException(this.code);
 
   /// Reason of why the mutation has failed.
-  CreateChatDirectLinkErrorCode code;
+  final CreateChatDirectLinkErrorCode code;
 
   @override
   String toString() => 'CreateChatDirectLinkException($code)';
@@ -1023,10 +1027,10 @@ class CreateChatDirectLinkException
 class DeleteChatDirectLinkException
     with LocalizedExceptionMixin
     implements Exception {
-  DeleteChatDirectLinkException(this.code);
+  const DeleteChatDirectLinkException(this.code);
 
   /// Reason of why the mutation has failed.
-  DeleteChatDirectLinkErrorCode code;
+  final DeleteChatDirectLinkErrorCode code;
 
   @override
   String toString() => 'DeleteChatDirectLinkException($code)';
@@ -1048,10 +1052,10 @@ class DeleteChatDirectLinkException
 class UseChatDirectLinkException
     with LocalizedExceptionMixin
     implements Exception {
-  UseChatDirectLinkException(this.code);
+  const UseChatDirectLinkException(this.code);
 
   /// Reason of why the mutation has failed.
-  UseChatDirectLinkErrorCode code;
+  final UseChatDirectLinkErrorCode code;
 
   @override
   String toString() => 'UseChatDirectLinkException($code)';
@@ -1073,10 +1077,10 @@ class UseChatDirectLinkException
 class EditChatMessageException
     with LocalizedExceptionMixin
     implements Exception {
-  EditChatMessageException(this.code);
+  const EditChatMessageException(this.code);
 
   /// Reason of why the mutation has failed.
-  EditChatMessageTextErrorCode code;
+  final EditChatMessageTextErrorCode code;
 
   @override
   String toString() => 'EditChatMessageTextException($code)';
@@ -1102,10 +1106,10 @@ class EditChatMessageException
 class UpdateUserAvatarException
     with LocalizedExceptionMixin
     implements Exception {
-  UpdateUserAvatarException(this.code);
+  const UpdateUserAvatarException(this.code);
 
   /// Reason of why the mutation has failed.
-  UpdateUserAvatarErrorCode code;
+  final UpdateUserAvatarErrorCode code;
 
   @override
   String toString() => 'UpdateUserAvatarException($code)';
@@ -1129,10 +1133,10 @@ class UpdateUserAvatarException
 class UpdateUserCallCoverException
     with LocalizedExceptionMixin
     implements Exception {
-  UpdateUserCallCoverException(this.code);
+  const UpdateUserCallCoverException(this.code);
 
   /// Reason of why the mutation has failed.
-  UpdateUserCallCoverErrorCode code;
+  final UpdateUserCallCoverErrorCode code;
 
   @override
   String toString() => 'UpdateUserCallCoverException($code)';
@@ -1156,10 +1160,10 @@ class UpdateUserCallCoverException
 class UploadUserGalleryItemException
     with LocalizedExceptionMixin
     implements Exception {
-  UploadUserGalleryItemException(this.code);
+  const UploadUserGalleryItemException(this.code);
 
   /// Reason of why the mutation has failed.
-  UploadUserGalleryItemErrorCode code;
+  final UploadUserGalleryItemErrorCode code;
 
   @override
   String toString() => 'UploadUserGalleryItemException($code)';
@@ -1186,10 +1190,10 @@ class UploadUserGalleryItemException
 class TransformDialogCallIntoGroupCallException
     with LocalizedExceptionMixin
     implements Exception {
-  TransformDialogCallIntoGroupCallException(this.code);
+  const TransformDialogCallIntoGroupCallException(this.code);
 
   /// Reason of why the mutation has failed.
-  TransformDialogCallIntoGroupCallErrorCode code;
+  final TransformDialogCallIntoGroupCallErrorCode code;
 
   @override
   String toString() => 'TransformDialogCallIntoGroupCallException($code)';

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -304,7 +304,7 @@ class HiveRxChat implements RxChat {
       }
 
       if (uploaded.whereType<LocalAttachment>().isNotEmpty) {
-        throw ConnectionException(PostChatMessageException(
+        throw const ConnectionException(PostChatMessageException(
           PostChatMessageErrorCode.unknownAttachment,
         ));
       }

--- a/test/unit/auth_test.dart
+++ b/test/unit/auth_test.dart
@@ -139,7 +139,7 @@ void main() async {
     when(graphQlProvider.signIn(
             UserPassword('123'), null, null, null, null, true))
         .thenThrow(
-            CreateSessionException((CreateSessionErrorCode.unknownUser)));
+            const CreateSessionException((CreateSessionErrorCode.unknownUser)));
 
     AuthRepository authRepository = Get.put(AuthRepository(graphQlProvider));
     AuthService authService = Get.put(AuthService(authRepository, provider));
@@ -203,23 +203,23 @@ void main() async {
 
     when(graphQlProvider.recoverUserPassword(
             UserLogin('unknown'), null, null, null))
-        .thenThrow(RecoverUserPasswordException(
+        .thenThrow(const RecoverUserPasswordException(
             RecoverUserPasswordErrorCode.unknownUser));
 
     when(graphQlProvider.recoverUserPassword(
             UserLogin('empty'), null, null, null))
-        .thenThrow(RecoverUserPasswordException(
+        .thenThrow(const RecoverUserPasswordException(
             RecoverUserPasswordErrorCode.nowhereToSend));
 
     when(graphQlProvider.validateUserPasswordRecoveryCode(
             UserLogin('unknown'), null, null, null, ConfirmationCode('1111')))
-        .thenThrow(ValidateUserPasswordRecoveryCodeException(
+        .thenThrow(const ValidateUserPasswordRecoveryCodeException(
             ValidateUserPasswordRecoveryErrorCode.wrongCode));
 
     when(graphQlProvider.resetUserPassword(UserLogin('unknown'), null, null,
             null, ConfirmationCode('1111'), UserPassword('123456')))
-        .thenThrow(
-            ResetUserPasswordException(ResetUserPasswordErrorCode.wrongCode));
+        .thenThrow(const ResetUserPasswordException(
+            ResetUserPasswordErrorCode.wrongCode));
 
     expect(
         () async =>
@@ -270,13 +270,13 @@ void main() async {
 
     when(graphQlProvider.validateUserPasswordRecoveryCode(
             UserLogin('login'), null, null, null, ConfirmationCode('1111')))
-        .thenThrow(ValidateUserPasswordRecoveryCodeException(
+        .thenThrow(const ValidateUserPasswordRecoveryCodeException(
             ValidateUserPasswordRecoveryErrorCode.wrongCode));
 
     when(graphQlProvider.resetUserPassword(UserLogin('login'), null, null, null,
             ConfirmationCode('1111'), UserPassword('123456')))
-        .thenThrow(
-            ResetUserPasswordException(ResetUserPasswordErrorCode.wrongCode));
+        .thenThrow(const ResetUserPasswordException(
+            ResetUserPasswordErrorCode.wrongCode));
 
     await authService.recoverUserPassword(login: UserLogin('login'));
 

--- a/test/unit/chat_attachment_test.dart
+++ b/test/unit/chat_attachment_test.dart
@@ -221,7 +221,7 @@ void main() async {
       any,
       onSendProgress: anyNamed('onSendProgress'),
     )).thenThrow(
-      UploadAttachmentException(UploadAttachmentErrorCode.artemisUnknown),
+      const UploadAttachmentException(UploadAttachmentErrorCode.artemisUnknown),
     );
 
     Get.put(chatHiveProvider);

--- a/test/unit/chat_delete_message_test.dart
+++ b/test/unit/chat_delete_message_test.dart
@@ -196,8 +196,8 @@ void main() async {
       () async {
     when(graphQlProvider.deleteChatMessage(
       const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-    )).thenThrow(
-        DeleteChatMessageException(DeleteChatMessageErrorCode.unknownChatItem));
+    )).thenThrow(const DeleteChatMessageException(
+        DeleteChatMessageErrorCode.unknownChatItem));
     Get.put(chatHiveProvider);
 
     expect(
@@ -240,7 +240,8 @@ void main() async {
       () async {
     when(graphQlProvider.hideChatItem(
       const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-    )).thenThrow(HideChatItemException(HideChatItemErrorCode.unknownChatItem));
+    )).thenThrow(
+        const HideChatItemException(HideChatItemErrorCode.unknownChatItem));
 
     Get.put(chatHiveProvider);
 

--- a/test/unit/chat_direct_link_test.dart
+++ b/test/unit/chat_direct_link_test.dart
@@ -313,11 +313,11 @@ void main() async {
     when(graphQlProvider.createChatDirectLink(
       ChatDirectLinkSlug('link'),
       groupId: const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-    )).thenThrow(CreateChatDirectLinkException(
+    )).thenThrow(const CreateChatDirectLinkException(
         CreateChatDirectLinkErrorCode.unknownChat));
 
     when(graphQlProvider.createUserDirectLink(ChatDirectLinkSlug('link')))
-        .thenThrow(CreateChatDirectLinkException(
+        .thenThrow(const CreateChatDirectLinkException(
             CreateChatDirectLinkErrorCode.unknownChat));
 
     UserRepository userRepository = Get.put(
@@ -355,7 +355,7 @@ void main() async {
       () async {
     when(graphQlProvider.deleteChatDirectLink(
       groupId: const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-    )).thenThrow(DeleteChatDirectLinkException(
+    )).thenThrow(const DeleteChatDirectLinkException(
         DeleteChatDirectLinkErrorCode.unknownChat));
 
     UserRepository userRepository = Get.put(
@@ -384,7 +384,7 @@ void main() async {
       () async {
     when(graphQlProvider.useChatDirectLink(
       ChatDirectLinkSlug('link'),
-    )).thenThrow(UseChatDirectLinkException(
+    )).thenThrow(const UseChatDirectLinkException(
         UseChatDirectLinkErrorCode.unknownDirectLink));
 
     UserRepository userRepository = Get.put(

--- a/test/unit/chat_edit_message_test.dart
+++ b/test/unit/chat_edit_message_test.dart
@@ -228,8 +228,8 @@ void main() async {
     when(graphQlProvider.editChatMessageText(
       const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),
       const ChatMessageText('new text'),
-    )).thenThrow(
-        EditChatMessageException(EditChatMessageTextErrorCode.unknownChatItem));
+    )).thenThrow(const EditChatMessageException(
+        EditChatMessageTextErrorCode.unknownChatItem));
 
     Get.put(chatHiveProvider);
 

--- a/test/unit/chat_hide_test.dart
+++ b/test/unit/chat_hide_test.dart
@@ -205,7 +205,7 @@ void main() async {
 
     when(graphQlProvider.hideChat(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-    )).thenThrow(HideChatException(HideChatErrorCode.unknownChat));
+    )).thenThrow(const HideChatException(HideChatErrorCode.unknownChat));
 
     UserRepository userRepository = Get.put(
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));

--- a/test/unit/chat_leave_test.dart
+++ b/test/unit/chat_leave_test.dart
@@ -276,7 +276,7 @@ void main() async {
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
       const UserId('0d72d245-8425-467a-9ebd-082d4f47850a'),
     )).thenThrow(
-        RemoveChatMemberException(RemoveChatMemberErrorCode.unknownChat));
+        const RemoveChatMemberException(RemoveChatMemberErrorCode.unknownChat));
 
     Get.put<GraphQlProvider>(graphQlProvider);
     ChatService chatService = await init(graphQlProvider);

--- a/test/unit/chat_members_test.dart
+++ b/test/unit/chat_members_test.dart
@@ -289,7 +289,8 @@ void main() async {
     when(graphQlProvider.addChatMember(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
       const UserId('0d72d245-8425-467a-9ebd-082d4f47850a'),
-    )).thenThrow(AddChatMemberException(AddChatMemberErrorCode.blacklisted));
+    )).thenThrow(
+        const AddChatMemberException(AddChatMemberErrorCode.blacklisted));
 
     expect(
       () async => await chatService.addChatMember(
@@ -331,7 +332,7 @@ void main() async {
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
       const UserId('0d72d245-8425-467a-9ebd-082d4f47850a'),
     )).thenThrow(
-        RemoveChatMemberException(RemoveChatMemberErrorCode.unknownChat));
+        const RemoveChatMemberException(RemoveChatMemberErrorCode.unknownChat));
 
     expect(
       () async => await chatService.removeChatMember(

--- a/test/unit/chat_read_test.dart
+++ b/test/unit/chat_read_test.dart
@@ -233,7 +233,7 @@ void main() async {
     when(graphQlProvider.readChat(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
       const ChatItemId(''),
-    )).thenThrow(ReadChatException(ReadChatErrorCode.unknownChat));
+    )).thenThrow(const ReadChatException(ReadChatErrorCode.unknownChat));
 
     Get.put(chatHiveProvider);
     UserRepository userRepository = Get.put(

--- a/test/unit/chat_rename_test.dart
+++ b/test/unit/chat_rename_test.dart
@@ -221,7 +221,7 @@ void main() async {
     when(graphQlProvider.renameChat(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
       ChatName('newname'),
-    )).thenThrow(RenameChatException(RenameChatErrorCode.unknownChat));
+    )).thenThrow(const RenameChatException(RenameChatErrorCode.unknownChat));
 
     Get.put(chatHiveProvider);
     UserRepository userRepository = Get.put(

--- a/test/unit/chat_reply_message_test.dart
+++ b/test/unit/chat_reply_message_test.dart
@@ -270,7 +270,7 @@ void main() async {
       attachments: anyNamed('attachments'),
       repliesTo: const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),
     )).thenThrow(
-        PostChatMessageException(PostChatMessageErrorCode.blacklisted));
+        const PostChatMessageException(PostChatMessageErrorCode.blacklisted));
 
     Get.put(chatHiveProvider);
     UserRepository userRepository = Get.put(

--- a/test/unit/contact_rename_test.dart
+++ b/test/unit/contact_rename_test.dart
@@ -199,7 +199,7 @@ void main() async {
         UserName('newname'),
       ),
     ).thenThrow(
-      UpdateChatContactNameException(
+      const UpdateChatContactNameException(
           UpdateChatContactNameErrorCode.unknownChatContact),
     );
 

--- a/test/unit/my_profile_emails_test.dart
+++ b/test/unit/my_profile_emails_test.dart
@@ -192,14 +192,14 @@ void main() async {
     );
 
     when(graphQlProvider.addUserEmail(UserEmail('test@mail.ru')))
-        .thenThrow(AddUserEmailException(AddUserEmailErrorCode.tooMany));
+        .thenThrow(const AddUserEmailException(AddUserEmailErrorCode.tooMany));
 
     when(graphQlProvider.resendEmail()).thenThrow(
-        ResendUserEmailConfirmationException(
+        const ResendUserEmailConfirmationException(
             ResendUserEmailConfirmationErrorCode.codeLimitExceeded));
 
     when(graphQlProvider.confirmEmailCode(ConfirmationCode('1234'))).thenThrow(
-        ConfirmUserEmailException(ConfirmUserEmailErrorCode.wrongCode));
+        const ConfirmUserEmailException(ConfirmUserEmailErrorCode.wrongCode));
 
     AuthService authService = Get.put(
       AuthService(

--- a/test/unit/my_profile_gallery_test.dart
+++ b/test/unit/my_profile_gallery_test.dart
@@ -285,15 +285,15 @@ void main() async {
     );
 
     when(graphQlProvider.uploadUserGalleryItem(any)).thenThrow(
-        UploadUserGalleryItemException(
+        const UploadUserGalleryItemException(
             UploadUserGalleryItemErrorCode.tooBigSize));
 
     when(graphQlProvider.updateUserAvatar(any, any)).thenThrow(
-        UpdateUserAvatarException(
+        const UpdateUserAvatarException(
             UpdateUserAvatarErrorCode.unknownGalleryItem));
 
     when(graphQlProvider.updateUserCallCover(any, any)).thenThrow(
-        UpdateUserCallCoverException(
+        const UpdateUserCallCoverException(
             UpdateUserCallCoverErrorCode.unknownGalleryItem));
 
     AuthService authService = Get.put(

--- a/test/unit/my_profile_phones_test.dart
+++ b/test/unit/my_profile_phones_test.dart
@@ -196,17 +196,17 @@ void main() async {
     when(
       graphQlProvider.addUserPhone(UserPhone('+380999999999')),
     ).thenThrow(
-      AddUserPhoneException(AddUserPhoneErrorCode.tooMany),
+      const AddUserPhoneException(AddUserPhoneErrorCode.tooMany),
     );
 
     when(
       graphQlProvider.resendPhone(),
-    ).thenThrow(ResendUserPhoneConfirmationException(
+    ).thenThrow(const ResendUserPhoneConfirmationException(
       ResendUserPhoneConfirmationErrorCode.codeLimitExceeded,
     ));
 
     when(graphQlProvider.confirmPhoneCode(ConfirmationCode('1234'))).thenThrow(
-        ConfirmUserPhoneException(ConfirmUserPhoneErrorCode.wrongCode));
+        const ConfirmUserPhoneException(ConfirmUserPhoneErrorCode.wrongCode));
 
     AuthService authService = Get.put(
       AuthService(

--- a/test/widget/password_recovery_test.dart
+++ b/test/widget/password_recovery_test.dart
@@ -95,7 +95,7 @@ void main() async {
         .thenAnswer((_) => Future.value());
     when(graphQlProvider.recoverUserPassword(
             UserLogin('emptyuser'), null, null, null))
-        .thenAnswer((_) => throw RecoverUserPasswordException(
+        .thenAnswer((_) => throw const RecoverUserPasswordException(
             RecoverUserPasswordErrorCode.unknownUser));
     when(graphQlProvider.validateUserPasswordRecoveryCode(
             UserLogin('login'), null, null, null, ConfirmationCode('1234')))


### PR DESCRIPTION
## Synopsis

`GraphQlProvider` exceptions are non-const currently.




## Solution

This PR makes all the exceptions be `const`, which compiler and `DartVM` might use to optimize their use.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
