### PR TITLE
Add timeout to More panel in Call (#119)

### DIFF
--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -525,6 +525,31 @@ Widget desktopCall(CallController c, BuildContext context) {
           ),
         ),
 
+        // Show additional panel while pointer is within [SizedBox].
+        Obx(() {
+          bool enabled = c.displayMore.value &&
+              c.primaryDrags.value == 0 &&
+              c.secondaryDrags.value == 0;
+
+          if (enabled) {
+            return Align(
+              alignment: Alignment.bottomCenter,
+              child: SizedBox(
+                height: 450,
+                width: double.infinity,
+                child: MouseRegion(
+                  opaque: false,
+                  hitTestBehavior: HitTestBehavior.translucent,
+                  onEnter: (d) => c.keepMore(true),
+                  onExit: (d) => c.keepMore(false),
+                ),
+              ),
+            );
+          }
+
+          return Container();
+        }),
+
         // Display the more hint, if not dismissed.
         Obx(() {
           return AnimatedSwitcher(

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -328,6 +328,9 @@ class CallController extends GetxController {
   /// Timer to toggle [showUi] value.
   Timer? _uiTimer;
 
+  /// Timer to close more panel.
+  Timer? _morePanelTimer;
+
   /// Subscription for [PlatformUtils.onFullscreenChange], used to correct the
   /// [fullscreen] value.
   StreamSubscription? _onFullscreenChange;
@@ -580,7 +583,7 @@ class CallController extends GetxController {
         DateTime begunAt = DateTime.now();
         _durationTimer = Timer.periodic(
           const Duration(seconds: 1),
-          (timer) {
+          (_) {
             duration.value = DateTime.now().difference(begunAt);
             if (hoveredRendererTimeout > 0) {
               --hoveredRendererTimeout;
@@ -614,6 +617,10 @@ class CallController extends GetxController {
     _onWindowFocus = WebUtils.onWindowFocus.listen((e) {
       if (!e) {
         hoveredRenderer.value = null;
+        if (_morePanelTimer?.isActive != true) {
+          keepMore();
+        }
+
         if (_uiTimer?.isActive != true) {
           keepUi(false);
         }
@@ -754,6 +761,7 @@ class CallController extends GetxController {
     _durationTimer?.cancel();
     _showUiWorker.dispose();
     _uiTimer?.cancel();
+    _morePanelTimer?.cancel();
     _stateWorker.dispose();
     _chatWorker.dispose();
     _onFullscreenChange?.cancel();
@@ -925,6 +933,14 @@ class CallController extends GetxController {
         const Duration(seconds: _uiDuration),
         () => showUi.value = false,
       );
+    }
+  }
+
+  /// Keeps the UI open if [keep] is true, and closes the UI after 5 seconds if [keep] is false.
+  void keepMore([bool keep = false]) {
+    _morePanelTimer?.cancel();
+    if (!keep && displayMore.value) {
+      _morePanelTimer = Timer(const Duration(seconds: 5), () => keepUi(false));
     }
   }
 


### PR DESCRIPTION
Resolves #119




## Synopsis

При нажатии на кнопку "Ещё" открывается панелька со всеми кнопками в звонке. Чтобы её закрыть, нужно нажать либо по звонку, либо по кнопке "Ещё" - это неудобно.




## Solution

Добавить таймаут на закрытие этой панели, если курсор не наведён на неё.




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
