### PR TITLE
Implement optimistic mutations in `Contact` store (#43)

### DIFF
--- a/lib/store/contact.dart
+++ b/lib/store/contact.dart
@@ -137,28 +137,20 @@ class ContactRepository implements AbstractContactRepository {
 
   @override
   Future<void> changeContactName(ChatContactId id, UserName name) async {
-    final HiveRxChatContact? chatContact = contacts[id];
-    final UserName? oldName = chatContact?.contact.value.name;
+    final HiveRxChatContact? contact = contacts[id];
+    final UserName? oldName = contact?.contact.value.name;
 
-    chatContact?.contact.update((c) => c?.name = name);
+    contact?.contact.update((c) => c?.name = name);
     contacts.emit(
-      MapChangeNotification.updated(
-        chatContact?.id,
-        chatContact?.id,
-        chatContact,
-      ),
+      MapChangeNotification.updated(contact?.id, contact?.id, contact),
     );
 
     try {
       await _graphQlProvider.changeContactName(id, name);
     } catch (_) {
-      chatContact?.contact.update((c) => c?.name = oldName!);
+      contact?.contact.update((c) => c?.name = oldName!);
       contacts.emit(
-        MapChangeNotification.updated(
-          chatContact?.id,
-          chatContact?.id,
-          chatContact,
-        ),
+        MapChangeNotification.updated(contact?.id, contact?.id, contact),
       );
       rethrow;
     }


### PR DESCRIPTION
Part of #43




## Synopsis

Currently every mutation is a no-op to ensure no state is modified inappropriately. This leads to UI/UX reactivity losses, which is worse than having an incorrect state (especially considering the odds of such a transaction are low, since in most cases mutation should finish without an error).




## Solution

This PR implements optimistic mutations for `Contact` store.

Mutation's actions are reflected only in reactive lists, Hive persisted lists are not affected. Therefore, no incorrect state is persisted.

Any errors occurred while applying mutation are considered and corresponding optimistic actions are reverted.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
