### PR TITLE
Fix flaky test

### DIFF
--- a/test/e2e/features/chat/sending_status/attachments.feature
+++ b/test/e2e/features/chat/sending_status/attachments.feature
@@ -7,7 +7,7 @@ Feature: Chat attachments have correct sending status
     And I am in chat with Bob
 
   Scenario: File attachment status changes from `sending` to `sent`
-    Given I have Internet with delay of 3 seconds
+    Given I have Internet with delay of 4 seconds
 
     When I attach "test.txt" file
     And I tap `Send` button
@@ -16,7 +16,7 @@ Feature: Chat attachments have correct sending status
     And I wait until status of "test.txt" attachment is sent
 
   Scenario: Image attachment status changes from `sending` to `sent`
-    Given I have Internet with delay of 3 seconds
+    Given I have Internet with delay of 4 seconds
 
     When I attach "test.jpg" image
     And I tap `Send` button
@@ -30,7 +30,7 @@ Feature: Chat attachments have correct sending status
     And I tap `Send` button
     Then I wait until status of "test.txt" attachment is error
 
-    Given I have Internet with delay of 3 seconds
+    Given I have Internet with delay of 4 seconds
     When I long press message with "test.txt"
     And I tap `Resend` button
     Then I wait until status of "test.txt" attachment is sending
@@ -42,7 +42,7 @@ Feature: Chat attachments have correct sending status
     And I tap `Send` button
     Then I wait until status of "test.jpg" attachment is error
 
-    Given I have Internet with delay of 3 seconds
+    Given I have Internet with delay of 4 seconds
     When I long press message with "test.jpg"
     And I tap `Resend` button
     Then I wait until status of "test.jpg" attachment is sending

--- a/test/e2e/features/chat/sending_status/messages.feature
+++ b/test/e2e/features/chat/sending_status/messages.feature
@@ -12,7 +12,7 @@ Feature: Chat messages have correct sending status
     Then I wait until status of "123" message is sent
 
   Scenario: Message status changes from `sending` to `sent`
-    Given I have Internet with delay of 3 seconds
+    Given I have Internet with delay of 4 seconds
 
     When I fill `MessageField` field with "123"
     And I tap `Send` button
@@ -37,7 +37,7 @@ Feature: Chat messages have correct sending status
     And I tap `Send` button
     Then I wait until status of "123" message is error
 
-    Given I have Internet with delay of 3 seconds
+    Given I have Internet with delay of 4 seconds
     When I long press "123" message
     And I tap `Resend` button
     Then I wait until status of "123" message is sending
@@ -49,7 +49,7 @@ Feature: Chat messages have correct sending status
     And I tap `Send` button
     Then I wait until status of "123" message is error
 
-    Given I have Internet with delay of 3 seconds
+    Given I have Internet with delay of 4 seconds
     When I restart app
     And I am in chat with Bob
     Then I wait until status of "123" message is error


### PR DESCRIPTION
Resolves #153




## Synopsis

Тест на проверку статуса сообщения при его отправке иногда падает.




## Solution

Будет увеличана задержка перед отправкой сообщения, чтобы тестировщик успел заметить все статуса сообщения.




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
