### PR TITLE
Fix `FLUTTER_VER` env `Makefile` variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ endif
 
 flutter.pub:
 ifeq ($(dockerized),yes)
-	docker run --platform linux/amd64 --rm --network=host -v "$(PWD)":/app -w /app \
+	docker run --rm --network=host -v "$(PWD)":/app -w /app \
 	           -v "$(HOME)/.pub-cache":/usr/local/flutter/.pub-cache \
 		ghcr.io/instrumentisto/flutter:$(FLUTTER_VER) \
 			make flutter.pub cmd='$(cmd)' dockerized=no

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ REGISTRIES := $(strip $(subst $(comma), ,\
 VERSION ?= $(strip $(shell grep -m1 'version: ' pubspec.yaml | cut -d ' ' -f2))
 FLUTTER_VER ?= $(strip \
 	$(shell grep -m1 'FLUTTER_VER: ' .github/workflows/ci.yml | cut -d':' -f2 \
-                                                              | tr -d'"'))
+                                                              | cut -d'"' -f2))
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ REGISTRIES := $(strip $(subst $(comma), ,\
 
 VERSION ?= $(strip $(shell grep -m1 'version: ' pubspec.yaml | cut -d ' ' -f2))
 FLUTTER_VER ?= $(strip \
-	$(shell grep -m1 'FLUTTER_VER: ' .github/workflows/ci.yml | cut -d':' -f2 \
-                                                              | cut -d'"' -f2))
+	$(shell grep -m1 'FLUTTER_VER: ' .github/workflows/ci.yml | cut -d'"' -f2))
 
 
 
@@ -203,7 +202,7 @@ endif
 
 flutter.pub:
 ifeq ($(dockerized),yes)
-	docker run --rm --network=host -v "$(PWD)":/app -w /app \
+	docker run --platform linux/amd64 --rm --network=host -v "$(PWD)":/app -w /app \
 	           -v "$(HOME)/.pub-cache":/usr/local/flutter/.pub-cache \
 		ghcr.io/instrumentisto/flutter:$(FLUTTER_VER) \
 			make flutter.pub cmd='$(cmd)' dockerized=no

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ REGISTRIES := $(strip $(subst $(comma), ,\
 
 VERSION ?= $(strip $(shell grep -m1 'version: ' pubspec.yaml | cut -d ' ' -f2))
 FLUTTER_VER ?= $(strip \
-	$(shell grep -m1 'FLUTTER_VER: ' .github/workflows/ci.yml | cut -d'"' -f2))
+	$(shell grep -m1 'FLUTTER_VER: ' .github/workflows/ci.yml | cut -d':' -f2 \
+                                                              | tr -d '"'))
 
 
 


### PR DESCRIPTION
## Synopsis

Currently invoking any `Makefile` command with `dockerized=yes` uses `FLUTER_VER` env, which is unable to be computed due to the `tr` being used incorrectly:
```
tr: illegal option -- "
usage: tr [-Ccsu] string1 string2
       tr [-Ccu] -d string1
       tr [-Ccu] -s string1
       tr [-Ccu] -ds string1 string2
``` 




## Solution

This PR adds a space after the `-d`: `tr -d '"'`, so `tr` is able to work correctly.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
