### PR TITLE
Redesign style of `ChatMemberInfo` (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,16 @@ All user visible changes to this project will be documented in this file. This p
     - Media panel:
         - Dock buttons persistence. ([#159], [#137])
 
+### Changed
+
+- UI:
+    - Chat page:
+        - Redesigned system messages. ([#161], [#158])
+
 [#137]: /../../issues/137
+[#158]: /../../issues/158
 [#159]: /../../pull/159
+[#161]: /../../pull/161
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -260,23 +260,6 @@ label_add_number = Add a number
 label_add_number_hint = Write your number in format of +33 478 88 88 88
 label_account_access_will_be_lost = Account access will be lost
 label_account_created = Account is created
-label_ago_date = { $years ->
-    [0] { $months ->
-            [0] { $weeks ->
-                    [0] { $days ->
-                            [0] Today
-                            [1] Yesterday
-                            *[other] {$days} days ago
-                        }
-                    [1] A week ago
-                    *[other] {$weeks} weeks ago
-                }
-            [1] A month ago
-            *[other] {$months} months ago
-        }
-    [1] An year ago
-    *[other] {$years} years ago
-}
 label_ago = { $years ->
     [0] { $months ->
             [0] { $weeks ->
@@ -300,6 +283,23 @@ label_ago = { $years ->
             *[other] {$months} months ago
         }
     [1] an year ago
+    *[other] {$years} years ago
+}
+label_ago_date = { $years ->
+    [0] { $months ->
+            [0] { $weeks ->
+                    [0] { $days ->
+                            [0] Today
+                            [1] Yesterday
+                            *[other] {$days} days ago
+                        }
+                    [1] A week ago
+                    *[other] {$weeks} weeks ago
+                }
+            [1] A month ago
+            *[other] {$months} months ago
+        }
+    [1] An year ago
     *[other] {$years} years ago
 }
 label_application = application

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -484,5 +484,5 @@ label_video_downloaded = Video downloaded.
 label_video_saved_to_gallery = Video saved to gallery.
 label_you = You
 label_you_were_added_to_group = You were added to the group
-label_was_added = was added
-label_was_removed = was removed
+label_was_added = {$who} was added
+label_was_removed = {$who} was removed

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -260,6 +260,23 @@ label_add_number = Add a number
 label_add_number_hint = Write your number in format of +33 478 88 88 88
 label_account_access_will_be_lost = Account access will be lost
 label_account_created = Account is created
+label_ago_date = { $years ->
+    [0] { $months ->
+            [0] { $weeks ->
+                    [0] { $days ->
+                            [0] Today
+                            [1] Yesterday
+                            *[other] {$days} days ago
+                        }
+                    [1] A week ago
+                    *[other] {$weeks} weeks ago
+                }
+            [1] A month ago
+            *[other] {$months} months ago
+        }
+    [1] An year ago
+    *[other] {$years} years ago
+}
 label_ago = { $years ->
     [0] { $months ->
             [0] { $weeks ->
@@ -350,6 +367,7 @@ label_direct_chat_link_in_chat_description =
     - visit group profile,
     - send messages to group chat,
     - make calls
+label_dialog_created = Dialog created
 label_drop_here =
     Drop here
     to upload
@@ -361,6 +379,7 @@ label_edit_message_hint = No text
 label_email_confirmation_code_was_sent =
       Confirmation code was send to your Email and/or to your phone
 label_emails = Emails
+label_empty_message = Empty message
 label_enable_popup_calls = Display calls in popup windows
 label_enter_confirmation_code = Confirmation code
 label_enter_confirmation_code_hint = Enter confirmation code
@@ -370,6 +389,7 @@ label_favorite_contacts = Favorite
 label_file = File
 label_forwarded_message = Forwarded message
 label_gallery = Gallery
+label_group_created = Group created
 label_hidden = Status is hidden
 label_hint_drag_n_drop_buttons =
     Add and remove elements of the control panel by drag-and-drop.
@@ -454,10 +474,15 @@ label_typing = is typing
 label_typings = are typing
 label_unconfirmed = Unconfirmed
 label_unknown_page = Unknown page
-label_unread_messages = Unread messages
+label_unread_messages = { $quantity ->
+    [1] {$quantity} unread message
+    *[other] {$quantity} unread messages
+}
 label_video = Video
 label_video_call = Video call
 label_video_downloaded = Video downloaded.
 label_video_saved_to_gallery = Video saved to gallery.
 label_you = You
 label_you_were_added_to_group = You were added to the group
+label_was_added = was added
+label_was_removed = was removed

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -349,6 +349,7 @@ label_delete_for_everyone = Delete for everyone
 label_delete_for_me = Delete for me
 label_delete_message = Delete the message?
 label_delivered = Delivered
+label_dialog_created = Dialog created
 label_direct_chat_link = Direct chat link
 label_direct_chat_link_description =
     Users who came via a direct link to
@@ -367,7 +368,6 @@ label_direct_chat_link_in_chat_description =
     - visit group profile,
     - send messages to group chat,
     - make calls
-label_dialog_created = Dialog created
 label_drop_here =
     Drop here
     to upload
@@ -482,7 +482,7 @@ label_video = Video
 label_video_call = Video call
 label_video_downloaded = Video downloaded.
 label_video_saved_to_gallery = Video saved to gallery.
-label_you = You
-label_you_were_added_to_group = You were added to the group
 label_was_added = {$who} was added
 label_was_removed = {$who} was removed
+label_you = You
+label_you_were_added_to_group = You were added to the group

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -365,6 +365,7 @@ label_delete_for_everyone = Удалить для всех
 label_delete_for_me = Удалить для меня
 label_delete_message = Удалить сообщение?
 label_delivered = Доставлено
+label_dialog_created = Диалог создан
 label_direct_chat_link = Прямая ссылка на чат
 label_direct_chat_link_description =
     Пользователи, пришедшие по прямой
@@ -385,7 +386,6 @@ label_direct_chat_link_in_chat_description =
     - просматривать профиль группы,
     - отправлять сообщения в чат группы,
     - совершать звонки
-label_dialog_created = Диалог создан
 label_drop_here =
     Перетащите сюда,
     чтобы прикрепить
@@ -500,7 +500,7 @@ label_video = Видео
 label_video_call = Видеозвонок
 label_video_downloaded = Видео загружено.
 label_video_saved_to_gallery = Видео сохранено в галерею.
+label_was_added = {$who} был(а) добавлен(а)
+label_was_removed = {$who} был(а) удален(а)
 label_you = Вы
 label_you_were_added_to_group = Вас добавили в группу
-label_was_added = {$who} был добавлен
-label_was_removed = {$who} был удален

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -264,28 +264,6 @@ label_add_number = Добавить номер
 label_add_number_hint = Напишите номер в формате +33 478 88 88 88
 label_account_access_will_be_lost = Доступ к аккаунту будет утерян
 label_account_created = Аккаунт создан
-label_ago_date = { $years ->
-    [0] { $months ->
-            [0] { $weeks ->
-                    [0] { $days ->
-                            [0] Сегодня
-                            [1] Вчера
-                            [2] Позавчера
-                            [few] {$days} дня назад
-                            *[other] {$days} дней назад
-                        }
-                    [1] Неделю назад
-                    [few] {$weeks} недели назад
-                    *[other] {$weeks} недель
-                }
-            [1] Месяц назад
-            [few] {$months} месяца назад
-            *[other] {$months} месяцев назад
-        }
-    [1] Год назад
-    [few] {$years} года назад
-    *[other] {$years} лет назад
-}
 label_ago = { $years ->
     [0] { $months ->
             [0] { $weeks ->
@@ -315,6 +293,28 @@ label_ago = { $years ->
             *[other] {$months} месяцев назад
         }
     [1] год назад
+    [few] {$years} года назад
+    *[other] {$years} лет назад
+}
+label_ago_date = { $years ->
+    [0] { $months ->
+            [0] { $weeks ->
+                    [0] { $days ->
+                            [0] Сегодня
+                            [1] Вчера
+                            [2] Позавчера
+                            [few] {$days} дня назад
+                            *[other] {$days} дней назад
+                        }
+                    [1] Неделю назад
+                    [few] {$weeks} недели назад
+                    *[other] {$weeks} недель
+                }
+            [1] Месяц назад
+            [few] {$months} месяца назад
+            *[other] {$months} месяцев назад
+        }
+    [1] Год назад
     [few] {$years} года назад
     *[other] {$years} лет назад
 }

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -264,6 +264,28 @@ label_add_number = Добавить номер
 label_add_number_hint = Напишите номер в формате +33 478 88 88 88
 label_account_access_will_be_lost = Доступ к аккаунту будет утерян
 label_account_created = Аккаунт создан
+label_ago_date = { $years ->
+    [0] { $months ->
+            [0] { $weeks ->
+                    [0] { $days ->
+                            [0] Сегодня
+                            [1] Вчера
+                            [2] Позавчера
+                            [few] {$days} дня назад
+                            *[other] {$days} дней назад
+                        }
+                    [1] Неделю назад
+                    [few] {$weeks} недели назад
+                    *[other] {$weeks} недель
+                }
+            [1] Месяц назад
+            [few] {$months} месяца назад
+            *[other] {$months} месяцев назад
+        }
+    [1] Год назад
+    [few] {$years} года назад
+    *[other] {$years} лет назад
+}
 label_ago = { $years ->
     [0] { $months ->
             [0] { $weeks ->
@@ -363,6 +385,7 @@ label_direct_chat_link_in_chat_description =
     - просматривать профиль группы,
     - отправлять сообщения в чат группы,
     - совершать звонки
+label_dialog_created = Диалог создан
 label_drop_here =
     Перетащите сюда,
     чтобы прикрепить
@@ -374,6 +397,7 @@ label_edit_message_hint = Без текста
 label_email_confirmation_code_was_sent =
     Код подтверждения был отправлен Вам на Email и/или на телефон
 label_emails = Эл.почта
+label_empty_message = Пустое сообщение
 label_enable_popup_calls = Отображать звонки в отдельных окнах
 label_enter_confirmation_code = Проверочный код
 label_enter_confirmation_code_hint = Введите проверочный код
@@ -383,6 +407,7 @@ label_favorite_contacts = Избранные
 label_file = Файл
 label_forwarded_message = Пересланное сообщение
 label_gallery = Галерея
+label_group_created = Группа создана
 label_hidden = Статус скрыт
 label_hint_drag_n_drop_buttons =
     Элементы панели управления могут быть добавлены и удалены простым перетаскиванием.
@@ -467,10 +492,15 @@ label_typing = печатает
 label_typings = печатают
 label_unconfirmed = Неподтвержденный
 label_unknown_page = Страница не найдена
-label_unread_messages = Непрочитанные сообщения
+label_unread_messages = { $quantity ->
+    [1] {$quantity} непрочитанное сообщение
+    *[other] {$quantity} непрочитанных сообщения
+}
 label_video = Видео
 label_video_call = Видеозвонок
 label_video_downloaded = Видео загружено.
 label_video_saved_to_gallery = Видео сохранено в галерею.
 label_you = Вы
 label_you_were_added_to_group = Вас добавили в группу
+label_was_added = был добавлен
+label_was_removed = был удален

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -502,5 +502,5 @@ label_video_downloaded = Видео загружено.
 label_video_saved_to_gallery = Видео сохранено в галерею.
 label_you = Вы
 label_you_were_added_to_group = Вас добавили в группу
-label_was_added = был добавлен
-label_was_removed = был удален
+label_was_added = {$who} был добавлен
+label_was_removed = {$who} был удален

--- a/lib/themes.dart
+++ b/lib/themes.dart
@@ -49,6 +49,14 @@ class Themes {
             contextMenuHoveredColor: const Color(0xFFE5E7E9),
             contextMenuRadius: BorderRadius.circular(10),
             sidebarColor: Colors.white.withOpacity(0.4),
+            systemMessageTextStyle: GoogleFonts.roboto(
+              color: const Color(0xFF888888),
+              fontSize: 13,
+              fontWeight: FontWeight.w300,
+            ),
+            systemMessageBorder:
+                Border.all(color: const Color(0xFFD2D2D2), width: 0.5),
+            systemMessageColor: const Color(0xFFEFEFEF).withOpacity(0.95),
           ),
         ],
         colorScheme: colors,
@@ -259,6 +267,9 @@ class Style extends ThemeExtension<Style> {
     required this.contextMenuHoveredColor,
     required this.contextMenuRadius,
     required this.sidebarColor,
+    required this.systemMessageTextStyle,
+    required this.systemMessageBorder,
+    required this.systemMessageColor,
   });
 
   /// [Color] of the modal background barrier color.
@@ -282,6 +293,15 @@ class Style extends ThemeExtension<Style> {
   /// [Color] of the [HomeView]'s side bar.
   final Color sidebarColor;
 
+  /// [TextStyle] to use for messages in [ChatView].
+  final TextStyle systemMessageTextStyle;
+
+  /// [Border] of the [ChatView] messages.
+  final Border systemMessageBorder;
+
+  /// [Color] of the [ChatView] messages.
+  final Color systemMessageColor;
+
   @override
   ThemeExtension<Style> copyWith({
     Color? barrierColor,
@@ -291,6 +311,9 @@ class Style extends ThemeExtension<Style> {
     Color? contextMenuHoveredColor,
     BorderRadius? contextMenuRadius,
     Color? sidebarColor,
+    TextStyle? systemMessageTextStyle,
+    Border? systemMessageBorder,
+    Color? systemMessageColor,
   }) {
     return Style(
       barrierColor: barrierColor ?? this.barrierColor,
@@ -302,6 +325,10 @@ class Style extends ThemeExtension<Style> {
           contextMenuHoveredColor ?? this.contextMenuHoveredColor,
       contextMenuRadius: contextMenuRadius ?? this.contextMenuRadius,
       sidebarColor: sidebarColor ?? this.sidebarColor,
+      systemMessageTextStyle:
+          systemMessageTextStyle ?? this.systemMessageTextStyle,
+      systemMessageBorder: systemMessageBorder ?? this.systemMessageBorder,
+      systemMessageColor: systemMessageColor ?? this.systemMessageColor,
     );
   }
 
@@ -328,6 +355,15 @@ class Style extends ThemeExtension<Style> {
       contextMenuRadius:
           BorderRadius.lerp(contextMenuRadius, other.contextMenuRadius, t)!,
       sidebarColor: Color.lerp(sidebarColor, other.sidebarColor, t)!,
+      systemMessageTextStyle: TextStyle.lerp(
+        systemMessageTextStyle,
+        other.systemMessageTextStyle,
+        t,
+      )!,
+      systemMessageBorder:
+          Border.lerp(systemMessageBorder, other.systemMessageBorder, t)!,
+      systemMessageColor:
+          Color.lerp(systemMessageColor, other.systemMessageColor, t)!,
     );
   }
 }

--- a/lib/themes.dart
+++ b/lib/themes.dart
@@ -49,14 +49,14 @@ class Themes {
             contextMenuHoveredColor: const Color(0xFFE5E7E9),
             contextMenuRadius: BorderRadius.circular(10),
             sidebarColor: Colors.white.withOpacity(0.4),
-            systemMessageTextStyle: GoogleFonts.roboto(
+            systemMessageBorder:
+                Border.all(color: const Color(0xFFD2D2D2), width: 0.5),
+            systemMessageColor: const Color(0xFFEFEFEF).withOpacity(0.95),
+            systemMessageStyle: GoogleFonts.roboto(
               color: const Color(0xFF888888),
               fontSize: 13,
               fontWeight: FontWeight.w300,
             ),
-            systemMessageBorder:
-                Border.all(color: const Color(0xFFD2D2D2), width: 0.5),
-            systemMessageColor: const Color(0xFFEFEFEF).withOpacity(0.95),
           ),
         ],
         colorScheme: colors,
@@ -267,9 +267,9 @@ class Style extends ThemeExtension<Style> {
     required this.contextMenuHoveredColor,
     required this.contextMenuRadius,
     required this.sidebarColor,
-    required this.systemMessageTextStyle,
     required this.systemMessageBorder,
     required this.systemMessageColor,
+    required this.systemMessageStyle,
   });
 
   /// [Color] of the modal background barrier color.
@@ -293,14 +293,14 @@ class Style extends ThemeExtension<Style> {
   /// [Color] of the [HomeView]'s side bar.
   final Color sidebarColor;
 
-  /// [TextStyle] to use for messages [ChatMemberInfo].
-  final TextStyle systemMessageTextStyle;
-
-  /// [Border] of the messages [ChatMemberInfo].
+  /// [Border] to apply to system messages.
   final Border systemMessageBorder;
 
-  /// [Color] of the messages [ChatMemberInfo].
+  /// [Color] of system messages.
   final Color systemMessageColor;
+
+  /// [TextStyle] of system messages.
+  final TextStyle systemMessageStyle;
 
   @override
   ThemeExtension<Style> copyWith({
@@ -311,9 +311,9 @@ class Style extends ThemeExtension<Style> {
     Color? contextMenuHoveredColor,
     BorderRadius? contextMenuRadius,
     Color? sidebarColor,
-    TextStyle? systemMessageTextStyle,
     Border? systemMessageBorder,
     Color? systemMessageColor,
+    TextStyle? systemMessageStyle,
   }) {
     return Style(
       barrierColor: barrierColor ?? this.barrierColor,
@@ -325,10 +325,9 @@ class Style extends ThemeExtension<Style> {
           contextMenuHoveredColor ?? this.contextMenuHoveredColor,
       contextMenuRadius: contextMenuRadius ?? this.contextMenuRadius,
       sidebarColor: sidebarColor ?? this.sidebarColor,
-      systemMessageTextStyle:
-          systemMessageTextStyle ?? this.systemMessageTextStyle,
       systemMessageBorder: systemMessageBorder ?? this.systemMessageBorder,
       systemMessageColor: systemMessageColor ?? this.systemMessageColor,
+      systemMessageStyle: systemMessageStyle ?? this.systemMessageStyle,
     );
   }
 
@@ -355,15 +354,15 @@ class Style extends ThemeExtension<Style> {
       contextMenuRadius:
           BorderRadius.lerp(contextMenuRadius, other.contextMenuRadius, t)!,
       sidebarColor: Color.lerp(sidebarColor, other.sidebarColor, t)!,
-      systemMessageTextStyle: TextStyle.lerp(
-        systemMessageTextStyle,
-        other.systemMessageTextStyle,
-        t,
-      )!,
       systemMessageBorder:
           Border.lerp(systemMessageBorder, other.systemMessageBorder, t)!,
       systemMessageColor:
           Color.lerp(systemMessageColor, other.systemMessageColor, t)!,
+      systemMessageStyle: TextStyle.lerp(
+        systemMessageStyle,
+        other.systemMessageStyle,
+        t,
+      )!,
     );
   }
 }

--- a/lib/themes.dart
+++ b/lib/themes.dart
@@ -293,13 +293,13 @@ class Style extends ThemeExtension<Style> {
   /// [Color] of the [HomeView]'s side bar.
   final Color sidebarColor;
 
-  /// [TextStyle] to use for messages in [ChatView].
+  /// [TextStyle] to use for messages [ChatMemberInfo].
   final TextStyle systemMessageTextStyle;
 
-  /// [Border] of the [ChatView] messages.
+  /// [Border] of the messages [ChatMemberInfo].
   final Border systemMessageBorder;
 
-  /// [Color] of the [ChatView] messages.
+  /// [Color] of the messages [ChatMemberInfo].
   final Color systemMessageColor;
 
   @override

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -430,10 +430,11 @@ class ChatController extends GetxController {
   Future<void> _fetchChat() async {
     status.value = RxStatus.loading();
     chat = await _chatService.get(id);
-    unreadMessages = chat?.chat.value.unreadCount ?? 0;
     if (chat == null) {
       status.value = RxStatus.empty();
     } else {
+      unreadMessages = chat!.chat.value.unreadCount;
+
       // Adds the provided [ChatItem] to the [elements].
       void add(Rx<ChatItem> e) {
         ChatItem item = e.value;

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -146,6 +146,9 @@ class ChatController extends GetxController {
   /// Maximum [Duration] between some [ChatForward]s to consider them grouped.
   static const Duration groupForwardThreshold = Duration(milliseconds: 5);
 
+  /// Count of [ChatItem]s unread by the authenticated [MyUser] in this [chat].
+  int unreadMessages = 0;
+
   /// Top visible [FlutterListViewItemPosition] in the [FlutterListView].
   FlutterListViewItemPosition? _topVisibleItem;
 
@@ -427,6 +430,7 @@ class ChatController extends GetxController {
   Future<void> _fetchChat() async {
     status.value = RxStatus.loading();
     chat = await _chatService.get(id);
+    unreadMessages = chat?.chat.value.unreadCount ?? 0;
     if (chat == null) {
       status.value = RxStatus.empty();
     } else {

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -35,6 +35,7 @@ import '/domain/repository/chat.dart';
 import '/domain/repository/user.dart';
 import '/l10n/l10n.dart';
 import '/routes.dart';
+import '/themes.dart';
 import '/ui/page/call/widget/animated_dots.dart';
 import '/ui/page/home/widget/avatar.dart';
 import '/ui/widget/animations.dart';
@@ -250,20 +251,50 @@ class _ChatViewState extends State<ChatView>
                                           c.elements.values.elementAt(i);
 
                                       if (e is UnreadMessagesElement) {
-                                        return Container(
-                                          color: const Color(0x33000000),
-                                          padding: const EdgeInsets.all(4),
-                                          margin: const EdgeInsets.symmetric(
-                                            vertical: 4,
-                                          ),
-                                          child: Center(
-                                            child: Text(
-                                              'label_unread_messages'.l10n,
-                                              style: const TextStyle(
-                                                color: Colors.white,
+                                        final Style? style = Theme.of(context)
+                                            .extension<Style>();
+
+                                        return Padding(
+                                          padding: const EdgeInsets.symmetric(
+                                              vertical: 24),
+                                          child: Row(
+                                            children: [
+                                              const SizedBox(width: 8),
+                                              Expanded(
+                                                child: Container(
+                                                  width: double.infinity,
+                                                  padding: const EdgeInsets
+                                                      .symmetric(
+                                                    horizontal: 12,
+                                                    vertical: 8,
+                                                  ),
+                                                  decoration: BoxDecoration(
+                                                    borderRadius:
+                                                        BorderRadius.circular(
+                                                            15),
+                                                    border: style
+                                                        ?.systemMessageBorder,
+                                                    color: style
+                                                        ?.systemMessageColor,
+                                                  ),
+                                                  child: Center(
+                                                    child: Text(
+                                                      'label_unread_messages'
+                                                          .l10nfmt({
+                                                        'quantity':
+                                                            c.unreadMessages
+                                                      }),
+                                                      style: const TextStyle(
+                                                        fontSize: 13,
+                                                        color:
+                                                            Color(0xFF888888),
+                                                      ),
+                                                    ),
+                                                  ),
+                                                ),
                                               ),
-                                              textAlign: TextAlign.center,
-                                            ),
+                                              const SizedBox(width: 8),
+                                            ],
                                           ),
                                         );
                                       } else if (e is ChatMessageElement ||
@@ -486,24 +517,27 @@ class _ChatViewState extends State<ChatView>
 
   /// Returns a centered [time] label.
   Widget _timeLabel(DateTime time) {
+    final Style? style = Theme.of(context).extension<Style>();
+
     return Column(
       children: [
-        const SizedBox(height: 7),
+        const SizedBox(height: 24),
         SwipeableStatus(
           animation: _animation,
           asStack: true,
-          padding: EdgeInsets.zero,
+          padding: const EdgeInsets.only(right: 8),
           crossAxisAlignment: CrossAxisAlignment.center,
           swipeable: Padding(
-            padding: const EdgeInsets.only(right: 8),
+            padding: const EdgeInsets.only(right: 4),
             child: Text(DateFormat('dd.MM.yy').format(time)),
           ),
           child: Center(
             child: Container(
-              padding: const EdgeInsets.fromLTRB(6, 4, 6, 4),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(30),
-                color: Colors.white,
+                borderRadius: BorderRadius.circular(15),
+                border: style?.systemMessageBorder,
+                color: style?.systemMessageColor,
               ),
               child: Text(
                 time.toRelative(),
@@ -512,7 +546,7 @@ class _ChatViewState extends State<ChatView>
             ),
           ),
         ),
-        const SizedBox(height: 7),
+        const SizedBox(height: 24),
       ],
     );
   }
@@ -1204,10 +1238,6 @@ extension DateTimeToRelative on DateTime {
     DateTime relative = now ?? DateTime.now();
     int days = relative.julianDayNumber() - local.julianDayNumber();
 
-    String time =
-        '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
-    String date = '';
-
     int months = 0;
     if (days >= 28) {
       months =
@@ -1217,16 +1247,12 @@ extension DateTimeToRelative on DateTime {
       }
     }
 
-    if (days > 0) {
-      date = 'label_ago'.l10nfmt({
-        'years': months ~/ 12,
-        'months': months,
-        'weeks': days ~/ 7,
-        'days': days,
-      });
-    }
-
-    return date.isEmpty ? time : '${date.capitalizeFirst!}, $time';
+    return 'label_ago_date'.l10nfmt({
+      'years': months ~/ 12,
+      'months': months,
+      'weeks': days ~/ 7,
+      'days': days,
+    });
   }
 
   /// Returns a Julian day number of this [DateTime].

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -251,52 +251,7 @@ class _ChatViewState extends State<ChatView>
                                           c.elements.values.elementAt(i);
 
                                       if (e is UnreadMessagesElement) {
-                                        final Style? style = Theme.of(context)
-                                            .extension<Style>();
-
-                                        return Padding(
-                                          padding: const EdgeInsets.symmetric(
-                                              vertical: 24),
-                                          child: Row(
-                                            children: [
-                                              const SizedBox(width: 8),
-                                              Expanded(
-                                                child: Container(
-                                                  width: double.infinity,
-                                                  padding: const EdgeInsets
-                                                      .symmetric(
-                                                    horizontal: 12,
-                                                    vertical: 8,
-                                                  ),
-                                                  decoration: BoxDecoration(
-                                                    borderRadius:
-                                                        BorderRadius.circular(
-                                                            15),
-                                                    border: style
-                                                        ?.systemMessageBorder,
-                                                    color: style
-                                                        ?.systemMessageColor,
-                                                  ),
-                                                  child: Center(
-                                                    child: Text(
-                                                      'label_unread_messages'
-                                                          .l10nfmt({
-                                                        'quantity':
-                                                            c.unreadMessages
-                                                      }),
-                                                      style: const TextStyle(
-                                                        fontSize: 13,
-                                                        color:
-                                                            Color(0xFF888888),
-                                                      ),
-                                                    ),
-                                                  ),
-                                                ),
-                                              ),
-                                              const SizedBox(width: 8),
-                                            ],
-                                          ),
-                                        );
+                                        return _unreadMessages(context, c);
                                       } else if (e is ChatMessageElement ||
                                           e is ChatCallElement ||
                                           e is ChatMemberInfoElement) {
@@ -1224,6 +1179,45 @@ class _ChatViewState extends State<ChatView>
       }
       c.horizontalScrollTimer.value = null;
     });
+  }
+
+  /// Builds a visual representation of a [UnreadMessagesElement].
+  Widget _unreadMessages(BuildContext context, ChatController c) {
+    final Style? style = Theme.of(context).extension<Style>();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Row(
+        children: [
+          const SizedBox(width: 8),
+          Expanded(
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12,
+                vertical: 8,
+              ),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(15),
+                border: style?.systemMessageBorder,
+                color: style?.systemMessageColor,
+              ),
+              child: Center(
+                child: Text(
+                  'label_unread_messages'
+                      .l10nfmt({'quantity': c.unreadMessages}),
+                  style: const TextStyle(
+                    fontSize: 13,
+                    color: Color(0xFF888888),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -474,35 +474,32 @@ class _ChatViewState extends State<ChatView>
   Widget _timeLabel(DateTime time) {
     final Style? style = Theme.of(context).extension<Style>();
 
-    return Column(
-      children: [
-        const SizedBox(height: 24),
-        SwipeableStatus(
-          animation: _animation,
-          asStack: true,
-          padding: const EdgeInsets.only(right: 8),
-          crossAxisAlignment: CrossAxisAlignment.center,
-          swipeable: Padding(
-            padding: const EdgeInsets.only(right: 4),
-            child: Text(DateFormat('dd.MM.yy').format(time)),
-          ),
-          child: Center(
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(15),
-                border: style?.systemMessageBorder,
-                color: style?.systemMessageColor,
-              ),
-              child: Text(
-                time.toRelative(),
-                style: const TextStyle(color: Color(0xFF888888)),
-              ),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: SwipeableStatus(
+        animation: _animation,
+        asStack: true,
+        padding: const EdgeInsets.only(right: 8),
+        crossAxisAlignment: CrossAxisAlignment.center,
+        swipeable: Padding(
+          padding: const EdgeInsets.only(right: 4),
+          child: Text(DateFormat('dd.MM.yy').format(time)),
+        ),
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(15),
+              border: style?.systemMessageBorder,
+              color: style?.systemMessageColor,
+            ),
+            child: Text(
+              time.toRelative(),
+              style: const TextStyle(color: Color(0xFF888888)),
             ),
           ),
         ),
-        const SizedBox(height: 24),
-      ],
+      ),
     );
   }
 
@@ -1181,7 +1178,7 @@ class _ChatViewState extends State<ChatView>
     });
   }
 
-  /// Builds a visual representation of a [UnreadMessagesElement].
+  /// Builds a visual representation of an [UnreadMessagesElement].
   Widget _unreadMessages(BuildContext context, ChatController c) {
     final Style? style = Theme.of(context).extension<Style>();
 

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -251,7 +251,7 @@ class _ChatViewState extends State<ChatView>
                                           c.elements.values.elementAt(i);
 
                                       if (e is UnreadMessagesElement) {
-                                        return _unreadMessages(context, c);
+                                        return _unreadLabel(context, c);
                                       } else if (e is ChatMessageElement ||
                                           e is ChatCallElement ||
                                           e is ChatMemberInfoElement) {
@@ -472,7 +472,7 @@ class _ChatViewState extends State<ChatView>
 
   /// Returns a centered [time] label.
   Widget _timeLabel(DateTime time) {
-    final Style? style = Theme.of(context).extension<Style>();
+    final Style style = Theme.of(context).extension<Style>()!;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 24),
@@ -490,13 +490,10 @@ class _ChatViewState extends State<ChatView>
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(15),
-              border: style?.systemMessageBorder,
-              color: style?.systemMessageColor,
+              border: style.systemMessageBorder,
+              color: style.systemMessageColor,
             ),
-            child: Text(
-              time.toRelative(),
-              style: const TextStyle(color: Color(0xFF888888)),
-            ),
+            child: Text(time.toRelative(), style: style.systemMessageStyle),
           ),
         ),
       ),
@@ -1179,40 +1176,23 @@ class _ChatViewState extends State<ChatView>
   }
 
   /// Builds a visual representation of an [UnreadMessagesElement].
-  Widget _unreadMessages(BuildContext context, ChatController c) {
-    final Style? style = Theme.of(context).extension<Style>();
+  Widget _unreadLabel(BuildContext context, ChatController c) {
+    final Style style = Theme.of(context).extension<Style>()!;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 24),
-      child: Row(
-        children: [
-          const SizedBox(width: 8),
-          Expanded(
-            child: Container(
-              width: double.infinity,
-              padding: const EdgeInsets.symmetric(
-                horizontal: 12,
-                vertical: 8,
-              ),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(15),
-                border: style?.systemMessageBorder,
-                color: style?.systemMessageColor,
-              ),
-              child: Center(
-                child: Text(
-                  'label_unread_messages'
-                      .l10nfmt({'quantity': c.unreadMessages}),
-                  style: const TextStyle(
-                    fontSize: 13,
-                    color: Color(0xFF888888),
-                  ),
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(width: 8),
-        ],
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 24),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(15),
+        border: style.systemMessageBorder,
+        color: style.systemMessageColor,
+      ),
+      child: Center(
+        child: Text(
+          'label_unread_messages'.l10nfmt({'quantity': c.unreadMessages}),
+          style: style.systemMessageStyle,
+        ),
       ),
     );
   }

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -152,7 +152,9 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
   /// whether the provided [ChatItem] was read by the authenticated [User].
   bool get _isRead {
     final Chat? chat = widget.chat.value;
-    if (chat == null) return false;
+    if (chat == null) {
+      return false;
+    }
 
     if (_fromMe) {
       return chat.isRead(widget.item.value, widget.me);
@@ -161,7 +163,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
     }
   }
 
-  /// Indicates whether the authenticated [User] has posted this [ChatItem].
+  /// Indicates whether this [ChatItemWidget.item] was posted by the
+  /// authenticated [MyUser].
   bool get _fromMe => widget.item.value.authorId == widget.me;
 
   @override
@@ -218,7 +221,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
   Widget _renderAsChatMemberInfo() {
     final Style? style = Theme.of(context).extension<Style>();
     final ChatMemberInfo message = widget.item.value as ChatMemberInfo;
-    Widget content = Text('${message.action}');
+
+    Widget? content;
 
     switch (message.action) {
       case ChatMemberInfoAction.created:
@@ -233,54 +237,56 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
         break;
 
       case ChatMemberInfoAction.added:
-        content = Text('label_was_added'
-            .l10nfmt({'who': '${message.user.name ?? message.user.num}'}));
+        content = Text(
+          'label_was_added'
+              .l10nfmt({'who': '${message.user.name ?? message.user.num}'}),
+        );
         break;
 
       case ChatMemberInfoAction.removed:
-        content = Text('label_was_removed'
-            .l10nfmt({'who': '${message.user.name ?? message.user.num}'}));
+        content = Text(
+          'label_was_removed'
+              .l10nfmt({'who': '${message.user.name ?? message.user.num}'}),
+        );
         break;
 
       case ChatMemberInfoAction.artemisUnknown:
         // No-op.
         break;
     }
+
     final bool isSent = widget.item.value.status.value == SendingStatus.sent;
 
-    return Column(
-      children: [
-        const SizedBox(height: 8),
-        SwipeableStatus(
-          animation: widget.animation,
-          asStack: true,
-          isSent: isSent && _fromMe,
-          isDelivered: isSent &&
-              _fromMe &&
-              widget.chat.value?.lastDelivery.isBefore(widget.item.value.at) ==
-                  false,
-          isRead: isSent && (!_fromMe || _isRead),
-          isError: message.status.value == SendingStatus.error,
-          isSending: message.status.value == SendingStatus.sending,
-          swipeable:
-              Text(DateFormat.Hm().format(widget.item.value.at.val.toLocal())),
-          child: Center(
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(15),
-                border: style?.systemMessageBorder,
-                color: style?.systemMessageColor,
-              ),
-              child: DefaultTextStyle.merge(
-                style: style?.systemMessageTextStyle,
-                child: content,
-              ),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: SwipeableStatus(
+        animation: widget.animation,
+        asStack: true,
+        isSent: isSent && _fromMe,
+        isDelivered: isSent &&
+            _fromMe &&
+            widget.chat.value?.lastDelivery.isBefore(widget.item.value.at) ==
+                false,
+        isRead: isSent && (!_fromMe || _isRead),
+        isError: message.status.value == SendingStatus.error,
+        isSending: message.status.value == SendingStatus.sending,
+        swipeable:
+            Text(DateFormat.Hm().format(widget.item.value.at.val.toLocal())),
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(15),
+              border: style?.systemMessageBorder,
+              color: style?.systemMessageColor,
+            ),
+            child: DefaultTextStyle.merge(
+              style: style?.systemMessageTextStyle,
+              child: content ?? Text('${message.action}'),
             ),
           ),
         ),
-        const SizedBox(height: 8),
-      ],
+      ),
     );
   }
 

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -147,10 +147,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
   /// corresponding [Widget].
   List<GlobalKey> _galleryKeys = [];
 
-  /// Indicates whether the provided [ChatItem] was read by some [User].
-  ///
-  /// If [User] is authenticated [ChatItem] was read some [User] other
-  /// than authenticated, otherwise was read by the authenticated [User].
+  /// Indicates whether this [ChatItem] was read by any [User].
   bool get _isRead {
     final Chat? chat = widget.chat.value;
     if (chat == null) {
@@ -220,10 +217,10 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
 
   /// Renders [widget.item] as [ChatMemberInfo].
   Widget _renderAsChatMemberInfo() {
-    final Style? style = Theme.of(context).extension<Style>();
+    final Style style = Theme.of(context).extension<Style>()!;
     final ChatMemberInfo message = widget.item.value as ChatMemberInfo;
 
-    Widget? content;
+    final Widget content;
 
     switch (message.action) {
       case ChatMemberInfoAction.created:
@@ -249,7 +246,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
         break;
 
       case ChatMemberInfoAction.artemisUnknown:
-        // No-op.
+        content = Text('${message.action}');
         break;
     }
 
@@ -263,24 +260,22 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
         isSent: isSent && _fromMe,
         isDelivered: isSent &&
             _fromMe &&
-            widget.chat.value?.lastDelivery.isBefore(widget.item.value.at) ==
-                false,
+            widget.chat.value?.lastDelivery.isBefore(message.at) == false,
         isRead: isSent && (!_fromMe || _isRead),
         isError: message.status.value == SendingStatus.error,
         isSending: message.status.value == SendingStatus.sending,
-        swipeable:
-            Text(DateFormat.Hm().format(widget.item.value.at.val.toLocal())),
+        swipeable: Text(DateFormat.Hm().format(message.at.val.toLocal())),
         child: Center(
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(15),
-              border: style?.systemMessageBorder,
-              color: style?.systemMessageColor,
+              border: style.systemMessageBorder,
+              color: style.systemMessageColor,
             ),
-            child: DefaultTextStyle.merge(
-              style: style?.systemMessageTextStyle,
-              child: content ?? Text('${message.action}'),
+            child: DefaultTextStyle(
+              style: style.systemMessageStyle,
+              child: content,
             ),
           ),
         ),

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -147,9 +147,10 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
   /// corresponding [Widget].
   List<GlobalKey> _galleryKeys = [];
 
-  /// If [User] is authenticated indicates whether the provided [ChatItem]
-  /// was read by some [User] other than authenticated, otherwise indicates
-  /// whether the provided [ChatItem] was read by the authenticated [User].
+  /// Indicates whether the provided [ChatItem] was read by some [User].
+  ///
+  /// If [User] is authenticated [ChatItem] was read some [User] other
+  /// than authenticated, otherwise was read by the authenticated [User].
   bool get _isRead {
     final Chat? chat = widget.chat.value;
     if (chat == null) {
@@ -164,7 +165,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
   }
 
   /// Indicates whether this [ChatItemWidget.item] was posted by the
-  /// authenticated [MyUser].
+  /// authenticated [User].
   bool get _fromMe => widget.item.value.authorId == widget.me;
 
   @override
@@ -229,10 +230,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
         if (widget.chat.value?.isGroup == true) {
           content = Text('label_group_created'.l10n);
         } else {
-          content = Text(
-            'label_dialog_created'.l10n,
-            style: const TextStyle(color: Color(0xFF888888)),
-          );
+          content = Text('label_dialog_created'.l10n);
         }
         break;
 

--- a/lib/ui/page/home/page/chat/widget/swipeable_status.dart
+++ b/lib/ui/page/home/page/chat/widget/swipeable_status.dart
@@ -16,6 +16,8 @@
 
 import 'package:flutter/material.dart';
 
+import '/themes.dart';
+
 /// Swipeable widget allowing its [child] to be swiped to reveal [swipeable]
 /// with a status next to it.
 class SwipeableStatus extends StatelessWidget {
@@ -31,11 +33,11 @@ class SwipeableStatus extends StatelessWidget {
     this.isSending = false,
     this.isError = false,
     this.crossAxisAlignment = CrossAxisAlignment.end,
-    this.padding = const EdgeInsets.only(bottom: 18),
+    this.padding = const EdgeInsets.only(bottom: 13),
   }) : super(key: key);
 
   /// Expanded width of the [swipeable].
-  static const double width = 55;
+  static const double width = 65;
 
   /// Child to swipe to reveal [swipeable].
   final Widget child;
@@ -87,7 +89,8 @@ class SwipeableStatus extends StatelessWidget {
           _animatedBuilder(
             Padding(
               padding: padding,
-              child: SizedBox(width: width, child: _swipeableWithStatus()),
+              child:
+                  SizedBox(width: width, child: _swipeableWithStatus(context)),
             ),
           ),
         ],
@@ -102,7 +105,7 @@ class SwipeableStatus extends StatelessWidget {
           Expanded(child: child),
           Padding(
             padding: padding,
-            child: SizedBox(width: width, child: _swipeableWithStatus()),
+            child: SizedBox(width: width, child: _swipeableWithStatus(context)),
           ),
         ],
       ),
@@ -110,40 +113,49 @@ class SwipeableStatus extends StatelessWidget {
   }
 
   /// Returns a [Row] of [swipeable] and a status.
-  Widget _swipeableWithStatus() => DefaultTextStyle.merge(
-        textAlign: TextAlign.end,
-        maxLines: 1,
-        overflow: TextOverflow.visible,
-        style: const TextStyle(fontSize: 10, color: Color(0xFF888888)),
-        child: Padding(
-          padding: const EdgeInsets.only(right: 3.5),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (isSent || isDelivered || isRead || isSending || isError) ...[
-                Icon(
-                  (isRead || isDelivered)
-                      ? Icons.done_all
-                      : isSending
-                          ? Icons.access_alarm
-                          : isError
-                              ? Icons.error_outline
-                              : Icons.done,
-                  color: isRead
-                      ? const Color(0xFF63B4FF)
-                      : isError
-                          ? Colors.red
-                          : const Color(0xFF888888),
-                  size: 12,
-                ),
-                const SizedBox(width: 3),
-              ],
-              swipeable,
-            ],
-          ),
+  Widget _swipeableWithStatus(BuildContext context) {
+    final Style? style = Theme.of(context).extension<Style>();
+
+    return DefaultTextStyle.merge(
+      textAlign: TextAlign.end,
+      maxLines: 1,
+      overflow: TextOverflow.visible,
+      style: style?.systemMessageTextStyle.copyWith(fontSize: 11),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 3),
+        margin: const EdgeInsets.only(right: 2, left: 8),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          border: style?.systemMessageBorder,
+          color: style?.systemMessageColor,
         ),
-      );
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isSent || isDelivered || isRead || isSending || isError)
+              Icon(
+                (isRead || isDelivered)
+                    ? Icons.done_all
+                    : isSending
+                        ? Icons.access_alarm
+                        : isError
+                            ? Icons.error_outline
+                            : Icons.done,
+                color: isRead
+                    ? const Color(0xFF63B4FF)
+                    : isError
+                        ? Colors.red
+                        : const Color(0xFF888888),
+                size: 12,
+              ),
+            const SizedBox(width: 3),
+            swipeable,
+          ],
+        ),
+      ),
+    );
+  }
 
   /// Returns an [AnimatedBuilder] with a [Transform.translate] transition.
   Widget _animatedBuilder(Widget child) => AnimatedBuilder(

--- a/lib/ui/page/home/page/chat/widget/swipeable_status.dart
+++ b/lib/ui/page/home/page/chat/widget/swipeable_status.dart
@@ -114,20 +114,20 @@ class SwipeableStatus extends StatelessWidget {
 
   /// Returns a [Row] of [swipeable] and a status.
   Widget _swipeableWithStatus(BuildContext context) {
-    final Style? style = Theme.of(context).extension<Style>();
+    final Style style = Theme.of(context).extension<Style>()!;
 
     return DefaultTextStyle.merge(
       textAlign: TextAlign.end,
       maxLines: 1,
       overflow: TextOverflow.visible,
-      style: style?.systemMessageTextStyle.copyWith(fontSize: 11),
+      style: style.systemMessageStyle.copyWith(fontSize: 11),
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 3),
         margin: const EdgeInsets.only(right: 2, left: 8),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(10),
-          border: style?.systemMessageBorder,
-          color: style?.systemMessageColor,
+          border: style.systemMessageBorder,
+          color: style.systemMessageColor,
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/ui/page/home/page/chat/widget/swipeable_status.dart
+++ b/lib/ui/page/home/page/chat/widget/swipeable_status.dart
@@ -143,10 +143,10 @@ class SwipeableStatus extends StatelessWidget {
                             ? Icons.error_outline
                             : Icons.done,
                 color: isRead
-                    ? const Color(0xFF63B4FF)
+                    ? Theme.of(context).colorScheme.secondary
                     : isError
                         ? Colors.red
-                        : const Color(0xFF888888),
+                        : Theme.of(context).colorScheme.primary,
                 size: 12,
               ),
             const SizedBox(width: 3),

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -250,7 +250,8 @@ class ChatsTabView extends StatelessWidget {
                 ),
               ];
             } else if (item is ChatMemberInfo) {
-              Widget content = Text('${item.action}');
+              Widget? content;
+
               switch (item.action) {
                 case ChatMemberInfoAction.created:
                   if (chat.isGroup) {
@@ -261,21 +262,25 @@ class ChatsTabView extends StatelessWidget {
                   break;
 
                 case ChatMemberInfoAction.added:
-                  content = Text('label_was_added'
-                      .l10nfmt({'who': '${item.user.name ?? item.user.num}'}));
+                  content = Text(
+                    'label_was_added'
+                        .l10nfmt({'who': '${item.user.name ?? item.user.num}'}),
+                  );
 
                   break;
 
                 case ChatMemberInfoAction.removed:
-                  content = Text('label_was_removed'
-                      .l10nfmt({'who': '${item.user.name ?? item.user.num}'}));
+                  content = Text(
+                    'label_was_removed'
+                        .l10nfmt({'who': '${item.user.name ?? item.user.num}'}),
+                  );
                   break;
 
                 case ChatMemberInfoAction.artemisUnknown:
                   // No-op.
                   break;
               }
-              subtitle = [Flexible(child: content)];
+              subtitle = [Flexible(child: content ?? Text('${item.action}'))];
             } else {
               subtitle = [
                 Flexible(child: Text('label_empty_message'.l10n, maxLines: 2))

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -18,7 +18,7 @@ import 'package:badges/badges.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '/api/backend/schema.graphql.dart';
+import '/api/backend/schema.graphql.dart' show ChatMemberInfoAction;
 import '/domain/model/chat.dart';
 import '/domain/model/chat_call.dart';
 import '/domain/model/chat_item.dart';
@@ -261,13 +261,14 @@ class ChatsTabView extends StatelessWidget {
                   break;
 
                 case ChatMemberInfoAction.added:
-                  content = Text(
-                      '${item.user.name ?? item.user.num} ${'label_was_added'.l10n}');
+                  content = Text('label_was_added'
+                      .l10nfmt({'who': '${item.user.name ?? item.user.num}'}));
+
                   break;
 
                 case ChatMemberInfoAction.removed:
-                  content = Text(
-                      '${item.user.name ?? item.user.num} ${'label_was_removed'.l10n}');
+                  content = Text('label_was_removed'
+                      .l10nfmt({'who': '${item.user.name ?? item.user.num}'}));
                   break;
 
                 case ChatMemberInfoAction.artemisUnknown:

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -18,7 +18,7 @@ import 'package:badges/badges.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '/api/backend/schema.graphql.dart' show ChatMemberInfoAction;
+import '/api/backend/schema.dart' show ChatMemberInfoAction;
 import '/domain/model/chat.dart';
 import '/domain/model/chat_call.dart';
 import '/domain/model/chat_item.dart';
@@ -250,7 +250,7 @@ class ChatsTabView extends StatelessWidget {
                 ),
               ];
             } else if (item is ChatMemberInfo) {
-              Widget? content;
+              final Widget content;
 
               switch (item.action) {
                 case ChatMemberInfoAction.created:
@@ -277,13 +277,14 @@ class ChatsTabView extends StatelessWidget {
                   break;
 
                 case ChatMemberInfoAction.artemisUnknown:
-                  // No-op.
+                  content = Text('${item.action}');
                   break;
               }
-              subtitle = [Flexible(child: content ?? Text('${item.action}'))];
+
+              subtitle = [Flexible(child: content)];
             } else {
               subtitle = [
-                Flexible(child: Text('label_empty_message'.l10n, maxLines: 2))
+                Flexible(child: Text('label_empty_message'.l10n, maxLines: 2)),
               ];
             }
           }

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -18,6 +18,7 @@ import 'package:badges/badges.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+import '/api/backend/schema.graphql.dart';
 import '/domain/model/chat.dart';
 import '/domain/model/chat_call.dart';
 import '/domain/model/chat_item.dart';
@@ -248,8 +249,36 @@ class ChatsTabView extends StatelessWidget {
                           : Container(),
                 ),
               ];
+            } else if (item is ChatMemberInfo) {
+              Widget content = Text('${item.action}');
+              switch (item.action) {
+                case ChatMemberInfoAction.created:
+                  if (chat.isGroup) {
+                    content = Text('label_group_created'.l10n);
+                  } else {
+                    content = Text('label_dialog_created'.l10n);
+                  }
+                  break;
+
+                case ChatMemberInfoAction.added:
+                  content = Text(
+                      '${item.user.name ?? item.user.num} ${'label_was_added'.l10n}');
+                  break;
+
+                case ChatMemberInfoAction.removed:
+                  content = Text(
+                      '${item.user.name ?? item.user.num} ${'label_was_removed'.l10n}');
+                  break;
+
+                case ChatMemberInfoAction.artemisUnknown:
+                  // No-op.
+                  break;
+              }
+              subtitle = [Flexible(child: content)];
             } else {
-              // TODO: Implement other ChatItems.
+              subtitle = [
+                Flexible(child: Text('label_empty_message'.l10n, maxLines: 2))
+              ];
             }
           }
         } else {

--- a/test/unit/datetime_relative_test.dart
+++ b/test/unit/datetime_relative_test.dart
@@ -26,227 +26,227 @@ void main() {
 
     expect(
       DateTime(2022, 2, 17, 13, 40).toRelative(DateTime(2022, 2, 17, 13, 40)),
-      '13:40',
+      'Today',
     );
 
     expect(
       DateTime(2022, 2, 17, 13, 40).toRelative(DateTime(2022, 2, 17, 14, 00)),
-      '13:40',
+      'Today',
     );
 
     expect(
       DateTime(2022, 2, 17, 13, 40).toRelative(DateTime(2022, 2, 17, 23, 59)),
-      '13:40',
+      'Today',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 2, 17, 23, 59)),
-      '00:00',
+      'Today',
     );
 
     expect(
       DateTime(2022, 2, 17, 23, 59).toRelative(DateTime(2022, 2, 18)),
-      'Yesterday, 23:59',
+      'Yesterday',
     );
 
     expect(
       DateTime(2022, 2, 17, 23, 59).toRelative(DateTime(2022, 2, 18, 23, 59)),
-      'Yesterday, 23:59',
+      'Yesterday',
     );
 
     expect(
       DateTime(2022, 2, 28).toRelative(DateTime(2022, 3, 1)),
-      'Yesterday, 00:00',
+      'Yesterday',
     );
 
     expect(
       DateTime(2022, 2, 28).toRelative(DateTime(2022, 3, 2)),
-      '2 days ago, 00:00',
+      '2 days ago',
     );
 
     expect(
       DateTime(2022, 2, 17, 23, 59).toRelative(DateTime(2022, 2, 19)),
-      '2 days ago, 23:59',
+      '2 days ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 2, 20, 23, 59)),
-      '3 days ago, 00:00',
+      '3 days ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 2, 21, 23, 59)),
-      '4 days ago, 00:00',
+      '4 days ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 2, 22, 23, 59)),
-      '5 days ago, 00:00',
+      '5 days ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 2, 23, 23, 59)),
-      '6 days ago, 00:00',
+      '6 days ago',
     );
 
     expect(
       DateTime(2022, 12, 31).toRelative(DateTime(2023)),
-      'Yesterday, 00:00',
+      'Yesterday',
     );
 
     expect(
       DateTime(2022, 12, 31).toRelative(DateTime(2023, 1, 5)),
-      '5 days ago, 00:00',
+      '5 days ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 2, 24)),
-      'A week ago, 00:00',
+      'A week ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 3, 2)),
-      'A week ago, 00:00',
+      'A week ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 3, 3)),
-      '2 weeks ago, 00:00',
+      '2 weeks ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 3, 17)),
-      'A month ago, 00:00',
+      'A month ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 3, 31)),
-      'A month ago, 00:00',
+      'A month ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 4, 1)),
-      'A month ago, 00:00',
+      'A month ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 4, 16)),
-      'A month ago, 00:00',
+      'A month ago',
     );
 
     expect(
       DateTime(2021, 12, 24, 18, 09).toRelative(DateTime(2022, 2, 17, 15, 43)),
-      'A month ago, 18:09',
+      'A month ago',
     );
 
     expect(
       DateTime(2022, 1, 18, 15, 16).toRelative(DateTime(2022, 2, 18, 10, 21)),
-      'A month ago, 15:16',
+      'A month ago',
     );
 
     expect(
       DateTime(2022, 1, 19, 15, 16).toRelative(DateTime(2022, 2, 18, 10, 21)),
-      '4 weeks ago, 15:16',
+      '4 weeks ago',
     );
 
     expect(
       DateTime(2022, 1, 21, 15, 16).toRelative(DateTime(2022, 2, 18, 10, 21)),
-      '4 weeks ago, 15:16',
+      '4 weeks ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2022, 4, 17)),
-      '2 months ago, 00:00',
+      '2 months ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2023, 2, 16)),
-      '11 months ago, 00:00',
+      '11 months ago',
     );
 
     expect(
       DateTime(2022, 2, 17).toRelative(DateTime(2023, 2, 17)),
-      'An year ago, 00:00',
+      'An year ago',
     );
 
     expect(
       DateTime(2022, 3).toRelative(DateTime(2023, 3)),
-      'An year ago, 00:00',
+      'An year ago',
     );
 
     expect(
       DateTime(2022).toRelative(DateTime(2023)),
-      'An year ago, 00:00',
+      'An year ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2023, 12, 12)),
-      '11 months ago, 00:00',
+      '11 months ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2023, 12, 13)),
-      'An year ago, 00:00',
+      'An year ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2024, 12, 12)),
-      'An year ago, 00:00',
+      'An year ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2024, 12, 12)),
-      'An year ago, 00:00',
+      'An year ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2024, 12, 13)),
-      '2 years ago, 00:00',
+      '2 years ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2025, 12, 12)),
-      '2 years ago, 00:00',
+      '2 years ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2025, 12, 13)),
-      '3 years ago, 00:00',
+      '3 years ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2026, 12, 12)),
-      '3 years ago, 00:00',
+      '3 years ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2026, 12, 13)),
-      '4 years ago, 00:00',
+      '4 years ago',
     );
 
     expect(
       DateTime(2022, 12, 13).toRelative(DateTime(2027, 12, 12)),
-      '4 years ago, 00:00',
+      '4 years ago',
     );
 
     expect(
       DateTime(2017, 9, 7, 17, 30).toRelative(DateTime(2022, 9, 7, 17, 30)),
-      '5 years ago, 17:30',
+      '5 years ago',
     );
 
     expect(
       DateTime(2017, 9, 7, 17, 30).toRelative(DateTime(2023, 01, 01)),
-      '5 years ago, 17:30',
+      '5 years ago',
     );
 
     expect(
       DateTime(2017, 9, 7, 17, 30).toRelative(DateTime(2023, 9, 7, 17, 30)),
-      '6 years ago, 17:30',
+      '6 years ago',
     );
 
     expect(
       DateTime(1970, 2, 17).toRelative(DateTime(2100, 2, 17)),
-      '130 years ago, 00:00',
+      '130 years ago',
     );
   });
 }


### PR DESCRIPTION
Resolves #158




## Synopsis

Служебная информация отображается как сообщения типа `ChatMemberInfo`. 




## Solution

Нужно провести редизайн этих сообщений и некоторых прочих служебных плашек.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
