### PR TITLE
Implement `CallMember` redialing (#233)

### DIFF
--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -469,6 +469,7 @@ label_offline = Offline
 label_online = Online
 label_or_register = or register
 label_outgoing_call = Outgoing call
+label_participant_redial_successfully = Redial participant was successfully
 label_participants = Participants
 label_participants_added_successfully = Participants successfully added
 label_password = Password

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -491,6 +491,7 @@ label_offline = Офлайн
 label_online = Онлайн
 label_or_register = или регистрация
 label_outgoing_call = Исходящий звонок
+label_participant_redial_successfully = Повторный звонок участнику прошел успешно
 label_participants = Участники
 label_participants_added_successfully = Участники успешно добавлены
 label_password = Пароль

--- a/lib/api/backend/graphql/mutation/call/RedialChatCallMember.graphql
+++ b/lib/api/backend/graphql/mutation/call/RedialChatCallMember.graphql
@@ -1,0 +1,27 @@
+# Copyright © 2022 IT ENGINEERING MANAGEMENT INC, <https://github.com/team113>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0 as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+# more details.
+#
+# You should have received a copy of the GNU Affero General Public License v3.0
+# along with this program. If not, see
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+mutation RedialChatCallMember($chatId: ChatId!, $memberId: UserId!) {
+    redialChatCallMember(chatId: $chatId, memberId: $memberId) {
+        __typename
+        ... on ChatCallEventsVersioned {
+            ...ChatCallEventsVersioned
+        }
+        ... on RedialChatCallMemberError {
+            code
+        }
+    }
+}

--- a/lib/domain/repository/call.dart
+++ b/lib/domain/repository/call.dart
@@ -82,6 +82,10 @@ abstract class AbstractCallRepository {
     ChatName? groupName,
   );
 
+  /// Redials a [User] who left or declined the ongoing [ChatCall] in the
+  /// specified [Chat]-group by the authenticated [MyUser].
+  Future<void> redialChatCallMember(ChatId chatId, UserId memberId);
+
   /// Generates the [ChatCallCredentials] for a [Chat] identified by the
   /// provided [id].
   ///

--- a/lib/domain/service/call.dart
+++ b/lib/domain/service/call.dart
@@ -289,6 +289,15 @@ class CallService extends DisposableService {
     }
   }
 
+  /// Redials a [User] who left or declined the ongoing [ChatCall] in the
+  /// specified [Chat]-group by the authenticated [MyUser].
+  Future<void> redialChatCallMember(ChatId chatId, UserId memberId) async {
+    Rx<OngoingCall>? call = _callsRepo[chatId];
+    if (call != null) {
+      await _callsRepo.redialChatCallMember(chatId, memberId);
+    }
+  }
+
   /// Moves an ongoing [ChatCall] in a [Chat]-dialog to a newly created
   /// [Chat]-group, optionally adding new members.
   Future<void> transformDialogCallIntoGroupCall(

--- a/lib/provider/gql/exceptions.dart
+++ b/lib/provider/gql/exceptions.dart
@@ -998,6 +998,37 @@ class ToggleChatCallHandException
   }
 }
 
+/// Exception of `Mutation.redialChatCallMember` described in the [code].
+class RedialChatCallMemberException
+    with LocalizedExceptionMixin
+    implements Exception {
+  const RedialChatCallMemberException(this.code);
+
+  /// Reason of why the mutation has failed.
+  final RedialChatCallMemberErrorCode code;
+
+  @override
+  String toString() => 'RedialChatCallMemberException($code)';
+
+  @override
+  String toMessage() {
+    switch (code) {
+      case RedialChatCallMemberErrorCode.notCallMember:
+        return 'err_not_call_member'.l10n;
+      case RedialChatCallMemberErrorCode.noCall:
+        return 'err_call_not_found'.l10n;
+      case RedialChatCallMemberErrorCode.unknownChat:
+        return 'err_unknown_chat'.l10n;
+      case RedialChatCallMemberErrorCode.notChatMember:
+        return 'err_not_member'.l10n;
+      case RedialChatCallMemberErrorCode.notGroup:
+        return 'err_contact_not_group'.l10n;
+      case RedialChatCallMemberErrorCode.artemisUnknown:
+        return 'err_unknown'.l10n;
+    }
+  }
+}
+
 /// Exception of `Mutation.createChatDirectLink` described in the [code].
 class CreateChatDirectLinkException
     with LocalizedExceptionMixin

--- a/lib/store/call.dart
+++ b/lib/store/call.dart
@@ -135,6 +135,10 @@ class CallRepository implements AbstractCallRepository {
       _graphQlProvider.toggleChatCallHand(chatId, raised);
 
   @override
+  Future<void> redialChatCallMember(ChatId chatId, UserId memberId) =>
+      _graphQlProvider.redialChatCallMember(chatId, memberId);
+
+  @override
   Future<void> transformDialogCallIntoGroupCall(
     ChatId chatId,
     List<UserId> additionalMemberIds,

--- a/lib/ui/page/call/participant/controller.dart
+++ b/lib/ui/page/call/participant/controller.dart
@@ -28,6 +28,7 @@ import '/l10n/l10n.dart';
 import '/provider/gql/exceptions.dart'
     show
         AddChatMemberException,
+        RedialChatCallMemberException,
         RemoveChatMemberException,
         TransformDialogCallIntoGroupCallException;
 import '/util/message_popup.dart';
@@ -182,6 +183,20 @@ class ParticipantController extends GetxController {
       rethrow;
     } finally {
       status.value = RxStatus.empty();
+    }
+  }
+
+  /// Redials a specified [User] who left or declined the ongoing [ChatCall].
+  Future<void> redialChatCallMember(UserId memberId) async {
+    try {
+      await _callService.redialChatCallMember(chatId.value, memberId);
+
+      MessagePopup.success('label_participant_redial_successfully'.l10n);
+    } on RedialChatCallMemberException catch (e) {
+      MessagePopup.error(e);
+    } catch (e) {
+      MessagePopup.error(e);
+      rethrow;
     }
   }
 

--- a/lib/ui/page/call/participant/view.dart
+++ b/lib/ui/page/call/participant/view.dart
@@ -309,9 +309,7 @@ class ParticipantView extends StatelessWidget {
                   color: Theme.of(context).colorScheme.secondary,
                   type: MaterialType.circle,
                   child: InkWell(
-                    onTap: () {
-                      // TODO: Redial the provided [user].
-                    },
+                    onTap: () => c.redialChatCallMember(user.id),
                     borderRadius: BorderRadius.circular(60),
                     child: SizedBox(
                       width: 30,


### PR DESCRIPTION
Resolves #233




## Synopsis

Приложение имеет интерфейс в звонке, откуда перенабирать участников можно (кнопка "Участники" в звонке), но перенабрать оттуда никого не получится, этот функционал не реализован.




## Solution

Реализовать соответствующий функционал




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
