### PR TITLE
Display `Call`'s title and duration in fullscreen popup (#74)

### DIFF
--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -733,7 +733,6 @@ Widget desktopCall(CallController c, BuildContext context) {
           bool enabled = !c.displayMore.value &&
               c.primaryDrags.value == 0 &&
               c.secondaryDrags.value == 0;
-
           return Align(
             alignment: Alignment.bottomCenter,
             child: SizedBox(

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -672,47 +672,13 @@ Widget desktopCall(CallController c, BuildContext context) {
 
         if (WebUtils.isPopup)
           Obx(() {
-            final Map<String, String> args = {
-              'title': c.chat.value?.title.value ?? ('dot'.l10n * 3),
-              'state': c.state.value.name,
-            };
-
-            switch (c.state.value) {
-              case OngoingCallState.local:
-              case OngoingCallState.pending:
-                bool isOutgoing =
-                    (c.outgoing || c.state.value == OngoingCallState.local) &&
-                        !c.started;
-                if (isOutgoing) {
-                  args['type'] = 'outgoing';
-                } else if (c.withVideo) {
-                  args['type'] = 'video';
-                } else {
-                  args['type'] = 'audio';
-                }
-                break;
-
-              case OngoingCallState.active:
-                final actualMembers =
-                    c.members.keys.map((k) => k.userId).toSet();
-                args['members'] = '${actualMembers.length}';
-                args['allMembers'] = '${c.chat.value?.members.length}';
-                args['duration'] = c.duration.value.hhMmSs();
-                break;
-
-              case OngoingCallState.joining:
-              case OngoingCallState.ended:
-                // No-op.
-                break;
-            }
-
             return Align(
               alignment: Alignment.topCenter,
               child: AnimatedSlider(
                 duration: 400.milliseconds,
                 translate: false,
-                beginOffset: const Offset(0.0, -1.0),
-                endOffset: const Offset(0.0, 0.0),
+                beginOffset: const Offset(0, -1),
+                endOffset: const Offset(0, 0),
                 isOpen: c.showHeader.value && c.fullscreen.value,
                 child: Container(
                   decoration: BoxDecoration(
@@ -743,7 +709,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                         horizontal: 10,
                       ),
                       child: Text(
-                        'label_call_title'.l10nfmt(args),
+                        'label_call_title'.l10nfmt(c.callTitleArguments),
                         style: context.textTheme.bodyText1?.copyWith(
                           fontSize: 13,
                           color: const Color(0xFFFFFFFF),

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -683,7 +683,9 @@ Widget desktopCall(CallController c, BuildContext context) {
                 translate: false,
                 beginOffset: const Offset(0, -1),
                 endOffset: const Offset(0, 0),
-                isOpen: c.showHeader.value && c.fullscreen.value,
+                isOpen: c.state.value == OngoingCallState.active &&
+                    c.showHeader.value &&
+                    c.fullscreen.value,
                 child: Container(
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(30),
@@ -712,7 +714,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                         horizontal: 10,
                       ),
                       child: Text(
-                        'label_call_title'.l10nfmt(c.callTitleArguments),
+                        'label_call_title'.l10nfmt(c.titleArguments),
                         style: context.textTheme.bodyText1?.copyWith(
                           fontSize: 13,
                           color: const Color(0xFFFFFFFF),
@@ -748,7 +750,7 @@ Widget desktopCall(CallController c, BuildContext context) {
           );
         }),
 
-        // Top [MouseRegion] that toggles UI on hover.
+        // Top [MouseRegion] that toggles title on hover.
         Align(
           alignment: Alignment.topCenter,
           child: SizedBox(
@@ -1110,39 +1112,6 @@ Widget desktopCall(CallController c, BuildContext context) {
 /// Title bar of the call containing information about the call and control
 /// buttons.
 Widget _titleBar(BuildContext context, CallController c) => Obx(() {
-      final Map<String, String> args = {
-        'title': c.chat.value?.title.value ?? ('dot'.l10n * 3),
-        'state': c.state.value.name,
-      };
-
-      switch (c.state.value) {
-        case OngoingCallState.local:
-        case OngoingCallState.pending:
-          bool isOutgoing =
-              (c.outgoing || c.state.value == OngoingCallState.local) &&
-                  !c.started;
-          if (isOutgoing) {
-            args['type'] = 'outgoing';
-          } else if (c.withVideo) {
-            args['type'] = 'video';
-          } else {
-            args['type'] = 'audio';
-          }
-          break;
-
-        case OngoingCallState.active:
-          var actualMembers = c.members.keys.map((k) => k.userId).toSet();
-          args['members'] = '${actualMembers.length}';
-          args['allMembers'] = '${c.chat.value?.members.length}';
-          args['duration'] = c.duration.value.hhMmSs();
-          break;
-
-        case OngoingCallState.joining:
-        case OngoingCallState.ended:
-          // No-op.
-          break;
-      }
-
       return Container(
         key: const ValueKey('TitleBar'),
         color: const Color(0xFF162636),
@@ -1161,7 +1130,7 @@ Widget _titleBar(BuildContext context, CallController c) => Obx(() {
             Align(
               alignment: Alignment.centerLeft,
               child: ConstrainedBox(
-                constraints: BoxConstraints(maxWidth: c.size.width / 2),
+                constraints: BoxConstraints(maxWidth: c.size.width - 60),
                 child: InkWell(
                   onTap: WebUtils.isPopup
                       ? null
@@ -1179,7 +1148,7 @@ Widget _titleBar(BuildContext context, CallController c) => Obx(() {
                       const SizedBox(width: 8),
                       Flexible(
                         child: Text(
-                          'label_call_title'.l10nfmt(args),
+                          'label_call_title'.l10nfmt(c.titleArguments),
                           style: context.textTheme.bodyText1?.copyWith(
                             fontSize: 13,
                             color: const Color(0xFFFFFFFF),

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -39,7 +39,6 @@ import '/domain/model/ongoing_call.dart';
 import '/l10n/l10n.dart';
 import '/routes.dart';
 import '/themes.dart';
-import '/ui/page/home/page/chat/widget/chat_item.dart';
 import '/ui/page/home/widget/animated_slider.dart';
 import '/ui/page/home/widget/avatar.dart';
 import '/ui/widget/animated_delayed_switcher.dart';

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -670,11 +670,99 @@ Widget desktopCall(CallController c, BuildContext context) {
           );
         }),
 
+        if (WebUtils.isPopup)
+          Obx(() {
+            final Map<String, String> args = {
+              'title': c.chat.value?.title.value ?? ('dot'.l10n * 3),
+              'state': c.state.value.name,
+            };
+
+            switch (c.state.value) {
+              case OngoingCallState.local:
+              case OngoingCallState.pending:
+                bool isOutgoing =
+                    (c.outgoing || c.state.value == OngoingCallState.local) &&
+                        !c.started;
+                if (isOutgoing) {
+                  args['type'] = 'outgoing';
+                } else if (c.withVideo) {
+                  args['type'] = 'video';
+                } else {
+                  args['type'] = 'audio';
+                }
+                break;
+
+              case OngoingCallState.active:
+                final actualMembers =
+                    c.members.keys.map((k) => k.userId).toSet();
+                args['members'] = '${actualMembers.length}';
+                args['allMembers'] = '${c.chat.value?.members.length}';
+                args['duration'] = c.duration.value.hhMmSs();
+                break;
+
+              case OngoingCallState.joining:
+              case OngoingCallState.ended:
+                // No-op.
+                break;
+            }
+
+            return Align(
+              alignment: Alignment.topCenter,
+              child: AnimatedSlider(
+                duration: 400.milliseconds,
+                translate: false,
+                beginOffset: const Offset(0.0, -1.0),
+                endOffset: const Offset(0.0, 0.0),
+                isOpen: c.showHeader.value && c.fullscreen.value,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.transparent,
+                    borderRadius: BorderRadius.circular(30),
+                    boxShadow: const [
+                      CustomBoxShadow(
+                        color: Color(0x33000000),
+                        blurRadius: 8,
+                        blurStyle: BlurStyle.outer,
+                      )
+                    ],
+                  ),
+                  margin: const EdgeInsets.fromLTRB(10, 5, 10, 2),
+                  child: ConditionalBackdropFilter(
+                    borderRadius: BorderRadius.circular(30),
+                    filter: ImageFilter.blur(
+                      sigmaX: 15,
+                      sigmaY: 15,
+                    ),
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: const Color(0x301D6AAE),
+                        borderRadius: BorderRadius.circular(30),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 8,
+                        horizontal: 10,
+                      ),
+                      child: Text(
+                        'label_call_title'.l10nfmt(args),
+                        style: context.textTheme.bodyText1?.copyWith(
+                          fontSize: 13,
+                          color: const Color(0xFFFFFFFF),
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }),
+
         // Bottom [MouseRegion] that toggles UI on hover.
         Obx(() {
           bool enabled = !c.displayMore.value &&
               c.primaryDrags.value == 0 &&
               c.secondaryDrags.value == 0;
+
           return Align(
             alignment: Alignment.bottomCenter,
             child: SizedBox(
@@ -686,6 +774,26 @@ Widget desktopCall(CallController c, BuildContext context) {
                 onHover: enabled ? (d) => c.keepUi(true) : null,
                 onExit:
                     c.showUi.value && enabled ? (d) => c.keepUi(false) : null,
+              ),
+            ),
+          );
+        }),
+
+        // Top [MouseRegion] that toggles UI on hover.
+        Obx(() {
+          bool enabled =
+              c.primaryDrags.value == 0 && c.secondaryDrags.value == 0;
+
+          return Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              height: 100,
+              width: double.infinity,
+              child: MouseRegion(
+                opaque: false,
+                onEnter: enabled ? (_) => c.showHeader.value = true : null,
+                onHover: enabled ? (_) => c.showHeader.value = true : null,
+                onExit: enabled ? (_) => c.showHeader.value = false : null,
               ),
             ),
           );

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -682,7 +682,6 @@ Widget desktopCall(CallController c, BuildContext context) {
                 isOpen: c.showHeader.value && c.fullscreen.value,
                 child: Container(
                   decoration: BoxDecoration(
-                    color: Colors.transparent,
                     borderRadius: BorderRadius.circular(30),
                     boxShadow: const [
                       CustomBoxShadow(
@@ -746,24 +745,19 @@ Widget desktopCall(CallController c, BuildContext context) {
         }),
 
         // Top [MouseRegion] that toggles UI on hover.
-        Obx(() {
-          bool enabled =
-              c.primaryDrags.value == 0 && c.secondaryDrags.value == 0;
-
-          return Align(
-            alignment: Alignment.topCenter,
-            child: SizedBox(
-              height: 100,
-              width: double.infinity,
-              child: MouseRegion(
-                opaque: false,
-                onEnter: enabled ? (_) => c.showHeader.value = true : null,
-                onHover: enabled ? (_) => c.showHeader.value = true : null,
-                onExit: enabled ? (_) => c.showHeader.value = false : null,
-              ),
+        Align(
+          alignment: Alignment.topCenter,
+          child: SizedBox(
+            height: 100,
+            width: double.infinity,
+            child: MouseRegion(
+              opaque: false,
+              onEnter: (_) => c.showHeader.value = true,
+              onHover: (_) => c.showHeader.value = true,
+              onExit: (_) => c.showHeader.value = false,
             ),
-          );
-        }),
+          ),
+        ),
 
         if (c.state.value == OngoingCallState.active) ...[
           // Secondary panel itself.

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -673,6 +673,7 @@ Widget desktopCall(CallController c, BuildContext context) {
           );
         }),
 
+        // Sliding from the top info header.
         if (WebUtils.isPopup)
           Obx(() {
             return Align(

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -749,7 +749,7 @@ Widget desktopCall(CallController c, BuildContext context) {
           );
         }),
 
-        // Top [MouseRegion] that toggles title on hover.
+        // Top [MouseRegion] that toggles info header on hover.
         Align(
           alignment: Alignment.topCenter,
           child: SizedBox(

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -471,7 +471,7 @@ class CallController extends GetxController {
 
       case OngoingCallState.active:
         final Set<UserId> actualMembers =
-            members.keys.map((k) => k.userId).toSet();
+            members.keys.map((RemoteMemberId m) => m.userId).toSet();
         args['members'] = '${actualMembers.length}';
         args['allMembers'] =
             '${chat.value?.members.length ?? ('dot'.l10n * 3)}';

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -74,7 +74,7 @@ class CallController extends GetxController {
   /// Indicator whether UI is shown or not.
   final RxBool showUi = RxBool(true);
 
-  /// Indicator whether title is shown or not.
+  /// Indicator whether info header is shown or not.
   final RxBool showHeader = RxBool(true);
 
   /// Local [Participant]s in `default` mode.

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -74,7 +74,7 @@ class CallController extends GetxController {
   /// Indicator whether UI is shown or not.
   final RxBool showUi = RxBool(true);
 
-  /// Indicator whether call title is shown or not.
+  /// Indicator whether call's title is shown or not.
   final RxBool showHeader = RxBool(true);
 
   /// Local [Participant]s in `default` mode.
@@ -470,7 +470,8 @@ class CallController extends GetxController {
         break;
 
       case OngoingCallState.active:
-        final actualMembers = members.keys.map((k) => k.userId).toSet();
+        final Set<UserId> actualMembers =
+            members.keys.map((k) => k.userId).toSet();
         args['members'] = '${actualMembers.length}';
         args['allMembers'] =
             '${chat.value?.members.length ?? ('dot'.l10n * 3)}';

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -74,7 +74,7 @@ class CallController extends GetxController {
   /// Indicator whether UI is shown or not.
   final RxBool showUi = RxBool(true);
 
-  /// Indicator whether call's title is shown or not.
+  /// Indicator whether title is shown or not.
   final RxBool showHeader = RxBool(true);
 
   /// Local [Participant]s in `default` mode.
@@ -433,8 +433,9 @@ class CallController extends GetxController {
   /// enabled.
   RxBool get isRemoteAudioEnabled => _currentCall.value.isRemoteAudioEnabled;
 
-  /// Returns [Map] arguments for call's title.
-  Map<String, String> get callTitleArguments {
+  /// Constructs the arguments to pass to [L10nExtension.l10nfmt] to get the
+  /// title of this [OngoingCall].
+  Map<String, String> get titleArguments {
     final Map<String, String> args = {
       'title': chat.value?.title.value ?? ('dot'.l10n * 3),
       'state': state.value.name,
@@ -455,10 +456,10 @@ class CallController extends GetxController {
         break;
 
       case OngoingCallState.active:
-        final actualMembers = members.keys.map((k) => k.userId).toSet();
+        final Set<UserId> actualMembers =
+            members.keys.map((k) => k.userId).toSet();
         args['members'] = '${actualMembers.length}';
-        args['allMembers'] =
-            '${chat.value?.members.length ?? ('dot'.l10n * 3)}';
+        args['allMembers'] = '${chat.value?.members.length ?? 1}';
         args['duration'] = duration.value.hhMmSs();
         break;
 
@@ -540,43 +541,8 @@ class CallController extends GetxController {
 
         if (v != null) {
           void updateTitle() {
-            final Map<String, String> args = {
-              'title': v.title.value,
-              'state': state.value.name,
-            };
-
-            switch (state.value) {
-              case OngoingCallState.local:
-              case OngoingCallState.pending:
-                bool isOutgoing =
-                    (outgoing || state.value == OngoingCallState.local) &&
-                        !started;
-                if (isOutgoing) {
-                  args['type'] = 'outgoing';
-                } else if (withVideo) {
-                  args['type'] = 'video';
-                } else {
-                  args['type'] = 'audio';
-                }
-                break;
-
-              case OngoingCallState.active:
-                var actualMembers = _currentCall.value.members.keys
-                    .map((k) => k.userId)
-                    .toSet();
-                args['members'] = '${actualMembers.length}';
-                args['allMembers'] = '${v.chat.value.members.length}';
-                args['duration'] = duration.value.hhMmSs();
-                break;
-
-              case OngoingCallState.joining:
-              case OngoingCallState.ended:
-                // No-op.
-                break;
-            }
-
             WebUtils.title(
-              '\u205f​​​ \u205f​​​${'label_call_title'.l10nfmt(args)}\u205f​​​ \u205f​​​',
+              '\u205f​​​ \u205f​​​${'label_call_title'.l10nfmt(titleArguments)}\u205f​​​ \u205f​​​',
             );
           }
 

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -470,8 +470,7 @@ class CallController extends GetxController {
         break;
 
       case OngoingCallState.active:
-        final Set<UserId> actualMembers =
-            members.keys.map((RemoteMemberId m) => m.userId).toSet();
+        final actualMembers = members.keys.map((k) => k.userId).toSet();
         args['members'] = '${actualMembers.length}';
         args['allMembers'] =
             '${chat.value?.members.length ?? ('dot'.l10n * 3)}';

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -448,6 +448,44 @@ class CallController extends GetxController {
   /// enabled.
   RxBool get isRemoteAudioEnabled => _currentCall.value.isRemoteAudioEnabled;
 
+  /// Returns [Map] arguments for call's title.
+  Map<String, String> get callTitleArguments {
+    final Map<String, String> args = {
+      'title': chat.value?.title.value ?? ('dot'.l10n * 3),
+      'state': state.value.name,
+    };
+
+    switch (state.value) {
+      case OngoingCallState.local:
+      case OngoingCallState.pending:
+        bool isOutgoing =
+            (outgoing || state.value == OngoingCallState.local) && !started;
+        if (isOutgoing) {
+          args['type'] = 'outgoing';
+        } else if (withVideo) {
+          args['type'] = 'video';
+        } else {
+          args['type'] = 'audio';
+        }
+        break;
+
+      case OngoingCallState.active:
+        final actualMembers = members.keys.map((k) => k.userId).toSet();
+        args['members'] = '${actualMembers.length}';
+        args['allMembers'] =
+            '${chat.value?.members.length ?? ('dot'.l10n * 3)}';
+        args['duration'] = duration.value.hhMmSs();
+        break;
+
+      case OngoingCallState.joining:
+      case OngoingCallState.ended:
+        // No-op.
+        break;
+    }
+
+    return args;
+  }
+
   @override
   void onInit() {
     super.onInit();

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -74,6 +74,9 @@ class CallController extends GetxController {
   /// Indicator whether UI is shown or not.
   final RxBool showUi = RxBool(true);
 
+  /// Indicator whether call title is shown or not.
+  final RxBool showHeader = RxBool(true);
+
   /// Local [Participant]s in `default` mode.
   final RxList<Participant> locals = RxList([]);
 
@@ -918,12 +921,16 @@ class CallController extends GetxController {
   void keepUi([bool? enabled]) {
     _uiTimer?.cancel();
     showUi.value = isPanelOpen.value || (enabled ?? true);
+    showHeader.value = (enabled ?? true);
     if (state.value == OngoingCallState.active &&
         enabled == null &&
         !isPanelOpen.value) {
       _uiTimer = Timer(
         const Duration(seconds: _uiDuration),
-        () => showUi.value = false,
+        () {
+          showUi.value = false;
+          showHeader.value = false;
+        },
       );
     }
   }


### PR DESCRIPTION
Resolves  #74




## Summary

При переходе в фуллскрин заголовок веб-окна не отображается, отсюда в фуллскрине popup звонка нельзя узнать ни название звонка, ни его продолжительность.




## Solution

Когда нет тайтл бара, т.е. когда WebUtils.isPopup == true, добавить отображение название и длительности звонка. И отображение, и функционал уже свёрстаны, их нужно перенести с new-design-preview.



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests