### PR TITLE
Add multiline support to `ChatController.send` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ All user visible changes to this project will be documented in this file. This p
     - UI not hiding on window focus loses ([#60]).
 - UI:
     - Chat page:
-        - Missing avatars in group creation popup ([#15], [#2]).
+        - Missing avatars in group creation popup ([#15], [#2]);
+        - Send field not supporting multiline on desktop ([#139]).
     - Home page:
         - Horizontal scroll overlapping with vertical ([#42], [#41]).
     - Media panel:
@@ -107,6 +108,7 @@ All user visible changes to this project will be documented in this file. This p
 [#112]: /../../pull/112
 [#115]: /../../pull/115
 [#117]: /../../pull/117
+[#139]: /../../pull/139
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ All user visible changes to this project will be documented in this file. This p
     - Chat page:
         - Message forwarding ([#72], [#8]);
         - Failed messages persistence ([#5], [#3]);
-        - Message splitting when character limit is exceeded ([#115], [#100]).
+        - Message splitting when character limit is exceeded ([#115], [#100]);
+        - Send field multiline support ([#139]).
 - Deployment:
     - [Helm] chart ([#73], [#85]).
 
@@ -55,8 +56,7 @@ All user visible changes to this project will be documented in this file. This p
     - UI not hiding on window focus loses ([#60]).
 - UI:
     - Chat page:
-        - Missing avatars in group creation popup ([#15], [#2]);
-        - Send field not supporting multiline on desktop ([#139]).
+        - Missing avatars in group creation popup ([#15], [#2]).
     - Home page:
         - Horizontal scroll overlapping with vertical ([#42], [#41]).
     - Media panel:

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -239,6 +239,34 @@ class ChatController extends GetxController {
           }
         }
       },
+      focus: FocusNode(
+        onKey: (FocusNode node, RawKeyEvent e) {
+          if (e.logicalKey == LogicalKeyboardKey.enter &&
+              e is RawKeyDownEvent) {
+            if (e.isAltPressed || e.isControlPressed || e.isMetaPressed) {
+              int cursor;
+
+              if (send.controller.selection.isCollapsed) {
+                cursor = send.controller.selection.base.offset;
+                send.text =
+                    '${send.text.substring(0, cursor)}\n${send.text.substring(cursor, send.text.length)}';
+              } else {
+                cursor = send.controller.selection.start;
+                send.text =
+                    '${send.text.substring(0, send.controller.selection.start)}\n${send.text.substring(send.controller.selection.end, send.text.length)}';
+              }
+
+              send.controller.selection =
+                  TextSelection.fromPosition(TextPosition(offset: cursor + 1));
+            } else if (!e.isShiftPressed) {
+              send.submit();
+              return KeyEventResult.handled;
+            }
+          }
+
+          return KeyEventResult.ignored;
+        },
+      ),
     );
 
     super.onInit();

--- a/lib/ui/page/home/page/chat/forward/controller.dart
+++ b/lib/ui/page/home/page/chat/forward/controller.dart
@@ -18,7 +18,8 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 
 import '/api/backend/schema.dart' show ForwardChatItemsErrorCode;
@@ -126,6 +127,34 @@ class ChatForwardController extends GetxController {
           s.unsubmit();
         }
       },
+      focus: FocusNode(
+        onKey: (FocusNode node, RawKeyEvent e) {
+          if (e.logicalKey == LogicalKeyboardKey.enter &&
+              e is RawKeyDownEvent) {
+            if (e.isAltPressed || e.isControlPressed || e.isMetaPressed) {
+              int cursor;
+
+              if (send.controller.selection.isCollapsed) {
+                cursor = send.controller.selection.base.offset;
+                send.text =
+                    '${send.text.substring(0, cursor)}\n${send.text.substring(cursor, send.text.length)}';
+              } else {
+                cursor = send.controller.selection.start;
+                send.text =
+                    '${send.text.substring(0, send.controller.selection.start)}\n${send.text.substring(send.controller.selection.end, send.text.length)}';
+              }
+
+              send.controller.selection =
+                  TextSelection.fromPosition(TextPosition(offset: cursor + 1));
+            } else if (!e.isShiftPressed) {
+              send.submit();
+              return KeyEventResult.handled;
+            }
+          }
+
+          return KeyEventResult.ignored;
+        },
+      ),
     );
 
     super.onInit();

--- a/lib/ui/page/home/page/chat/forward/view.dart
+++ b/lib/ui/page/home/page/chat/forward/view.dart
@@ -587,10 +587,8 @@ class ChatForwardView extends StatelessWidget {
                     minLines: 1,
                     maxLines: 6,
                     style: const TextStyle(fontSize: 17),
-                    type: PlatformUtils.isDesktop
-                        ? TextInputType.text
-                        : TextInputType.multiline,
-                    textInputAction: TextInputAction.send,
+                    type: TextInputType.multiline,
+                    textInputAction: TextInputAction.newline,
                   ),
                 ),
               ),

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -725,12 +725,8 @@ class _ChatViewState extends State<ChatView>
                   minLines: 1,
                   maxLines: 6,
                   style: const TextStyle(fontSize: 17),
-                  type: PlatformUtils.isDesktop
-                      ? TextInputType.text
-                      : TextInputType.multiline,
-                  textInputAction: PlatformUtils.isDesktop
-                      ? TextInputAction.send
-                      : TextInputAction.newline,
+                  type: TextInputType.multiline,
+                  textInputAction: TextInputAction.newline,
                 ),
               ),
             ),

--- a/lib/ui/page/home/page/my_profile/widget/dropdown.dart
+++ b/lib/ui/page/home/page/my_profile/widget/dropdown.dart
@@ -129,6 +129,9 @@ class DropdownFieldState<T> extends ReactiveFieldState {
   @override
   final RxBool isEmpty = RxBool(true);
 
+  @override
+  final FocusNode focus = FocusNode();
+
   /// Currently selected value of this [DropdownFieldState].
   T? _value;
 

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -299,7 +299,7 @@ abstract class ReactiveFieldState {
   RxBool get isEmpty;
 
   /// [FocusNode] of this [ReactiveFieldState] used to determine focus changes.
-  final FocusNode focus = FocusNode();
+  FocusNode get focus;
 
   /// Reactive error message.
   final RxnString error = RxnString();
@@ -318,8 +318,9 @@ class TextFieldState extends ReactiveFieldState {
     this.onChanged,
     this.onSubmitted,
     RxStatus? status,
+    FocusNode? focus,
     bool editable = true,
-  }) {
+  }) : focus = focus ?? FocusNode() {
     controller = TextEditingController(text: text);
     isEmpty = RxBool(text?.isEmpty ?? true);
 
@@ -327,12 +328,12 @@ class TextFieldState extends ReactiveFieldState {
     this.status = Rx(status ?? RxStatus.empty());
 
     if (onChanged != null) {
-      focus.addListener(
+      this.focus.addListener(
         () {
           if (controller.text != _previousText &&
               (_previousText != null || controller.text.isNotEmpty)) {
             isEmpty.value = controller.text.isEmpty;
-            if (!focus.hasFocus) {
+            if (!this.focus.hasFocus) {
               onChanged?.call(this);
               _previousText = controller.text;
             }
@@ -371,6 +372,9 @@ class TextFieldState extends ReactiveFieldState {
 
   @override
   late final RxBool isEmpty;
+
+  @override
+  late final FocusNode focus;
 
   /// Previous [TextEditingController]'s text used to determine if the [text]
   /// was modified on any [focus] change.


### PR DESCRIPTION
## Synopsis

Currently `ChatController.send` field (the one sending the messages) does not append a new line character when pressing enter + any modifier key.




## Solution

Make `ChatController.send` field multiline and handle enter presses separately in its `FocusNode`. Also it worth mentioning that Flutter supports only `enter + shift` multiline addition, so this `FocusNode` also handles `enter + meta`, `enter + alt`, `enter + control` to add new lines.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
