### PR TITLE
Fix screen share prompt absence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ All user visible changes to this project will be documented in this file. This p
         - Horizontal scroll overlapping with vertical ([#42], [#41]).
     - Media panel:
         - Mobile minimization gesture being too rapid ([#45], [#44]);
-        - Camera not enabling in empty call ([#79], [#75], [#116]);
+        - Camera not enabling in empty call ([#79], [#75], [#117]);
         - Prevent device from sleeping ([#112], [#92]). 
 
 [#2]: /../../issues/2
@@ -95,7 +95,7 @@ All user visible changes to this project will be documented in this file. This p
 [#92]: /../../issues/92
 [#106]: /../../pull/106
 [#112]: /../../pull/112
-[#116]: /../../pull/116
+[#117]: /../../pull/117
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ All user visible changes to this project will be documented in this file. This p
         - Horizontal scroll overlapping with vertical ([#42], [#41]).
     - Media panel:
         - Mobile minimization gesture being too rapid ([#45], [#44]);
-        - Camera not enabling in empty call ([#79], [#75], [#117]);
+        - Media not enabling in empty call ([#79], [#117], [#75]);
         - Prevent device from sleeping ([#112], [#92]). 
 
 [#2]: /../../issues/2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ All user visible changes to this project will be documented in this file. This p
         - Horizontal scroll overlapping with vertical ([#42], [#41]).
     - Media panel:
         - Mobile minimization gesture being too rapid ([#45], [#44]);
-        - Camera not enabling in empty call ([#79], [#75]);
+        - Camera not enabling in empty call ([#79], [#75], [#116]);
         - Prevent device from sleeping ([#112], [#92]). 
 
 [#2]: /../../issues/2
@@ -95,6 +95,7 @@ All user visible changes to this project will be documented in this file. This p
 [#92]: /../../issues/92
 [#106]: /../../pull/106
 [#112]: /../../pull/112
+[#116]: /../../pull/116
 
 
 

--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -488,7 +488,7 @@ class OngoingCall {
           try {
             await _room?.enableVideo(MediaSourceKind.Display);
             screenShareState.value = LocalTrackState.enabled;
-            if (!isActive) {
+            if (!isActive || members.isEmpty) {
               _updateTracks();
             }
           } on MediaStateTransitionException catch (_) {
@@ -1057,7 +1057,7 @@ class OngoingCall {
           this.audioDevice.value = audioDevice ?? this.audioDevice.value;
           this.videoDevice.value = videoDevice ?? this.videoDevice.value;
 
-          if (!isActive) {
+          if (!isActive || members.isEmpty) {
             await _updateTracks();
           }
         } catch (_) {


### PR DESCRIPTION
Related to #79  




## Synopsis

#79 fixed the camera not enabling, but not the screen share prompt.




## Solution

This PR fixes missing screen share prompt when no members are in the call.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
