### PR TITLE
Add local `User`s searching in `UserService.search` (#65)

### DIFF
--- a/lib/domain/repository/user.dart
+++ b/lib/domain/repository/user.dart
@@ -29,6 +29,9 @@ abstract class AbstractUserRepository {
   /// used.
   RxBool get isReady;
 
+  /// Found users from local storage [users] and backend.
+  RxSet<RxUser> get foundUsers;
+
   /// Initializes this repository.
   Future<void> init();
 
@@ -38,25 +41,25 @@ abstract class AbstractUserRepository {
   /// Clears the stored [users].
   Future<void> clearCache();
 
-  /// Searches [User]s by the provided [UserNum].
+  /// Searches [User]s by the provided [UserNum] and passes the result through [foundUsers].
   ///
   /// This is an exact match search.
-  Future<List<RxUser>> searchByNum(UserNum num);
+  void searchByNum(UserNum num);
 
-  /// Searches [User]s by the provided [UserLogin].
+  /// Searches [User]s by the provided [UserLogin] and passes the result through [foundUsers].
   ///
   /// This is an exact match search.
-  Future<List<RxUser>> searchByLogin(UserLogin login);
+  void searchByLogin(UserLogin login);
 
-  /// Searches [User]s by the provided [UserName].
+  /// Searches [User]s by the provided [UserName] and passes the result through [foundUsers].
   ///
   /// This is a fuzzy search.
-  Future<List<RxUser>> searchByName(UserName name);
+  void searchByName(UserName name);
 
-  /// Searches [User]s by the provided [ChatDirectLinkSlug].
+  /// Searches [User]s by the provided [ChatDirectLinkSlug] and passes the result through [foundUsers].
   ///
   /// This is an exact match search.
-  Future<List<RxUser>> searchByLink(ChatDirectLinkSlug link);
+  void searchByLink(ChatDirectLinkSlug link);
 
   /// Returns an [User] by the provided [id].
   Future<RxUser?> get(UserId id);

--- a/lib/domain/repository/user.dart
+++ b/lib/domain/repository/user.dart
@@ -29,9 +29,6 @@ abstract class AbstractUserRepository {
   /// used.
   RxBool get isReady;
 
-  /// Found users from local storage [users] and backend.
-  RxSet<RxUser> get foundUsers;
-
   /// Initializes this repository.
   Future<void> init();
 
@@ -41,25 +38,25 @@ abstract class AbstractUserRepository {
   /// Clears the stored [users].
   Future<void> clearCache();
 
-  /// Searches [User]s by the provided [UserNum] and passes the result through [foundUsers].
+  /// Searches [User]s by the provided [UserNum].
   ///
   /// This is an exact match search.
-  void searchByNum(UserNum num);
+  Future<List<RxUser>> searchByNum(UserNum num);
 
-  /// Searches [User]s by the provided [UserLogin] and passes the result through [foundUsers].
+  /// Searches [User]s by the provided [UserLogin].
   ///
   /// This is an exact match search.
-  void searchByLogin(UserLogin login);
+  Future<List<RxUser>> searchByLogin(UserLogin login);
 
-  /// Searches [User]s by the provided [UserName] and passes the result through [foundUsers].
+  /// Searches [User]s by the provided [UserName].
   ///
   /// This is a fuzzy search.
-  void searchByName(UserName name);
+  Future<List<RxUser>> searchByName(UserName name);
 
-  /// Searches [User]s by the provided [ChatDirectLinkSlug] and passes the result through [foundUsers].
+  /// Searches [User]s by the provided [ChatDirectLinkSlug].
   ///
   /// This is an exact match search.
-  void searchByLink(ChatDirectLinkSlug link);
+  Future<List<RxUser>> searchByLink(ChatDirectLinkSlug link);
 
   /// Returns an [User] by the provided [id].
   Future<RxUser?> get(UserId id);

--- a/lib/domain/service/user.dart
+++ b/lib/domain/service/user.dart
@@ -101,6 +101,13 @@ class SearchResult {
   /// Found [RxUser]s themselves.
   final RxList<RxUser> users = RxList<RxUser>();
 
-  /// Reactive [RxStatus] of this [SearchResult].
+  /// Reactive [RxStatus] of [users] being fetched.
+  ///
+  /// May be:
+  /// - `status.isEmpty`, meaning the query is not yet started.
+  /// - `status.isLoading`, meaning the [users] are being fetched.
+  /// - `status.isLoadingMore`, meaning some [users] were fetched from local
+  ///   storage.
+  /// - `status.isSuccess`, meaning the [users] were successfully fetched.
   final Rx<RxStatus> status = Rx(RxStatus.empty());
 }

--- a/lib/domain/service/user.dart
+++ b/lib/domain/service/user.dart
@@ -37,6 +37,9 @@ class UserService extends DisposableService {
   /// Returns the current reactive map of [User]s.
   RxMap<UserId, RxUser> get users => _userRepository.users;
 
+  /// Users found by search.
+  RxSet<RxUser> get foundUsers => _userRepository.foundUsers;
+
   @override
   void onInit() {
     _userRepository.init();
@@ -50,32 +53,22 @@ class UserService extends DisposableService {
   }
 
   /// Searches [User]s by the given criteria.
-  Future<List<RxUser>> search({
+  RxSet<RxUser> search({
     UserNum? num,
     UserName? name,
     UserLogin? login,
     ChatDirectLinkSlug? link,
-  }) async {
+  }) {
     if (num == null && name == null && login == null && link == null) {
-      return [];
+      return RxSet<RxUser>();
     }
 
-    HashMap<UserId, RxUser> result = HashMap();
+    if (num != null) _userRepository.searchByNum(num);
+    if (name != null) _userRepository.searchByName(name);
+    if (login != null) _userRepository.searchByLogin(login);
+    if (link != null) _userRepository.searchByLink(link);
 
-    List<Future<List<RxUser>>> futures = [
-      if (num != null) _userRepository.searchByNum(num),
-      if (name != null) _userRepository.searchByName(name),
-      if (login != null) _userRepository.searchByLogin(login),
-      if (link != null) _userRepository.searchByLink(link),
-    ];
-
-    // TODO: Don't wait for all request to finish, but display results as they
-    //       are ready.
-    (await Future.wait(futures)).expand((e) => e).forEach((user) {
-      result[user.id] = user;
-    });
-
-    return result.values.toList();
+    return _userRepository.foundUsers;
   }
 
   /// Returns an [User] by the provided [id].

--- a/lib/domain/service/user.dart
+++ b/lib/domain/service/user.dart
@@ -63,7 +63,7 @@ class UserService extends DisposableService {
     final List<RxUser> users = _userRepository.users.values
         .where((u) =>
             (num != null && u.user.value.num == num) ||
-            (name != null && u.user.value.name == name))
+            (name != null && u.user.value.name?.val.contains(name.val) == true))
         .toList();
 
     searchResult.users.value = users;

--- a/lib/domain/service/user.dart
+++ b/lib/domain/service/user.dart
@@ -96,7 +96,7 @@ class UserService extends DisposableService {
   Future<void> clearCached() async => await _userRepository.clearCache();
 }
 
-/// Result of an [UserService.search] query.
+/// Result of a [UserService.search] query.
 class SearchResult {
   /// Found [RxUser]s themselves.
   final RxList<RxUser> users = RxList<RxUser>();

--- a/lib/store/user.dart
+++ b/lib/store/user.dart
@@ -209,24 +209,24 @@ class UserRepository implements AbstractUserRepository {
     ChatDirectLinkSlug? link,
   }) async {
     const maxInt = 120;
-      List<HiveUser> result = (await _graphQlProvider.searchUsers(
-        first: maxInt,
-        num: num,
-        name: name,
-        login: login,
-        link: link,
-      ))
-          .searchUsers
-          .nodes
-          .map((c) => c.toHive())
-          .toList();
+    List<HiveUser> result = (await _graphQlProvider.searchUsers(
+      first: maxInt,
+      num: num,
+      name: name,
+      login: login,
+      link: link,
+    ))
+        .searchUsers
+        .nodes
+        .map((c) => c.toHive())
+        .toList();
 
-      for (HiveUser user in result) {
-        put(user);
-      }
-      await Future.delayed(Duration.zero);
+    for (HiveUser user in result) {
+      put(user);
+    }
+    await Future.delayed(Duration.zero);
 
-      Iterable<Future<RxUser?>> futures = result.map((e) => get(e.value.id));
+    Iterable<Future<RxUser?>> futures = result.map((e) => get(e.value.id));
     List<RxUser> users = (await Future.wait(futures)).whereNotNull().toList();
 
     return users;

--- a/lib/ui/page/home/widget/user_search_bar/controller.dart
+++ b/lib/ui/page/home/widget/user_search_bar/controller.dart
@@ -14,7 +14,6 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
-import 'package:async/async.dart';
 import 'package:get/get.dart';
 
 import '/domain/model/user.dart';

--- a/lib/ui/page/home/widget/user_search_bar/controller.dart
+++ b/lib/ui/page/home/widget/user_search_bar/controller.dart
@@ -46,7 +46,7 @@ class UserSearchBarController extends GetxController {
   /// [User]s service, used to search [User]s.
   final UserService _userService;
 
-  /// Worker to react on [SearchResult.status] changes.
+  /// Worker to react on a [SearchResult.status] changes.
   Worker? _searchWorker;
 
   @override
@@ -59,7 +59,7 @@ class UserSearchBarController extends GetxController {
   // TODO: Implement search by a [ChatDirectLinkSlug].
   /// Performs searching for [User]s based on the provided [query].
   ///
-  /// Query may be an [UserNum], [UserName] or [UserLogin].
+  /// Query may be a [UserNum], [UserName] or [UserLogin].
   void search(String query) {
     _searchWorker?.dispose();
     _searchWorker = null;

--- a/lib/ui/page/home/widget/user_search_bar/controller.dart
+++ b/lib/ui/page/home/widget/user_search_bar/controller.dart
@@ -24,10 +24,11 @@ export 'view.dart';
 
 /// Controller of an [UserSearchBar] widget.
 class UserSearchBarController extends GetxController {
-  UserSearchBarController(this._userService);
+  UserSearchBarController(this._userService)
+      : searchResults = _userService.foundUsers;
 
   /// [User]s search results.
-  final RxList<RxUser> searchResults = RxList<RxUser>([]);
+  final RxSet<RxUser> searchResults;
 
   /// Recently searched [User]s.
   final RxList<RxUser> recentSearchResults = RxList<RxUser>([]);
@@ -78,8 +79,7 @@ class UserSearchBarController extends GetxController {
         searchStatus.value = searchStatus.value.isSuccess
             ? RxStatus.loadingMore()
             : RxStatus.loading();
-        searchResults.value =
-            await _userService.search(num: num, name: name, login: login);
+        _userService.search(num: num, name: name, login: login);
         searchStatus.value = RxStatus.success();
       }
     } else {

--- a/lib/ui/page/home/widget/user_search_bar/controller.dart
+++ b/lib/ui/page/home/widget/user_search_bar/controller.dart
@@ -102,8 +102,6 @@ class UserSearchBarController extends GetxController {
     } else {
       searchStatus.value = RxStatus.empty();
       searchResults.value = null;
-      _searchWorker?.dispose();
-      _searchWorker = null;
     }
   }
 

--- a/lib/ui/page/home/widget/user_search_bar/controller.dart
+++ b/lib/ui/page/home/widget/user_search_bar/controller.dart
@@ -27,7 +27,7 @@ class UserSearchBarController extends GetxController {
   UserSearchBarController(this._userService);
 
   /// [User]s search results.
-  RxList<RxUser> searchResults = RxList<RxUser>([]);
+  final Rx<RxList<RxUser>?> searchResults = Rx(null);
 
   /// Recently searched [User]s.
   final RxList<RxUser> recentSearchResults = RxList<RxUser>([]);
@@ -41,16 +41,28 @@ class UserSearchBarController extends GetxController {
   ///   [searchResults] were already acquired.
   /// - `searchStatus.success`, meaning search is done and [searchResults] are
   ///   acquired.
-  Rx<RxStatus> searchStatus = Rx<RxStatus>(RxStatus.empty());
+  final Rx<RxStatus> searchStatus = Rx<RxStatus>(RxStatus.empty());
 
   /// [User]s service, used to search [User]s.
   final UserService _userService;
+
+  Worker? _searchWorker;
+
+  @override
+  void onClose() {
+    _searchWorker?.dispose();
+    _searchWorker = null;
+    super.onClose();
+  }
 
   // TODO: Implement search by a [ChatDirectLinkSlug].
   /// Performs searching for [User]s based on the provided [query].
   ///
   /// Query may be a [UserNum], [UserName] or [UserLogin].
   void search(String query) {
+    _searchWorker?.dispose();
+    _searchWorker = null;
+
     if (query.isNotEmpty) {
       UserNum? num;
       UserName? name;
@@ -78,15 +90,18 @@ class UserSearchBarController extends GetxController {
         searchStatus.value = searchStatus.value.isSuccess
             ? RxStatus.loadingMore()
             : RxStatus.loading();
-        final searchResult =
+        final SearchResult result =
             _userService.search(num: num, name: name, login: login);
 
-        searchResults = searchResult.users;
-        searchStatus = searchResult.status;
+        searchResults.value = result.users;
+        _searchWorker =
+            ever(result.status, (RxStatus s) => searchStatus.value = s);
       }
     } else {
       searchStatus.value = RxStatus.empty();
-      searchResults.clear();
+      searchResults.value = null;
+      _searchWorker?.dispose();
+      _searchWorker = null;
     }
   }
 

--- a/lib/ui/page/home/widget/user_search_bar/controller.dart
+++ b/lib/ui/page/home/widget/user_search_bar/controller.dart
@@ -46,7 +46,7 @@ class UserSearchBarController extends GetxController {
   /// [User]s service, used to search [User]s.
   final UserService _userService;
 
-  /// Worker to react on [SearchResult] changes.
+  /// Worker to react on [SearchResult.status] changes.
   Worker? _searchWorker;
 
   @override

--- a/lib/ui/page/home/widget/user_search_bar/controller.dart
+++ b/lib/ui/page/home/widget/user_search_bar/controller.dart
@@ -59,7 +59,7 @@ class UserSearchBarController extends GetxController {
   // TODO: Implement search by a [ChatDirectLinkSlug].
   /// Performs searching for [User]s based on the provided [query].
   ///
-  /// Query may be a [UserNum], [UserName] or [UserLogin].
+  /// Query may be an [UserNum], [UserName] or [UserLogin].
   void search(String query) {
     _searchWorker?.dispose();
     _searchWorker = null;

--- a/lib/ui/page/home/widget/user_search_bar/controller.dart
+++ b/lib/ui/page/home/widget/user_search_bar/controller.dart
@@ -46,6 +46,7 @@ class UserSearchBarController extends GetxController {
   /// [User]s service, used to search [User]s.
   final UserService _userService;
 
+  /// Worker to react on [SearchResult] changes.
   Worker? _searchWorker;
 
   @override
@@ -94,6 +95,7 @@ class UserSearchBarController extends GetxController {
             _userService.search(num: num, name: name, login: login);
 
         searchResults.value = result.users;
+        searchStatus.value = result.status.value;
         _searchWorker =
             ever(result.status, (RxStatus s) => searchStatus.value = s);
       }

--- a/lib/ui/page/home/widget/user_search_bar/view.dart
+++ b/lib/ui/page/home/widget/user_search_bar/view.dart
@@ -87,7 +87,8 @@ class UserSearchBar extends StatelessWidget {
                 child: Obx(
                   () => Column(
                     mainAxisSize: MainAxisSize.min,
-                    children: c.searchStatus.value.isSuccess
+                    children: c.searchStatus.value.isSuccess ||
+                            c.searchStatus.value.isLoadingMore
                         ? [
                             const SizedBox(height: 10),
                             ...c.searchResults.isEmpty

--- a/lib/ui/page/home/widget/user_search_bar/view.dart
+++ b/lib/ui/page/home/widget/user_search_bar/view.dart
@@ -87,17 +87,17 @@ class UserSearchBar extends StatelessWidget {
                 child: Obx(
                   () => Column(
                     mainAxisSize: MainAxisSize.min,
-                    children: c.searchStatus.value.isSuccess ||
-                            c.searchStatus.value.isLoadingMore
+                    children: c.searchStatus.value.isSuccess
                         ? [
                             const SizedBox(height: 10),
-                            ...c.searchResults.isEmpty
+                            ...c.searchResults.value?.isEmpty != false
                                 ? [
                                     ListTile(
-                                        title:
-                                            Text('label_search_not_found'.l10n))
+                                      title:
+                                          Text('label_search_not_found'.l10n),
+                                    )
                                   ]
-                                : c.searchResults
+                                : (c.searchResults.value ?? [])
                                     .map((e) => _user(e, c))
                                     .toList(),
                             const SizedBox(height: 10),


### PR DESCRIPTION
Resolves #65




## Synopsis

UsetRepository.searchUsers ищет пользователей, которые соответствуют переданным критериям.




## Solution

Поиск игнорирует имеющиеся в локальной базе данных пользователей и сразу отправляет GraphQL запрос. Поиск должен осуществляться в первую очередь среди имеющихся результатов и включать их в список вместе с подтянутыми чуть позже результатами с бэкэнда.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
