### PR TITLE
Fix flaky attachment downloading E2E test(#175)

### DIFF
--- a/test/e2e/mock/platform_utils.dart
+++ b/test/e2e/mock/platform_utils.dart
@@ -35,7 +35,7 @@ class PlatformUtilsMock extends PlatformUtilsImpl {
       if (cancelToken?.isCancelled == true) {
         break;
       }
-      await Future.delayed(20.milliseconds);
+      await Future.delayed(40.milliseconds);
       onReceiveProgress?.call(count, total);
     }
 


### PR DESCRIPTION
Resolves #175




## Synopsis

E2E тест на отмену скачивания файла иногда падает.




## Solution

Будет увеличено время скачивания файла, чтобы тестер всегда успевал его отменить.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
