### PR TITLE
Display `MyUser.unreadChatsCount` on macOS application icon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: $FLUTTER_VER
+          flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
 
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: $FLUTTER_VER
+          flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
 
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: $FLUTTER_VER
+          flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
 
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: $FLUTTER_VER
+          flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
 
@@ -232,7 +232,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: $FLUTTER_VER
+          flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
 
@@ -309,7 +309,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: $FLUTTER_VER
+          flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
 
@@ -350,7 +350,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: $FLUTTER_VER
+          flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Added
 
+- macOS:
+    - Unread chats count badge on app's icon ([#106]).
 - UI:
     - User information auto-updating on changes ([#7], [#4]).
     - Menu:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All user visible changes to this project will be documented in this file. This p
 [#83]: /../../pull/83
 [#85]: /../../pull/85
 [#90]: /../../pull/90
+[#106]: /../../pull/106
 
 
 

--- a/lib/ui/worker/my_user.dart
+++ b/lib/ui/worker/my_user.dart
@@ -14,6 +14,7 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'package:flutter_app_badger/flutter_app_badger.dart';
 import 'package:get/get.dart';
 
 import '/domain/model/my_user.dart';
@@ -32,14 +33,20 @@ class MyUserWorker extends DisposableService {
   /// [Worker] reacting on the [MyUser] changes.
   Worker? _worker;
 
+  /// [MyUser.unreadChatsCount] latest value, used to exclude the unnecessary
+  /// [_updateBadge] invokes.
+  int? _lastUnreadChatsCount;
+
   @override
   void onInit() {
+    _updateBadge(_myUser.myUser.value?.unreadChatsCount ?? 0);
     router.prefix.value = _myUser.myUser.value == null ||
             _myUser.myUser.value?.unreadChatsCount == 0
         ? null
         : '(${_myUser.myUser.value!.unreadChatsCount})';
 
     _worker = ever(_myUser.myUser, (MyUser? u) {
+      _updateBadge(u?.unreadChatsCount ?? 0);
       router.prefix.value = u == null || u.unreadChatsCount == 0
           ? null
           : '(${u.unreadChatsCount})';
@@ -53,5 +60,24 @@ class MyUserWorker extends DisposableService {
     _worker?.dispose();
     router.prefix.value = null;
     super.onClose();
+  }
+
+  /// Updates the application's badge with the provided [count].
+  void _updateBadge(int count) async {
+    if (_lastUnreadChatsCount != count) {
+      _lastUnreadChatsCount = count;
+
+      try {
+        if (await FlutterAppBadger.isAppBadgeSupported()) {
+          if (count == 0) {
+            FlutterAppBadger.removeBadge();
+          } else {
+            FlutterAppBadger.updateBadgeCount(count);
+          }
+        }
+      } catch (_) {
+        // No-op.
+      }
+    }
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import audioplayers_darwin
 import connectivity_plus_macos
 import desktop_drop
+import flutter_app_badger
 import flutter_local_notifications
 import medea_flutter_webrtc
 import medea_jason
@@ -23,6 +24,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   ConnectivityPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
+  FlutterAppBadgerPlugin.register(with: registry.registrar(forPlugin: "FlutterAppBadgerPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   MedeaFlutterWebrtcPlugin.register(with: registry.registrar(forPlugin: "MedeaFlutterWebrtcPlugin"))
   MedeaJasonPlugin.register(with: registry.registrar(forPlugin: "MedeaJasonPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -458,6 +458,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_app_badger:
+    dependency: "direct main"
+    description:
+      name: flutter_app_badger
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
   flutter_background_service:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
     git: https://github.com/sagudev/fluent-dart.git
   flutter:
     sdk: flutter
+  flutter_app_badger: ^1.4.0
   flutter_background_service: ^2.0.0
   flutter_background_service_android: ^2.0.0
   flutter_background_service_ios: ^2.0.0


### PR DESCRIPTION
## Synopsis

`MyUser.unreadChatsCount` are being displayed on the `Chats` tab icon and in the browser's title. However, macOS application supports displaying this count on its icon as well.




## Solution

This PR adds `MyUser.unreadChatsCount` displaying over the macOS application icon.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
