### PR TITLE
Prevent device from sleeping while in Call (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ All user visible changes to this project will be documented in this file. This p
     - Media panel:
         - Mobile minimization gesture being too rapid ([#45], [#44]);
         - Camera not enabling in empty call ([#79], [#75]).
+    - Call:
+        - Prevent device from sleeping while in call ([#92], [#112]). 
 
 [#2]: /../../issues/2
 [#3]: /../../issues/3
@@ -89,6 +91,7 @@ All user visible changes to this project will be documented in this file. This p
 [#83]: /../../pull/83
 [#85]: /../../pull/85
 [#90]: /../../pull/90
+[#92]: /../../pull/112
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,8 @@ All user visible changes to this project will be documented in this file. This p
         - Horizontal scroll overlapping with vertical ([#42], [#41]).
     - Media panel:
         - Mobile minimization gesture being too rapid ([#45], [#44]);
-        - Camera not enabling in empty call ([#79], [#75]).
-    - Call:
-        - Prevent device from sleeping while in call ([#92], [#112]). 
+        - Camera not enabling in empty call ([#79], [#75]);
+        - Prevent device from sleeping ([#112], [#92]). 
 
 [#2]: /../../issues/2
 [#3]: /../../issues/3
@@ -93,8 +92,9 @@ All user visible changes to this project will be documented in this file. This p
 [#83]: /../../pull/83
 [#85]: /../../pull/85
 [#90]: /../../pull/90
-[#92]: /../../pull/112
+[#92]: /../../issues/92
 [#106]: /../../pull/106
+[#112]: /../../pull/112
 
 
 

--- a/lib/domain/service/call.dart
+++ b/lib/domain/service/call.dart
@@ -18,6 +18,7 @@ import 'dart:async';
 
 import 'package:get/get.dart';
 import 'package:uuid/uuid.dart';
+import 'package:wakelock/wakelock.dart';
 
 import '/api/backend/schema.dart';
 import '/domain/model/chat_call.dart';
@@ -98,6 +99,7 @@ class CallService extends DisposableService {
     }
 
     try {
+      _enableWakeLockWhenNoActiveCalls();
       Rx<OngoingCall> call = Rx<OngoingCall>(
         OngoingCall(
           chatId,
@@ -250,6 +252,7 @@ class CallService extends DisposableService {
       removed?.value.state.value = OngoingCallState.ended;
       removed?.value.dispose();
     }
+    _disableWakeLockWhenNoActiveCalls();
   }
 
   /// Raises/lowers a hand of the authenticated [MyUser] in the [OngoingCall]
@@ -385,5 +388,31 @@ class CallService extends DisposableService {
         }
       },
     );
+  }
+
+  /// The following code will enable the wakelock on the device using the wakelock plugin, when no active users.
+  Future<void> _enableWakeLockWhenNoActiveCalls() {
+    if (_callsRepo.calls.isEmpty) {
+      return _enableWakeLock();
+    }
+    return Future.value();
+  }
+
+  /// The following code will disable the wakelock on the device using the wakelock plugin, when no active users.
+  Future<void> _disableWakeLockWhenNoActiveCalls() {
+    if (_callsRepo.calls.isEmpty) {
+      return _disableWakeLock();
+    }
+    return Future.value();
+  }
+
+  /// The following code will enable the wakelock on the device using the wakelock plugin.
+  Future<void> _enableWakeLock() {
+    return Wakelock.enable();
+  }
+
+  /// The following code will disable the wakelock on the device using the wakelock plugin.
+  Future<void> _disableWakeLock() {
+    return Wakelock.disable();
   }
 }

--- a/lib/domain/service/call.dart
+++ b/lib/domain/service/call.dart
@@ -18,7 +18,6 @@ import 'dart:async';
 
 import 'package:get/get.dart';
 import 'package:uuid/uuid.dart';
-import 'package:wakelock/wakelock.dart';
 
 import '/api/backend/schema.dart';
 import '/domain/model/chat_call.dart';
@@ -99,7 +98,6 @@ class CallService extends DisposableService {
     }
 
     try {
-      _enableWakeLockWhenNoActiveCalls();
       Rx<OngoingCall> call = Rx<OngoingCall>(
         OngoingCall(
           chatId,
@@ -252,7 +250,6 @@ class CallService extends DisposableService {
       removed?.value.state.value = OngoingCallState.ended;
       removed?.value.dispose();
     }
-    _disableWakeLockWhenNoActiveCalls();
   }
 
   /// Raises/lowers a hand of the authenticated [MyUser] in the [OngoingCall]
@@ -388,31 +385,5 @@ class CallService extends DisposableService {
         }
       },
     );
-  }
-
-  /// The following code will enable the wakelock on the device using the wakelock plugin, when no active users.
-  Future<void> _enableWakeLockWhenNoActiveCalls() {
-    if (_callsRepo.calls.isEmpty) {
-      return _enableWakeLock();
-    }
-    return Future.value();
-  }
-
-  /// The following code will disable the wakelock on the device using the wakelock plugin, when no active users.
-  Future<void> _disableWakeLockWhenNoActiveCalls() {
-    if (_callsRepo.calls.isEmpty) {
-      return _disableWakeLock();
-    }
-    return Future.value();
-  }
-
-  /// The following code will enable the wakelock on the device using the wakelock plugin.
-  Future<void> _enableWakeLock() {
-    return Wakelock.enable();
-  }
-
-  /// The following code will disable the wakelock on the device using the wakelock plugin.
-  Future<void> _disableWakeLock() {
-    return Wakelock.disable();
   }
 }

--- a/lib/ui/page/popup_call/controller.dart
+++ b/lib/ui/page/popup_call/controller.dart
@@ -18,6 +18,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:get/get.dart';
+import 'package:wakelock/wakelock.dart';
 
 import '/domain/model/chat.dart';
 import '/domain/model/ongoing_call.dart';
@@ -96,11 +97,13 @@ class PopupCallController extends GetxController {
     });
 
     _tryToConnect();
+    Wakelock.enable();
     super.onInit();
   }
 
   @override
   void onClose() {
+    Wakelock.disable();
     WebUtils.removeCall(call.value.chatId.value);
     _storageSubscription?.cancel();
     _stateWorker.dispose();

--- a/lib/ui/page/popup_call/controller.dart
+++ b/lib/ui/page/popup_call/controller.dart
@@ -97,13 +97,13 @@ class PopupCallController extends GetxController {
     });
 
     _tryToConnect();
-    Wakelock.enable();
+    Wakelock.enable().onError((_, __) => false);
     super.onInit();
   }
 
   @override
   void onClose() {
-    Wakelock.disable();
+    Wakelock.disable().onError((_, __) => false);
     WebUtils.removeCall(call.value.chatId.value);
     _storageSubscription?.cancel();
     _stateWorker.dispose();

--- a/lib/ui/worker/call.dart
+++ b/lib/ui/worker/call.dart
@@ -94,7 +94,7 @@ class CallWorker extends DisposableService {
   bool _isEnabledWakelock = false;
 
   @override
-  void onInit() async {
+  void onInit() {
     _initAudio();
     _initBackgroundService();
     _initWebUtils();

--- a/lib/ui/worker/call.dart
+++ b/lib/ui/worker/call.dart
@@ -99,16 +99,16 @@ class CallWorker extends DisposableService {
 
     bool wakelock = _callService.calls.isNotEmpty;
     if (wakelock) {
-      Wakelock.enable();
+      Wakelock.enable().onError((_, __) => false);
     }
 
     _subscription = _callService.calls.changes.listen((event) async {
       if (!wakelock && _callService.calls.isNotEmpty) {
         wakelock = true;
-        Wakelock.enable();
+        Wakelock.enable().onError((_, __) => false);
       } else if (wakelock && _callService.calls.isEmpty) {
         wakelock = false;
-        Wakelock.disable();
+        Wakelock.disable().onError((_, __) => false);
       }
 
       switch (event.op) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1570,12 +1570,12 @@ packages:
     source: hosted
     version: "8.2.2"
   wakelock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: wakelock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+2"
+    version: "0.6.2"
   wakelock_macos:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ dependencies:
   vibration: ^1.7.4-nullsafety.0
   video_player: ^2.4.2
   visibility_detector: ^0.3.3
+  wakelock: ^0.6.2
   web_socket_channel: ^2.2.0
   window_manager: ^0.2.3
 


### PR DESCRIPTION
Resolves #92




## Synopsis

В звонке участники видят видео и слышат аудио друг друга. Во время звонка устройство переходит в сон, т.к. не знает, что мы отображаем видео/аудио, при которых этого делать ему позволять не стоит.




## Solution

Использовать [wakelock](https://pub.dev/packages/wakelock), чтобы при хотя бы одном активном звонке сказать устройству не входить в сон.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
