### PR TITLE
Refactor code to use `AuthService.userId` instead of `MyUserService`

### DIFF
--- a/lib/domain/service/chat.dart
+++ b/lib/domain/service/chat.dart
@@ -25,18 +25,18 @@ import '/api/backend/schema.dart';
 import '/provider/gql/exceptions.dart';
 import '/routes.dart';
 import '/util/obs/obs.dart';
+import 'auth.dart';
 import 'disposable_service.dart';
-import 'my_user.dart';
 
 /// Service responsible for [Chat]s related functionality.
 class ChatService extends DisposableService {
-  ChatService(this._chatRepository, this._myUser);
+  ChatService(this._chatRepository, this._authService);
 
   /// Repository to fetch [Chat]s from.
   final AbstractChatRepository _chatRepository;
 
-  /// Service to get an authorized user.
-  final MyUserService _myUser;
+  /// [AuthService] to get an authorized user.
+  final AuthService _authService;
 
   /// Changes to `true` once the underlying data storage is initialized and
   /// [chats] value is fetched.
@@ -46,7 +46,7 @@ class ChatService extends DisposableService {
   RxObsMap<ChatId, RxChat> get chats => _chatRepository.chats;
 
   /// Returns [MyUser]'s [UserId].
-  UserId? get me => _myUser.myUser.value?.id;
+  UserId? get me => _authService.userId;
 
   @override
   void onInit() {

--- a/lib/provider/hive/contact.dart
+++ b/lib/provider/hive/contact.dart
@@ -16,9 +16,10 @@
 
 import 'package:hive_flutter/hive_flutter.dart';
 
+import '/domain/model_type_id.dart';
+import '/domain/model/chat_call.dart';
 import '/domain/model/contact.dart';
 import '/domain/model/user.dart';
-import '/domain/model_type_id.dart';
 import '/store/model/contact.dart';
 import 'base.dart';
 
@@ -34,6 +35,7 @@ class ContactHiveProvider extends HiveBaseProvider<HiveChatContact> {
 
   @override
   void registerAdapters() {
+    Hive.maybeRegisterAdapter(ChatCallRoomJoinLinkAdapter());
     Hive.maybeRegisterAdapter(ChatContactAdapter());
     Hive.maybeRegisterAdapter(ChatContactIdAdapter());
     Hive.maybeRegisterAdapter(ChatContactPositionAdapter());

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -430,13 +430,12 @@ class AppRouterDelegate extends RouterDelegate<RouteConfiguration>
                 ),
               );
 
-              MyUserService myUserService =
-                  deps.put(MyUserService(Get.find(), myUserRepository));
+              deps.put(MyUserService(Get.find(), myUserRepository));
               deps.put(UserService(userRepository));
               deps.put(ContactService(contactRepository));
               deps.put(
                   CallService(Get.find(), settingsRepository, callRepository));
-              deps.put(ChatService(chatRepository, myUserService));
+              deps.put(ChatService(chatRepository, Get.find()));
 
               return deps;
             },
@@ -525,7 +524,7 @@ class AppRouterDelegate extends RouterDelegate<RouteConfiguration>
               callRepository,
             ));
             ChatService chatService =
-                deps.put(ChatService(chatRepository, myUserService));
+                deps.put(ChatService(chatRepository, Get.find()));
 
             deps.put(CallWorker(
               Get.find(),

--- a/lib/ui/page/home/page/chat/info/controller.dart
+++ b/lib/ui/page/home/page/chat/info/controller.dart
@@ -24,8 +24,8 @@ import '/config.dart';
 import '/domain/model/chat.dart';
 import '/domain/model/user.dart';
 import '/domain/repository/chat.dart';
+import '/domain/service/auth.dart';
 import '/domain/service/chat.dart';
-import '/domain/service/my_user.dart';
 import '/l10n/l10n.dart';
 import '/provider/gql/exceptions.dart';
 import '/routes.dart';
@@ -39,7 +39,7 @@ class ChatInfoController extends GetxController {
   ChatInfoController(
     this.chatId,
     this._chatService,
-    this._myUserService,
+    this._authService,
   );
 
   /// ID of the [Chat] this page is about.
@@ -48,8 +48,8 @@ class ChatInfoController extends GetxController {
   /// [Chat]s service used to get the [chat] value.
   final ChatService _chatService;
 
-  /// [MyUser] service used to get [me] value.
-  final MyUserService _myUserService;
+  /// [AuthService] used to get [me] value.
+  final AuthService _authService;
 
   /// List of [UserId]s that are being removed from the [chat].
   final RxList<UserId> membersOnRemoval = RxList([]);
@@ -70,7 +70,7 @@ class ChatInfoController extends GetxController {
   Worker? _worker;
 
   /// Returns [MyUser]'s [UserId].
-  UserId? get me => _myUserService.myUser.value?.id;
+  UserId? get me => _authService.userId;
 
   /// Reactive state of the [Chat] this page is about.
   RxChat? chat;

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -29,10 +29,10 @@ import '/domain/repository/call.dart'
         CallIsInPopupException;
 import '/domain/repository/chat.dart';
 import '/domain/repository/user.dart';
+import '/domain/service/auth.dart';
 import '/domain/service/call.dart';
 import '/domain/service/chat.dart';
 import '/domain/service/contact.dart';
-import '/domain/service/my_user.dart';
 import '/domain/service/user.dart';
 import '/provider/gql/exceptions.dart'
     show RemoveChatMemberException, HideChatException;
@@ -47,7 +47,7 @@ class ChatsTabController extends GetxController {
   ChatsTabController(
     this._chatService,
     this._callService,
-    this._myUserService,
+    this._authService,
     this._userService,
   );
 
@@ -60,8 +60,8 @@ class ChatsTabController extends GetxController {
   /// Calls service used to join the ongoing call in the [Chat].
   final CallService _callService;
 
-  /// [MyUser] service used to get [me] value.
-  final MyUserService _myUserService;
+  /// [AuthService] used to get [me] value.
+  final AuthService _authService;
 
   /// [User]s service fetching the [User]s in [getUser] method.
   final UserService _userService;
@@ -74,7 +74,7 @@ class ChatsTabController extends GetxController {
       HashMap<ChatId, _ChatSortingData>();
 
   /// Returns [MyUser]'s [UserId].
-  UserId? get me => _myUserService.myUser.value?.id;
+  UserId? get me => _authService.userId;
 
   /// Indicates whether [ContactService] is ready to be used.
   RxBool get chatsReady => _chatService.isReady;

--- a/test/unit/chat_attachment_test.dart
+++ b/test/unit/chat_attachment_test.dart
@@ -19,7 +19,6 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/attachment.dart';
@@ -27,21 +26,17 @@ import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/native_file.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/user.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -63,28 +58,8 @@ void main() async {
   await chatHiveProvider.init();
   var sessionProvider = Get.put(SessionDataHiveProvider());
   await sessionProvider.init();
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var userProvider = UserHiveProvider();
   await userProvider.init();
-
-  var myUserData = {
-    'id': 'id',
-    'num': '1234567890123456',
-    'login': null,
-    'name': null,
-    'bio': null,
-    'emails': {'confirmed': []},
-    'phones': {'confirmed': []},
-    'gallery': {'nodes': []},
-    'chatDirectLink': null,
-    'hasPassword': false,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -114,18 +89,6 @@ void main() async {
     }
   };
 
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...myUserData},
-        },
-      ),
-    ])),
-  );
-
   when(graphQlProvider.recentChatsTopEvents(3))
       .thenAnswer((_) => Future.value(const Stream.empty()));
   when(graphQlProvider.keepOnline())
@@ -143,11 +106,6 @@ void main() async {
     ),
   );
   await authService.init();
-
-  AbstractMyUserRepository myUserRepository =
-      MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
-  MyUserService myUserService =
-      Get.put(MyUserService(authService, myUserRepository));
 
   test('ChatService successfully uploads an attachment', () async {
     when(graphQlProvider.recentChats(
@@ -188,8 +146,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, Get.find(), userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     await chatService.uploadAttachment(
       LocalAttachment(
@@ -229,8 +186,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, Get.find(), userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     var attachment = LocalAttachment(
       NativeFile(

--- a/test/unit/chat_delete_message_test.dart
+++ b/test/unit/chat_delete_message_test.dart
@@ -16,32 +16,27 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/chat_item.dart';
 import 'package:messenger/domain/model/precise_date_time/precise_date_time.dart';
 import 'package:messenger/domain/model/sending_status.dart';
+import 'package:messenger/domain/model/session.dart';
 import 'package:messenger/domain/model/user.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/model/my_user.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/user.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -61,28 +56,21 @@ void main() async {
   await galleryItemProvider.init();
   var sessionProvider = Get.put(SessionDataHiveProvider());
   await sessionProvider.init();
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
+  sessionProvider.setCredentials(
+    Credentials(
+      Session(
+        const AccessToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      RememberedSession(
+        const RememberToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      const UserId('me'),
+    ),
+  );
   var userProvider = UserHiveProvider();
   await userProvider.init();
-
-  var myUserData = {
-    'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
-    'num': '1234567890123456',
-    'login': null,
-    'name': null,
-    'bio': null,
-    'emails': {'confirmed': []},
-    'phones': {'confirmed': []},
-    'gallery': {'nodes': []},
-    'chatDirectLink': null,
-    'hasPassword': false,
-    'unreadChatsCount': 1,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -133,22 +121,6 @@ void main() async {
     const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
   )).thenAnswer((_) => Future.value(GetChat$Query.fromJson(chatData)));
 
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...myUserData},
-        },
-      ),
-    ])),
-  );
-
-  when(graphQlProvider.myUserEvents(
-    MyUserVersion('0'),
-  )).thenAnswer((_) => Future.value(const Stream.empty()));
-
   AuthService authService = Get.put(
     AuthService(
       Get.put<AbstractAuthRepository>(AuthRepository(graphQlProvider)),
@@ -156,10 +128,6 @@ void main() async {
     ),
   );
   await authService.init();
-  AbstractMyUserRepository myUserRepository =
-      MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
-  MyUserService myUserService =
-      Get.put(MyUserService(authService, myUserRepository));
 
   var chatHiveProvider = ChatHiveProvider();
   await chatHiveProvider.init();
@@ -168,7 +136,7 @@ void main() async {
       UserRepository(graphQlProvider, userProvider, galleryItemProvider));
   AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
       ChatRepository(graphQlProvider, chatHiveProvider, userRepository));
-  ChatService chatService = Get.put(ChatService(chatRepository, myUserService));
+  ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
   test('ChatService successfully deletes chat message', () async {
     when(graphQlProvider.deleteChatMessage(
@@ -181,7 +149,7 @@ void main() async {
       ChatMessage(
         const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),
         const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-        const UserId('0d72d245-8425-467a-9ebd-082d4f47850b'),
+        const UserId('me'),
         PreciseDateTime.now(),
         status: SendingStatus.sent,
       ),
@@ -204,7 +172,7 @@ void main() async {
       () async => await chatService.deleteChatItem(ChatMessage(
         const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),
         const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-        const UserId('0d72d245-8425-467a-9ebd-082d4f47850b'),
+        const UserId('me'),
         PreciseDateTime.now(),
         status: SendingStatus.sent,
       )),
@@ -226,7 +194,7 @@ void main() async {
     await chatService.hideChatItem(ChatMessage(
       const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-      const UserId('0d72d245-8425-467a-9ebd-082d4f47850b'),
+      const UserId('me'),
       PreciseDateTime.now(),
       status: SendingStatus.sent,
     ));
@@ -249,7 +217,7 @@ void main() async {
       () async => await chatService.hideChatItem(ChatMessage(
         const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),
         const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-        const UserId('0d72d245-8425-467a-9ebd-082d4f47850b'),
+        const UserId('me'),
         PreciseDateTime.now(),
         status: SendingStatus.sent,
       )),

--- a/test/unit/chat_direct_link_test.dart
+++ b/test/unit/chat_direct_link_test.dart
@@ -209,8 +209,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     await chatService.createChatDirectLink(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
@@ -239,8 +238,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     await chatService.deleteChatDirectLink(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
@@ -298,7 +296,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
-    Get.put(ChatService(chatRepository, myUserService));
+    Get.put(ChatService(chatRepository, authService));
 
     authService.useChatDirectLink(ChatDirectLinkSlug('link'));
 
@@ -324,8 +322,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     expect(
       () async => await chatService.createChatDirectLink(
@@ -362,8 +359,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     expect(
       () async => await chatService.deleteChatDirectLink(
@@ -391,7 +387,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
-    Get.put(ChatService(chatRepository, myUserService));
+    Get.put(ChatService(chatRepository, authService));
 
     expect(
       () => authService.useChatDirectLink(

--- a/test/unit/chat_edit_message_test.dart
+++ b/test/unit/chat_edit_message_test.dart
@@ -16,7 +16,6 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
@@ -25,22 +24,17 @@ import 'package:messenger/domain/model/precise_date_time/precise_date_time.dart'
 import 'package:messenger/domain/model/user.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/model/my_user.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/user.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -55,22 +49,6 @@ void main() async {
 
   final graphQlProvider = MockGraphQlProvider();
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
-
-  var userData = {
-    'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
-    'num': '1234567890123456',
-    'login': 'login',
-    'name': 'name',
-    'bio': 'bio',
-    'emails': {'confirmed': [], 'unconfirmed': null},
-    'phones': {'confirmed': [], 'unconfirmed': null},
-    'gallery': {'nodes': []},
-    'hasPassword': true,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -122,29 +100,11 @@ void main() async {
     const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
   )).thenAnswer((_) => Future.value(GetChat$Query.fromJson(chatData)));
 
-  when(graphQlProvider.myUserEvents(
-    MyUserVersion('0'),
-  )).thenAnswer((_) => Future.value(const Stream.empty()));
-
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...userData},
-        },
-      )
-    ])),
-  );
-
   test('ChatService successfully edits a ChatMessage', () async {
     var galleryItemProvider = GalleryItemHiveProvider();
     await galleryItemProvider.init();
     var sessionProvider = Get.put(SessionDataHiveProvider());
     await sessionProvider.init();
-    var myUserProvider = Get.put(MyUserHiveProvider());
-    await myUserProvider.init();
     var userProvider = Get.put(UserHiveProvider());
     await userProvider.init();
     var chatHiveProvider = Get.put(ChatHiveProvider());
@@ -160,15 +120,10 @@ void main() async {
 
     UserRepository userRepository =
         UserRepository(graphQlProvider, userProvider, galleryItemProvider);
-    AbstractMyUserRepository myUserRepository =
-        MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
-    MyUserService myUserService =
-        Get.put(MyUserService(authService, myUserRepository));
 
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatHiveProvider, userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     when(graphQlProvider.editChatMessageText(
       const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),
@@ -198,8 +153,6 @@ void main() async {
     await galleryItemProvider.init();
     var sessionProvider = Get.put(SessionDataHiveProvider());
     await sessionProvider.init();
-    var myUserProvider = Get.put(MyUserHiveProvider());
-    await myUserProvider.init();
     var userProvider = Get.put(UserHiveProvider());
     await userProvider.init();
     var chatHiveProvider = Get.put(ChatHiveProvider());
@@ -215,15 +168,10 @@ void main() async {
 
     UserRepository userRepository =
         UserRepository(graphQlProvider, userProvider, galleryItemProvider);
-    AbstractMyUserRepository myUserRepository =
-        MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
-    MyUserService myUserService =
-        Get.put(MyUserService(authService, myUserRepository));
 
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatHiveProvider, userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     when(graphQlProvider.editChatMessageText(
       const ChatItemId('0d72d245-8425-467a-9ebd-082d4f47850b'),

--- a/test/unit/chat_hide_test.dart
+++ b/test/unit/chat_hide_test.dart
@@ -16,28 +16,23 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/user.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -59,9 +54,6 @@ void main() async {
   await galleryItemProvider.init();
   var sessionProvider = Get.put(SessionDataHiveProvider());
   await sessionProvider.init();
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var userProvider = UserHiveProvider();
   await userProvider.init();
 
@@ -100,35 +92,6 @@ void main() async {
     }
   };
 
-  var myUserData = {
-    'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
-    'num': '1234567890123456',
-    'login': null,
-    'name': null,
-    'bio': null,
-    'emails': {'confirmed': []},
-    'phones': {'confirmed': []},
-    'gallery': {'nodes': []},
-    'chatDirectLink': null,
-    'hasPassword': false,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
-
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...myUserData},
-        },
-      ),
-    ])),
-  );
-
   when(graphQlProvider.keepOnline())
       .thenAnswer((_) => Future.value(const Stream.empty()));
 
@@ -141,11 +104,6 @@ void main() async {
   await authService.init();
 
   router = RouterState(authService);
-
-  AbstractMyUserRepository myUserRepository =
-      MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
-  MyUserService myUserService =
-      Get.put(MyUserService(authService, myUserRepository));
 
   when(graphQlProvider.recentChatsTopEvents(3))
       .thenAnswer((_) => Future.value(const Stream.empty()));
@@ -184,8 +142,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     await chatService.hideChat(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
@@ -214,8 +171,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     expect(
       () async => await chatService.hideChat(

--- a/test/unit/chat_members_test.dart
+++ b/test/unit/chat_members_test.dart
@@ -16,7 +16,6 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
@@ -25,19 +24,15 @@ import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/chat.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/model/my_user.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/user.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -55,9 +50,6 @@ void main() async {
 
   var sessionProvider = Get.put(SessionDataHiveProvider());
   await sessionProvider.init();
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var chatProvider = Get.put(ChatHiveProvider());
   await chatProvider.init();
   var galleryItemProvider = Get.put(GalleryItemHiveProvider());
@@ -66,23 +58,6 @@ void main() async {
   await chatHiveProvider.init();
   var userProvider = UserHiveProvider();
   await userProvider.init();
-
-  var myUserData = {
-    'id': 'id',
-    'num': '1234567890123456',
-    'login': null,
-    'name': null,
-    'bio': null,
-    'emails': {'confirmed': []},
-    'phones': {'confirmed': []},
-    'gallery': {'nodes': []},
-    'chatDirectLink': null,
-    'hasPassword': false,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
 
   var recentChats = {
     'recentChats': {'nodes': []}
@@ -190,17 +165,6 @@ void main() async {
     }
   };
 
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...myUserData},
-        },
-      ),
-    ])),
-  );
   when(graphQlProvider.keepOnline())
       .thenAnswer((_) => Future.value(const Stream.empty()));
 
@@ -214,22 +178,11 @@ void main() async {
     );
     await authService.init();
 
-    MyUserService myUserService = Get.put(
-      MyUserService(
-        authService,
-        MyUserRepository(
-          graphQlProvider,
-          myUserProvider,
-          galleryItemProvider,
-        ),
-      ),
-    );
-
     UserRepository userRepository = Get.put(
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
-    return Get.put(ChatService(chatRepository, myUserService));
+    return Get.put(ChatService(chatRepository, authService));
   }
 
   when(graphQlProvider.recentChats(
@@ -242,13 +195,6 @@ void main() async {
   when(graphQlProvider.getChat(
     const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
   )).thenAnswer((_) => Future.value(GetChat$Query.fromJson(chatData)));
-
-  when(graphQlProvider.getMyUser())
-      .thenAnswer((_) => Future.value(GetMyUser$Query.fromJson(myUserData)));
-
-  when(graphQlProvider.myUserEvents(
-    MyUserVersion('0'),
-  )).thenAnswer((_) => Future.value(const Stream.empty()));
 
   when(graphQlProvider.recentChatsTopEvents(3))
       .thenAnswer((_) => Future.value(const Stream.empty()));

--- a/test/unit/chat_read_test.dart
+++ b/test/unit/chat_read_test.dart
@@ -16,28 +16,23 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/chat_item.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/user.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -60,28 +55,8 @@ void main() async {
   await chatHiveProvider.init();
   var sessionProvider = Get.put(SessionDataHiveProvider());
   await sessionProvider.init();
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var userProvider = UserHiveProvider();
   await userProvider.init();
-
-  var myUserData = {
-    'id': 'id',
-    'num': '1234567890123456',
-    'login': null,
-    'name': null,
-    'bio': null,
-    'emails': {'confirmed': []},
-    'phones': {'confirmed': []},
-    'gallery': {'nodes': []},
-    'chatDirectLink': null,
-    'hasPassword': false,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -111,18 +86,6 @@ void main() async {
     }
   };
 
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...myUserData},
-        },
-      ),
-    ])),
-  );
-
   when(graphQlProvider.recentChatsTopEvents(3))
       .thenAnswer((_) => Future.value(const Stream.empty()));
 
@@ -141,10 +104,6 @@ void main() async {
     ),
   );
   await authService.init();
-  AbstractMyUserRepository myUserRepository =
-      MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
-  MyUserService myUserService =
-      Get.put(MyUserService(authService, myUserRepository));
 
   test('ChatService successfully reads messages', () async {
     when(graphQlProvider.recentChats(
@@ -204,8 +163,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, Get.find(), userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     await chatService.readChat(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
@@ -240,8 +198,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, Get.find(), userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     expect(
       () async => await chatService.readChat(

--- a/test/unit/chat_rename_test.dart
+++ b/test/unit/chat_rename_test.dart
@@ -16,27 +16,22 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/user.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -58,28 +53,8 @@ void main() async {
   await chatHiveProvider.init();
   var sessionProvider = Get.put(SessionDataHiveProvider());
   await sessionProvider.init();
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var userProvider = UserHiveProvider();
   await userProvider.init();
-
-  var myUserData = {
-    'id': 'id',
-    'num': '1234567890123456',
-    'login': null,
-    'name': null,
-    'bio': null,
-    'emails': {'confirmed': []},
-    'phones': {'confirmed': []},
-    'gallery': {'nodes': []},
-    'chatDirectLink': null,
-    'hasPassword': false,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -119,18 +94,6 @@ void main() async {
     ChatVersion('0'),
   )).thenAnswer((_) => Future.value(const Stream.empty()));
 
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...myUserData},
-        },
-      ),
-    ])),
-  );
-
   when(graphQlProvider.recentChats(
     first: 120,
     after: null,
@@ -149,10 +112,6 @@ void main() async {
     ),
   );
   await authService.init();
-  AbstractMyUserRepository myUserRepository =
-      MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
-  MyUserService myUserService =
-      Get.put(MyUserService(authService, myUserRepository));
 
   test('ChatService successfully changes chat name', () async {
     when(graphQlProvider.renameChat(
@@ -203,8 +162,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, Get.find(), userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     await chatService.renameChat(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
@@ -228,8 +186,7 @@ void main() async {
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, Get.find(), userRepository));
-    ChatService chatService =
-        Get.put(ChatService(chatRepository, myUserService));
+    ChatService chatService = Get.put(ChatService(chatRepository, authService));
 
     expect(
       () async => await chatService.renameChat(

--- a/test/unit/contact_rename_test.dart
+++ b/test/unit/contact_rename_test.dart
@@ -28,7 +28,6 @@ import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/contact.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/store/contact.dart';
@@ -45,9 +44,6 @@ void main() async {
   var sessionData = Get.put(SessionDataHiveProvider());
   await sessionData.init();
   await sessionData.clear();
-  var userProvider = Get.put(MyUserHiveProvider());
-  await userProvider.init();
-  await userProvider.clear();
   var galleryItemProvider = Get.put(GalleryItemHiveProvider());
   await galleryItemProvider.init();
   var userHiveProvider = Get.put(UserHiveProvider());

--- a/test/widget/chat_delete_message_test.dart
+++ b/test/widget/chat_delete_message_test.dart
@@ -24,16 +24,16 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/chat_item.dart';
+import 'package:messenger/domain/model/precise_date_time/precise_date_time.dart';
+import 'package:messenger/domain/model/session.dart';
 import 'package:messenger/domain/model/user.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/call.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/repository/settings.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/call.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/application_settings.dart';
@@ -42,7 +42,6 @@ import 'package:messenger/provider/hive/chat_item.dart';
 import 'package:messenger/provider/hive/contact.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/routes.dart';
@@ -50,7 +49,6 @@ import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/settings.dart';
 import 'package:messenger/store/user.dart';
 import 'package:messenger/themes.dart';
@@ -67,22 +65,6 @@ void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   Hive.init('./test/.temp_hive/chat_delete_message_widget');
 
-  var userData = {
-    'id': '0d72d245-8425-467a-9ebd-082d4f47850a',
-    'num': '1234567890123456',
-    'login': 'login',
-    'name': 'name',
-    'bio': 'bio',
-    'emails': {'confirmed': [], 'unconfirmed': null},
-    'phones': {'confirmed': [], 'unconfirmed': null},
-    'gallery': {'nodes': []},
-    'hasPassword': true,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
-
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
     'name': 'startname',
@@ -95,10 +77,7 @@ void main() async {
     'createdAt': '2021-12-15T15:11:18.316846+00:00',
     'updatedAt': '2021-12-15T15:11:18.316846+00:00',
     'lastReads': [
-      {
-        'memberId': '0d72d245-8425-467a-9ebd-082d4f47850a',
-        'at': '2022-01-01T07:27:30.151628+00:00'
-      },
+      {'memberId': 'me', 'at': '2022-01-01T07:27:30.151628+00:00'},
     ],
     'lastDelivery': '1970-01-01T00:00:00+00:00',
     'lastItem': null,
@@ -128,41 +107,6 @@ void main() async {
     ChatVersion('0'),
   )).thenAnswer((_) => Future.value(chatEvents.stream));
 
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...userData},
-        },
-      ),
-    ])),
-  );
-
-  when(graphQlProvider.signIn(
-          UserPassword('testPass'), null, null, null, null, true))
-      .thenAnswer(
-    (_) => Future.value(SignIn$Mutation.fromJson({
-      'createSession': {
-        '__typename': 'CreateSessionOk',
-        'user': userData,
-        'session': {
-          'expireAt': '2022-08-02T13:17:55Z',
-          'token':
-              'eyJpZCI6IjU3ZTMwZjhhLWVlNmMtNDdkYy1hNTMwLWNiZDc5MmJmMjRhNiIsInNlY3JldCI6Imh4UERlekFQT0xuQ2hEOVpwOE9UUHdSOE02ODJjTFQrTW80S2ZpNGxUMnc9In0=',
-          'ver': '30611347541830950583282840677231825138'
-        },
-        'remembered': {
-          'expireAt': '2023-08-02T12:47:55Z',
-          'token':
-              'eyJpZCI6ImE0MzlmYjAwLTRiZjMtNGU5Yi1iMWE4LWJmNzYyMjdlYWQ2ZiIsInNlY3JldCI6IkdqaGVKY1BVV21hS1UyTWRNeFNwNmxTYjZUZkhhQXo0RFdiVnhYalRicWs9In0=',
-          'ver': '30611347541270427360343145140867880719'
-        }
-      }
-    }).createSession as SignIn$Mutation$CreateSession$CreateSessionOk),
-  );
-
   when(graphQlProvider
           .getChat(const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b')))
       .thenAnswer((_) => Future.value(GetChat$Query.fromJson(chatData)));
@@ -189,7 +133,7 @@ void main() async {
                   '__typename': 'ChatMessage',
                   'id': '3a8547a2-bb2a-43bf-a8af-9e3b1d3a21f1',
                   'chatId': '0d72d245-8425-467a-9ebd-082d4f47850b',
-                  'authorId': '0d72d245-8425-467a-9ebd-082d4f47850a',
+                  'authorId': 'me',
                   'at': '2022-01-21T11:42:40.553339+00:00',
                   'ver': '1',
                   'repliesTo': null,
@@ -204,7 +148,7 @@ void main() async {
                   '__typename': 'ChatMessage',
                   'id': '91e6e597-e6ca-4b1f-ad70-83dd621e4cb2',
                   'chatId': '0d72d245-8425-467a-9ebd-082d4f47850b',
-                  'authorId': '0d72d245-8425-467a-9ebd-082d4f47850a',
+                  'authorId': 'me',
                   'at': '2022-01-21T11:42:35.284555+00:00',
                   'ver': '1',
                   'repliesTo': null,
@@ -287,9 +231,20 @@ void main() async {
   var sessionProvider = Get.put(SessionDataHiveProvider());
   await sessionProvider.init();
   await sessionProvider.clear();
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
+  sessionProvider.setCredentials(
+    Credentials(
+      Session(
+        const AccessToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      RememberedSession(
+        const RememberToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      const UserId('me'),
+    ),
+  );
+
   var galleryItemProvider = Get.put(GalleryItemHiveProvider());
   await galleryItemProvider.init();
   await galleryItemProvider.clear();
@@ -340,13 +295,10 @@ void main() async {
       ),
     );
     await authService.init();
-    await authService.signIn(UserPassword('testPass'));
 
     router = RouterState(authService);
     router.provider = MockPlatformRouteInformationProvider();
 
-    AbstractMyUserRepository myUserRepository =
-        MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
     UserRepository userRepository = Get.put(
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractSettingsRepository settingsRepository = Get.put(
@@ -356,11 +308,9 @@ void main() async {
     AbstractCallRepository callRepository =
         CallRepository(graphQlProvider, userRepository);
 
-    MyUserService myUserService =
-        Get.put(MyUserService(authService, myUserRepository));
     Get.put(UserService(userRepository));
     Get.put(CallService(authService, settingsRepository, callRepository));
-    Get.put(ChatService(chatRepository, myUserService));
+    Get.put(ChatService(chatRepository, authService));
 
     await tester.pumpWidget(createWidgetForTesting(
       child: const ChatView(ChatId('0d72d245-8425-467a-9ebd-082d4f47850b')),

--- a/test/widget/chat_edit_message_test.dart
+++ b/test/widget/chat_edit_message_test.dart
@@ -24,16 +24,16 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/chat_item.dart';
+import 'package:messenger/domain/model/precise_date_time/precise_date_time.dart';
+import 'package:messenger/domain/model/session.dart';
 import 'package:messenger/domain/model/user.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/call.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/repository/settings.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/call.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/application_settings.dart';
@@ -42,7 +42,6 @@ import 'package:messenger/provider/hive/chat_item.dart';
 import 'package:messenger/provider/hive/contact.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/routes.dart';
@@ -50,7 +49,6 @@ import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/settings.dart';
 import 'package:messenger/store/user.dart';
 import 'package:messenger/themes.dart';
@@ -67,22 +65,6 @@ void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   Hive.init('./test/.temp_hive/chat_edit_message_text_widget');
 
-  var userData = {
-    'id': '0d72d245-8425-467a-9ebd-082d4f47850a',
-    'num': '1234567890123456',
-    'login': 'login',
-    'name': 'name',
-    'bio': 'bio',
-    'emails': {'confirmed': [], 'unconfirmed': null},
-    'phones': {'confirmed': [], 'unconfirmed': null},
-    'gallery': {'nodes': []},
-    'hasPassword': true,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
-
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
     'name': 'startname',
@@ -95,10 +77,7 @@ void main() async {
     'createdAt': '2021-12-15T15:11:18.316846+00:00',
     'updatedAt': '2021-12-15T15:11:18.316846+00:00',
     'lastReads': [
-      {
-        'memberId': '0d72d245-8425-467a-9ebd-082d4f47850a',
-        'at': '2022-01-01T07:27:30.151628+00:00'
-      },
+      {'memberId': 'me', 'at': '2022-01-01T07:27:30.151628+00:00'},
     ],
     'lastDelivery': '1970-01-01T00:00:00+00:00',
     'lastItem': null,
@@ -130,47 +109,9 @@ void main() async {
     ChatVersion('0'),
   )).thenAnswer((_) => Future.value(chatEvents.stream));
 
-  when(graphQlProvider.getMyUser())
-      .thenAnswer((_) => Future.value(GetMyUser$Query.fromJson(userData)));
-
   when(graphQlProvider
           .keepTyping(const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b')))
       .thenAnswer((_) => Future.value(const Stream.empty()));
-
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...userData},
-        },
-      )
-    ])),
-  );
-
-  when(graphQlProvider.signIn(
-          UserPassword('testPass'), null, null, null, null, true))
-      .thenAnswer(
-    (_) => Future.value(SignIn$Mutation.fromJson({
-      'createSession': {
-        '__typename': 'CreateSessionOk',
-        'user': userData,
-        'session': {
-          'expireAt': '2022-08-02T13:17:55Z',
-          'token':
-              'eyJpZCI6IjU3ZTMwZjhhLWVlNmMtNDdkYy1hNTMwLWNiZDc5MmJmMjRhNiIsInNlY3JldCI6Imh4UERlekFQT0xuQ2hEOVpwOE9UUHdSOE02ODJjTFQrTW80S2ZpNGxUMnc9In0=',
-          'ver': '30611347541830950583282840677231825138'
-        },
-        'remembered': {
-          'expireAt': '2023-08-02T12:47:55Z',
-          'token':
-              'eyJpZCI6ImE0MzlmYjAwLTRiZjMtNGU5Yi1iMWE4LWJmNzYyMjdlYWQ2ZiIsInNlY3JldCI6IkdqaGVKY1BVV21hS1UyTWRNeFNwNmxTYjZUZkhhQXo0RFdiVnhYalRicWs9In0=',
-          'ver': '30611347541270427360343145140867880719'
-        }
-      }
-    }).createSession as SignIn$Mutation$CreateSession$CreateSessionOk),
-  );
 
   when(graphQlProvider
           .getChat(const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b')))
@@ -188,7 +129,7 @@ void main() async {
                       '__typename': 'ChatMessage',
                       'id': '91e6e597-e6ca-4b1f-ad70-83dd621e4cb2',
                       'chatId': '0d72d245-8425-467a-9ebd-082d4f47850b',
-                      'authorId': '0d72d245-8425-467a-9ebd-082d4f47850a',
+                      'authorId': 'me',
                       'at': DateTime.now().toIso8601String(),
                       'ver': '0',
                       'repliesTo': null,
@@ -245,16 +186,22 @@ void main() async {
   });
 
   var sessionProvider = Get.put(SessionDataHiveProvider());
-  AuthService authService =
-      AuthService(AuthRepository(graphQlProvider), SessionDataHiveProvider());
-  await authService.init();
+  await sessionProvider.init();
+  await sessionProvider.clear();
+  sessionProvider.setCredentials(
+    Credentials(
+      Session(
+        const AccessToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      RememberedSession(
+        const RememberToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      const UserId('me'),
+    ),
+  );
 
-  router = RouterState(authService);
-  router.provider = MockPlatformRouteInformationProvider();
-
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var galleryItemProvider = Get.put(GalleryItemHiveProvider());
   await galleryItemProvider.init();
   await galleryItemProvider.clear();
@@ -300,12 +247,12 @@ void main() async {
       ),
     );
     await authService.init();
-    await authService.signIn(UserPassword('testPass'));
+
+    router = RouterState(authService);
+    router.provider = MockPlatformRouteInformationProvider();
 
     UserRepository userRepository =
         UserRepository(graphQlProvider, userProvider, galleryItemProvider);
-    AbstractMyUserRepository myUserRepository =
-        MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
         ChatRepository(graphQlProvider, chatProvider, userRepository));
     AbstractSettingsRepository settingsRepository = Get.put(
@@ -313,12 +260,9 @@ void main() async {
     AbstractCallRepository callRepository =
         CallRepository(graphQlProvider, userRepository);
 
-    MyUserService myUserService =
-        Get.put(MyUserService(authService, myUserRepository));
-
     Get.put(UserService(userRepository));
     Get.put(CallService(authService, settingsRepository, callRepository));
-    Get.put(ChatService(chatRepository, myUserService));
+    Get.put(ChatService(chatRepository, authService));
 
     await tester.pumpWidget(createWidgetForTesting(
       child: const ChatView(ChatId('0d72d245-8425-467a-9ebd-082d4f47850b')),

--- a/test/widget/chat_leave_test.dart
+++ b/test/widget/chat_leave_test.dart
@@ -23,16 +23,16 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
+import 'package:messenger/domain/model/precise_date_time/precise_date_time.dart';
+import 'package:messenger/domain/model/session.dart';
 import 'package:messenger/domain/model/user.dart';
 import 'package:messenger/domain/repository/chat.dart';
 import 'package:messenger/domain/repository/contact.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/repository/settings.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/call.dart';
 import 'package:messenger/domain/service/chat.dart';
 import 'package:messenger/domain/service/contact.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/application_settings.dart';
@@ -41,7 +41,6 @@ import 'package:messenger/provider/hive/chat_item.dart';
 import 'package:messenger/provider/hive/contact.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/routes.dart';
@@ -50,7 +49,6 @@ import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/contact.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/settings.dart';
 import 'package:messenger/store/user.dart';
 import 'package:messenger/themes.dart';
@@ -66,22 +64,6 @@ import 'chat_leave_test.mocks.dart';
 void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   Hive.init('./test/.temp_hive/chat_leave_widget');
-
-  var userData = {
-    'id': '12',
-    'num': '1234567890123456',
-    'login': 'login',
-    'name': 'name',
-    'bio': 'bio',
-    'emails': {'confirmed': [], 'unconfirmed': null},
-    'phones': {'confirmed': [], 'unconfirmed': null},
-    'gallery': {'nodes': []},
-    'hasPassword': true,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
 
   var recentChats = {
     'recentChats': {
@@ -114,6 +96,20 @@ void main() async {
   var sessionProvider = Get.put(SessionDataHiveProvider());
   await sessionProvider.init();
   await sessionProvider.clear();
+  sessionProvider.setCredentials(
+    Credentials(
+      Session(
+        const AccessToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      RememberedSession(
+        const RememberToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      const UserId('me'),
+    ),
+  );
+
   var graphQlProvider = Get.put(MockGraphQlProvider());
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
   when(graphQlProvider.recentChatsTopEvents(3))
@@ -126,9 +122,6 @@ void main() async {
   router = RouterState(authService);
   router.provider = MockPlatformRouteInformationProvider();
 
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var galleryItemProvider = Get.put(GalleryItemHiveProvider());
   await galleryItemProvider.init();
   await galleryItemProvider.clear();
@@ -148,7 +141,7 @@ void main() async {
   await applicationSettingsProvider.init();
   var chatItemHiveProvider = ChatItemHiveProvider(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'));
-  await chatItemHiveProvider.init(userId: const UserId('12'));
+  await chatItemHiveProvider.init(userId: const UserId('me'));
   await chatItemHiveProvider.clear();
 
   Widget createWidgetForTesting({required Widget child}) {
@@ -186,18 +179,6 @@ void main() async {
       ])),
     );
 
-    when(graphQlProvider.myUserEvents(null)).thenAnswer(
-      (_) => Future.value(Stream.fromIterable([
-        QueryResult.internal(
-          parserFn: (_) => null,
-          source: null,
-          data: {
-            'myUserEvents': {'__typename': 'MyUser', ...userData},
-          },
-        ),
-      ])),
-    );
-
     when(graphQlProvider.recentChats(
       first: 120,
       after: null,
@@ -213,7 +194,7 @@ void main() async {
         .thenAnswer((_) => Future.value(const Stream.empty()));
     when(graphQlProvider.removeChatMember(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-      const UserId('12'),
+      const UserId('me'),
     )).thenAnswer((_) {
       var event = {
         '__typename': 'ChatEventsVersioned',
@@ -226,12 +207,12 @@ void main() async {
                 '__typename': 'ChatMemberInfo',
                 'id': 'id',
                 'chatId': '0d72d245-8425-467a-9ebd-082d4f47850b',
-                'authorId': '12',
+                'authorId': 'me',
                 'at': DateTime.now().toString(),
                 'ver': '0',
                 'user': {
                   '__typename': 'User',
-                  'id': '12',
+                  'id': 'me',
                   'num': '1234567890123456',
                   'login': null,
                   'name': null,
@@ -292,12 +273,8 @@ void main() async {
       ),
     ));
 
-    AbstractMyUserRepository myUserRepository =
-        MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
     AbstractSettingsRepository settingsRepository = Get.put(
         SettingsRepository(settingsProvider, applicationSettingsProvider));
-    MyUserService myUserService = MyUserService(authService, myUserRepository);
-    Get.put(myUserService);
 
     Get.put(CallService(
       authService,
@@ -310,7 +287,7 @@ void main() async {
         Get.put<AbstractChatRepository>(
           ChatRepository(graphQlProvider, chatProvider, userRepository),
         ),
-        myUserService,
+        authService,
       ),
     );
 
@@ -331,14 +308,13 @@ void main() async {
     verifyInOrder([
       graphQlProvider.removeChatMember(
         const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-        const UserId('12'),
+        const UserId('me'),
       ),
     ]);
 
     await Get.deleteAll(force: true);
   });
 
-  await myUserProvider.clear();
   await galleryItemProvider.clear();
   await contactProvider.clear();
   await userProvider.clear();

--- a/test/widget/chat_rename_test.dart
+++ b/test/widget/chat_rename_test.dart
@@ -26,12 +26,10 @@ import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/call.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/repository/settings.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/call.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/application_settings.dart';
@@ -48,7 +46,6 @@ import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/settings.dart';
 import 'package:messenger/store/user.dart';
 import 'package:messenger/ui/page/home/page/chat/info/controller.dart';
@@ -61,22 +58,6 @@ import 'chat_rename_test.mocks.dart';
 void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   Hive.init('./test/.temp_hive/chat_rename_widget');
-
-  var userData = {
-    'id': 'id',
-    'num': '1234567890123456',
-    'login': 'login',
-    'name': 'name',
-    'bio': 'bio',
-    'emails': {'confirmed': [], 'unconfirmed': null},
-    'phones': {'confirmed': [], 'unconfirmed': null},
-    'gallery': {'nodes': []},
-    'hasPassword': true,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -149,18 +130,6 @@ void main() async {
       (WidgetTester tester) async {
     when(graphQlProvider.recentChatsTopEvents(3))
         .thenAnswer((_) => Future.value(const Stream.empty()));
-
-    when(graphQlProvider.myUserEvents(null)).thenAnswer(
-      (_) => Future.value(Stream.fromIterable([
-        QueryResult.internal(
-          parserFn: (_) => null,
-          source: null,
-          data: {
-            'myUserEvents': {'__typename': 'MyUser', ...userData},
-          },
-        ),
-      ])),
-    );
 
     final StreamController<QueryResult> chatEvents = StreamController();
     when(graphQlProvider.chatEvents(
@@ -254,8 +223,6 @@ void main() async {
     );
     await authService.init();
 
-    AbstractMyUserRepository myUserRepository =
-        MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
     UserRepository userRepository = Get.put(
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractSettingsRepository settingsRepository = Get.put(
@@ -265,10 +232,8 @@ void main() async {
     AbstractCallRepository callRepository =
         CallRepository(graphQlProvider, userRepository);
 
-    MyUserService myUserService =
-        Get.put(MyUserService(authService, myUserRepository));
     Get.put(UserService(userRepository));
-    Get.put(ChatService(chatRepository, myUserService));
+    Get.put(ChatService(chatRepository, authService));
     Get.put(CallService(authService, settingsRepository, callRepository));
 
     await tester.pumpWidget(createWidgetForTesting(

--- a/test/widget/chat_reply_message_test.dart
+++ b/test/widget/chat_reply_message_test.dart
@@ -24,16 +24,16 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/chat_item.dart';
+import 'package:messenger/domain/model/precise_date_time/precise_date_time.dart';
+import 'package:messenger/domain/model/session.dart';
 import 'package:messenger/domain/model/user.dart';
 import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/repository/call.dart';
 import 'package:messenger/domain/repository/chat.dart';
-import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/repository/settings.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/call.dart';
 import 'package:messenger/domain/service/chat.dart';
-import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/application_settings.dart';
@@ -42,7 +42,6 @@ import 'package:messenger/provider/hive/chat_item.dart';
 import 'package:messenger/provider/hive/contact.dart';
 import 'package:messenger/provider/hive/gallery_item.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session.dart';
 import 'package:messenger/provider/hive/user.dart';
 import 'package:messenger/routes.dart';
@@ -50,7 +49,6 @@ import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
 import 'package:messenger/store/model/chat.dart';
-import 'package:messenger/store/my_user.dart';
 import 'package:messenger/store/settings.dart';
 import 'package:messenger/store/user.dart';
 import 'package:messenger/themes.dart';
@@ -67,22 +65,6 @@ void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   Hive.init('./test/.temp_hive/chat_reply_message_widget');
 
-  var userData = {
-    'id': '0d72d245-8425-467a-9ebd-082d4f47850a',
-    'num': '1234567890123456',
-    'login': 'login',
-    'name': 'name',
-    'bio': 'bio',
-    'emails': {'confirmed': [], 'unconfirmed': null},
-    'phones': <String, dynamic>{'confirmed': [], 'unconfirmed': null},
-    'gallery': {'nodes': []},
-    'hasPassword': true,
-    'unreadChatsCount': 0,
-    'ver': '0',
-    'presence': 'AWAY',
-    'online': {'__typename': 'UserOnline'},
-  };
-
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
     'name': 'startname',
@@ -95,10 +77,7 @@ void main() async {
     'createdAt': '2021-12-15T15:11:18.316846+00:00',
     'updatedAt': '2021-12-15T15:11:18.316846+00:00',
     'lastReads': [
-      {
-        'memberId': '0d72d245-8425-467a-9ebd-082d4f47850a',
-        'at': '2022-01-01T07:27:30.151628+00:00'
-      },
+      {'memberId': 'me', 'at': '2022-01-01T07:27:30.151628+00:00'},
     ],
     'lastDelivery': '1970-01-01T00:00:00+00:00',
     'lastItem': null,
@@ -132,41 +111,6 @@ void main() async {
           .keepTyping(const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b')))
       .thenAnswer((_) => Future.value(const Stream.empty()));
 
-  when(graphQlProvider.myUserEvents(null)).thenAnswer(
-    (_) => Future.value(Stream.fromIterable([
-      QueryResult.internal(
-        parserFn: (_) => null,
-        source: null,
-        data: {
-          'myUserEvents': {'__typename': 'MyUser', ...userData},
-        },
-      ),
-    ])),
-  );
-
-  when(graphQlProvider.signIn(
-          UserPassword('testPass'), null, null, null, null, true))
-      .thenAnswer(
-    (_) => Future.value(SignIn$Mutation.fromJson({
-      'createSession': {
-        '__typename': 'CreateSessionOk',
-        'user': userData,
-        'session': {
-          'expireAt': '2022-08-02T13:17:55Z',
-          'token':
-              'eyJpZCI6IjU3ZTMwZjhhLWVlNmMtNDdkYy1hNTMwLWNiZDc5MmJmMjRhNiIsInNlY3JldCI6Imh4UERlekFQT0xuQ2hEOVpwOE9UUHdSOE02ODJjTFQrTW80S2ZpNGxUMnc9In0=',
-          'ver': '30611347541830950583282840677231825138'
-        },
-        'remembered': {
-          'expireAt': '2023-08-02T12:47:55Z',
-          'token':
-              'eyJpZCI6ImE0MzlmYjAwLTRiZjMtNGU5Yi1iMWE4LWJmNzYyMjdlYWQ2ZiIsInNlY3JldCI6IkdqaGVKY1BVV21hS1UyTWRNeFNwNmxTYjZUZkhhQXo0RFdiVnhYalRicWs9In0=',
-          'ver': '30611347541270427360343145140867880719'
-        }
-      }
-    }).createSession as SignIn$Mutation$CreateSession$CreateSessionOk),
-  );
-
   when(graphQlProvider
           .getChat(const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b')))
       .thenAnswer((_) => Future.value(GetChat$Query.fromJson(chatData)));
@@ -176,13 +120,13 @@ void main() async {
           const ChatItemId('91e6e597-e6ca-4b1f-ad70-83dd621e4cb4')))
       .thenAnswer((_) => Future.value(null));
 
-  when(graphQlProvider.keepOnline())
-      .thenAnswer((_) => Future.value(const Stream.empty()));
-
   when(graphQlProvider.readChat(
           const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-          const ChatItemId('91e6e597-e6ca-4b1f-ad70-83dd621e4cb2')))
+          const ChatItemId('145f6006-82b9-4d07-9229-354146e4f332')))
       .thenAnswer((_) => Future.value(null));
+
+  when(graphQlProvider.keepOnline())
+      .thenAnswer((_) => Future.value(const Stream.empty()));
 
   when(graphQlProvider.chatItems(
     const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
@@ -196,7 +140,7 @@ void main() async {
                   '__typename': 'ChatMessage',
                   'id': '91e6e597-e6ca-4b1f-ad70-83dd621e4cb4',
                   'chatId': '0d72d245-8425-467a-9ebd-082d4f47850b',
-                  'authorId': '0d72d245-8425-467a-9ebd-082d4f47850a',
+                  'authorId': 'me',
                   'at': '2022-01-05T15:40:57.010950+00:00',
                   'ver': '1',
                   'repliesTo': null,
@@ -235,7 +179,7 @@ void main() async {
               '__typename': 'ChatMessage',
               'id': '145f6006-82b9-4d07-9229-354146e4f332',
               'chatId': '0d72d245-8425-467a-9ebd-082d4f47850b',
-              'authorId': '0d72d245-8425-467a-9ebd-082d4f47850a',
+              'authorId': 'me',
               'at': '2022-01-27T11:34:37.191440+00:00',
               'ver': '1',
               'repliesTo': {
@@ -243,7 +187,7 @@ void main() async {
                   '__typename': 'ChatMessage',
                   'id': '91e6e597-e6ca-4b1f-ad70-83dd621e4cb4',
                   'chatId': '0d72d245-8425-467a-9ebd-082d4f47850b',
-                  'authorId': '0d72d245-8425-467a-9ebd-082d4f47850a',
+                  'authorId': 'me',
                   'at': '2022-01-05T15:40:57.010950+00:00',
                   'ver': '1',
                   'repliesTo': null,
@@ -282,6 +226,22 @@ void main() async {
       .thenAnswer((_) => Future.value(const Stream.empty()));
 
   var sessionProvider = Get.put(SessionDataHiveProvider());
+  await sessionProvider.init();
+  await sessionProvider.clear();
+  sessionProvider.setCredentials(
+    Credentials(
+      Session(
+        const AccessToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      RememberedSession(
+        const RememberToken('token'),
+        PreciseDateTime.now().add(const Duration(days: 1)),
+      ),
+      const UserId('me'),
+    ),
+  );
+
   AuthService authService =
       AuthService(AuthRepository(graphQlProvider), SessionDataHiveProvider());
   await authService.init();
@@ -289,9 +249,6 @@ void main() async {
   router = RouterState(authService);
   router.provider = MockPlatformRouteInformationProvider();
 
-  var myUserProvider = Get.put(MyUserHiveProvider());
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var galleryItemProvider = Get.put(GalleryItemHiveProvider());
   await galleryItemProvider.init();
   await galleryItemProvider.clear();
@@ -313,8 +270,7 @@ void main() async {
   var messagesProvider = Get.put(ChatItemHiveProvider(
     const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
   ));
-  await messagesProvider.init(
-      userId: const UserId('0d72d245-8425-467a-9ebd-082d4f47850a'));
+  await messagesProvider.init(userId: const UserId('me'));
   await messagesProvider.clear();
 
   Widget createWidgetForTesting({required Widget child}) {
@@ -338,10 +294,7 @@ void main() async {
       ),
     );
     await authService.init();
-    await authService.signIn(UserPassword('testPass'));
 
-    AbstractMyUserRepository myUserRepository =
-        MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
     UserRepository userRepository = Get.put(
         UserRepository(graphQlProvider, userProvider, galleryItemProvider));
     AbstractSettingsRepository settingsRepository = Get.put(
@@ -351,17 +304,15 @@ void main() async {
         graphQlProvider,
         chatProvider,
         userRepository,
-        me: const UserId('0d72d245-8425-467a-9ebd-082d4f47850a'),
+        me: const UserId('me'),
       ),
     );
     AbstractCallRepository callRepository =
         CallRepository(graphQlProvider, userRepository);
 
-    MyUserService myUserService =
-        Get.put(MyUserService(authService, myUserRepository));
     Get.put(UserService(userRepository));
     Get.put(CallService(authService, settingsRepository, callRepository));
-    Get.put(ChatService(chatRepository, myUserService));
+    Get.put(ChatService(chatRepository, authService));
 
     await tester.pumpWidget(createWidgetForTesting(
       child: const ChatView(ChatId('0d72d245-8425-467a-9ebd-082d4f47850b')),

--- a/test/widget/my_profile_gallery_test.dart
+++ b/test/widget/my_profile_gallery_test.dart
@@ -53,6 +53,7 @@ void main() async {
   Hive.init('./test/.temp_hive/my_profile_gallery_widget');
   Config.url = 'http://testUrl.com';
   Config.port = 0;
+
   var userData = {
     'id': 'id',
     'num': '1234567890123456',

--- a/test/widget/user_profile_test.dart
+++ b/test/widget/user_profile_test.dart
@@ -317,12 +317,11 @@ void main() async {
         sessionProvider,
       ),
     );
+    await authService.init();
 
     AbstractMyUserRepository myUserRepository =
         MyUserRepository(graphQlProvider, myUserProvider, galleryItemProvider);
-    await authService.init();
-    MyUserService myUserService =
-        Get.put(MyUserService(authService, myUserRepository));
+    Get.put(MyUserService(authService, myUserRepository));
 
     UserRepository userRepository =
         UserRepository(graphQlProvider, userProvider, galleryItemProvider);
@@ -334,7 +333,7 @@ void main() async {
 
     ChatRepository chatRepository =
         ChatRepository(graphQlProvider, chatProvider, userRepository);
-    Get.put(ChatService(chatRepository, myUserService));
+    Get.put(ChatService(chatRepository, authService));
 
     SettingsRepository settingsRepository =
         SettingsRepository(mediaProvider, applicationSettingsProvider);


### PR DESCRIPTION
## Synopsis

A lot of services currently use `MyUserService` just to get `UserId` of the authenticated `MyUser`. However, `MyUserService` populates its `MyUser` not instantaneously, it might take a second or two to fetch. And we already have `AuthService.userId`, which is always there.




## Solution

Refactor code to use `AuthService.userId` in getters, where `UserId` of `MyUser` is required, instead of using `MyUserService`. This also simplifies the tests, as some of them no longer need to construct `MyUserService` at all.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
