### PR TITLE
Fix call ringtone not being looped on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All user visible changes to this project will be documented in this file. This p
 - Android:
     - [ConnectionService] displaying call when application is in foreground ([#14]);
     - Back button not minimizing call ([#80], [#76]).
+- macOS:
+    - Call ringtone not being looped ([#90]).
 - Web:
     - UI not hiding on window focus loses ([#60]).
 - UI:
@@ -85,6 +87,7 @@ All user visible changes to this project will be documented in this file. This p
 [#79]: /../../pull/79
 [#80]: /../../pull/80
 [#83]: /../../pull/83
+[#90]: /../../pull/90
 
 
 

--- a/lib/ui/worker/call.dart
+++ b/lib/ui/worker/call.dart
@@ -283,7 +283,7 @@ class CallWorker extends DisposableService {
       await _audioPlayer?.play(
         AssetSource('audio/$asset'),
         position: Duration.zero,
-        mode: PlayerMode.lowLatency,
+        mode: PlayerMode.mediaPlayer,
       );
     }, (e, _) {
       if (!e.toString().contains('NotAllowedError')) {


### PR DESCRIPTION
## Synopsis

Call plays an audio when calling or being called.




## Solution

This PR fixes this audio not being looped on macOS by changing the `PlayerMode` to `mediaPlayer` (`lowLatency` currently set is not widely supported on macOS).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
