### PR TITLE
Implement searching on `Contact`s tab (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All user visible changes to this project will be documented in this file. This p
         - Participants redialing. ([#241], [#233])
     - Contacts tab:
         - Favorite contacts. ([#237], [#223])
+        - Searching. ([#260], [#259])
     - User page:
         - Blacklisting. ([#234], [#229])
 
@@ -103,6 +104,8 @@ All user visible changes to this project will be documented in this file. This p
 [#251]: /../../pull/251
 [#252]: /../../issues/252
 [#254]: /../../pull/254
+[#252]: /../../issues/259
+[#254]: /../../pull/260
 
 
 

--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -569,12 +569,16 @@ class OngoingCall {
             }
           } on MediaStateTransitionException catch (_) {
             // No-op.
-          } catch (e) {
-            if (!e.toString().contains('Permission denied')) {
-              screenShareState.value = LocalTrackState.disabled;
+          } on LocalMediaInitException catch (e) {
+            screenShareState.value = LocalTrackState.disabled;
+            if (!e.cause().contains('Permission denied')) {
               _errors.add('enableScreenShare() call failed with $e');
               rethrow;
             }
+          } catch (e) {
+            screenShareState.value = LocalTrackState.disabled;
+            _errors.add('enableScreenShare() call failed with $e');
+            rethrow;
           }
         }
         break;

--- a/lib/ui/page/call/screen_share/controller.dart
+++ b/lib/ui/page/call/screen_share/controller.dart
@@ -48,7 +48,7 @@ class ScreenShareController extends GetxController {
       RxMap<MediaDisplayInfo, RtcVideoRenderer>();
 
   /// Subscription for the [CallService.calls] changes.
-  late final StreamSubscription? _chatsSubscription;
+  late final StreamSubscription? _callsSubscription;
 
   /// Subscription for the [OngoingCall.displays] updating the [renderers].
   late final StreamSubscription? _displaysSubscription;
@@ -68,7 +68,7 @@ class ScreenShareController extends GetxController {
 
   @override
   void onInit() {
-    _chatsSubscription = _callService.calls.changes.listen((e) {
+    _callsSubscription = _callService.calls.changes.listen((e) {
       switch (e.op) {
         case OperationKind.removed:
           if (call.value.chatId.value == e.key) {
@@ -103,7 +103,7 @@ class ScreenShareController extends GetxController {
 
   @override
   void onClose() {
-    _chatsSubscription?.cancel();
+    _callsSubscription?.cancel();
     _displaysSubscription?.cancel();
     _mediaManager.free();
     _jason.free();

--- a/lib/ui/page/call/search/controller.dart
+++ b/lib/ui/page/call/search/controller.dart
@@ -358,8 +358,8 @@ class SearchController extends GetxController {
     if (categories.contains(SearchCategory.contact)) {
       Map<UserId, RxChatContact> allContacts = {
         for (var u in {
-          ..._contactService.contacts,
           ..._contactService.favorites,
+          ..._contactService.contacts,
         }.values.where((e) {
           if (e.contact.value.users.length == 1) {
             RxUser? user = e.user.value;

--- a/lib/ui/page/call/search/controller.dart
+++ b/lib/ui/page/call/search/controller.dart
@@ -357,7 +357,10 @@ class SearchController extends GetxController {
 
     if (categories.contains(SearchCategory.contact)) {
       Map<UserId, RxChatContact> allContacts = {
-        for (var u in _contactService.contacts.values.where((e) {
+        for (var u in {
+          ..._contactService.contacts,
+          ..._contactService.favorites,
+        }.values.where((e) {
           if (e.contact.value.users.length == 1) {
             RxUser? user = e.user.value;
 

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -186,158 +186,158 @@ class ChatsTabView extends StatelessWidget {
             ],
           ),
           body: Obx(() {
-            if (c.chatsReady.value) {
-              final Widget? child;
-
-              if (c.search.value?.search.isEmpty.value == false) {
-                if (c.search.value!.searchStatus.value.isLoading &&
-                    c.elements.isEmpty) {
-                  child = const Center(
-                    key: Key('Loading'),
-                    child: CircularProgressIndicator(),
-                  );
-                } else if (c.elements.isNotEmpty) {
-                  child = AnimationLimiter(
-                    child: ListView.builder(
-                      key: const Key('Search'),
-                      controller: ScrollController(),
-                      itemCount: c.elements.length,
-                      itemBuilder: (_, i) {
-                        final ListElement element = c.elements[i];
-                        final Widget child;
-
-                        if (element is ChatElement) {
-                          final RxChat chat = element.chat;
-                          child = Padding(
-                            padding: const EdgeInsets.only(left: 10, right: 10),
-                            child: RecentChatTile(
-                              chat,
-                              key: Key('SearchChat_${chat.id}'),
-                              me: c.me,
-                              getUser: c.getUser,
-                              onJoin: () => c.joinCall(chat.id),
-                              onDrop: () => c.dropCall(chat.id),
-                              inCall: () => c.inCall(chat.id),
-                            ),
-                          );
-                        } else if (element is ContactElement) {
-                          child = SearchUserTile(
-                            key: Key('SearchContact_${element.contact.id}'),
-                            contact: element.contact,
-                            onTap: () => c.openChat(contact: element.contact),
-                          );
-                        } else if (element is UserElement) {
-                          child = SearchUserTile(
-                            key: Key('SearchUser_${element.user.id}'),
-                            user: element.user,
-                            onTap: () => c.openChat(user: element.user),
-                          );
-                        } else if (element is DividerElement) {
-                          child = Center(
-                            child: Container(
-                              margin: const EdgeInsets.fromLTRB(10, 2, 10, 2),
-                              padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
-                              width: double.infinity,
-                              child: Center(
-                                child: Text(
-                                  element.category.name.capitalizeFirst!,
-                                  style: style.systemMessageStyle.copyWith(
-                                    color: Colors.black,
-                                    fontSize: 15,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          );
-                        } else {
-                          child = const SizedBox();
-                        }
-
-                        return AnimationConfiguration.staggeredList(
-                          position: i,
-                          duration: const Duration(milliseconds: 375),
-                          child: SlideAnimation(
-                            horizontalOffset: 50,
-                            child: FadeInAnimation(
-                              child: Padding(
-                                padding: EdgeInsets.only(
-                                  top: i == 0 ? 3 : 0,
-                                  bottom: i == c.elements.length - 1 ? 4 : 0,
-                                ),
-                                child: child,
-                              ),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                  );
-                } else {
-                  child = Center(
-                    key: const Key('NothingFound'),
-                    child: Text('label_nothing_found'.l10n),
-                  );
-                }
-              } else {
-                if (c.chats.isEmpty) {
-                  child = Center(
-                    key: const Key('NoChats'),
-                    child: Text('label_no_chats'.l10n),
-                  );
-                } else {
-                  child = AnimationLimiter(
-                    key: const Key('Chats'),
-                    child: ListView.builder(
-                      controller: ScrollController(),
-                      itemCount: c.chats.length,
-                      itemBuilder: (_, i) {
-                        final RxChat chat = c.chats[i];
-                        return AnimationConfiguration.staggeredList(
-                          position: i,
-                          duration: const Duration(milliseconds: 375),
-                          child: SlideAnimation(
-                            horizontalOffset: 50,
-                            child: FadeInAnimation(
-                              child: Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 10),
-                                child: RecentChatTile(
-                                  chat,
-                                  key: Key('RecentChat_${chat.id}'),
-                                  me: c.me,
-                                  getUser: c.getUser,
-                                  onJoin: () => c.joinCall(chat.id),
-                                  onDrop: () => c.dropCall(chat.id),
-                                  onLeave: () => c.leaveChat(chat.id),
-                                  onHide: () => c.hideChat(chat.id),
-                                  inCall: () => c.inCall(chat.id),
-                                  onMute: () => c.muteChat(chat.id),
-                                  onUnmute: () => c.unmuteChat(chat.id),
-                                  onFavorite: () => c.favoriteChat(chat.id),
-                                  onUnfavorite: () => c.unfavoriteChat(chat.id),
-                                ),
-                              ),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                  );
-                }
-              }
-
-              return Padding(
-                padding: const EdgeInsets.symmetric(vertical: 5),
-                child: ContextMenuInterceptor(
-                  child: AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 250),
-                    child: child,
-                  ),
-                ),
-              );
+            if (!c.chatsReady.value) {
+              return const Center(child: CircularProgressIndicator());
             }
 
-            return const Center(child: CircularProgressIndicator());
+            final Widget? child;
+
+            if (c.search.value?.search.isEmpty.value == false) {
+              if (c.search.value!.searchStatus.value.isLoading &&
+                  c.elements.isEmpty) {
+                child = const Center(
+                  key: Key('Loading'),
+                  child: CircularProgressIndicator(),
+                );
+              } else if (c.elements.isNotEmpty) {
+                child = AnimationLimiter(
+                  child: ListView.builder(
+                    key: const Key('Search'),
+                    controller: ScrollController(),
+                    itemCount: c.elements.length,
+                    itemBuilder: (_, i) {
+                      final ListElement element = c.elements[i];
+                      final Widget child;
+
+                      if (element is ChatElement) {
+                        final RxChat chat = element.chat;
+                        child = Padding(
+                          padding: const EdgeInsets.only(left: 10, right: 10),
+                          child: RecentChatTile(
+                            chat,
+                            key: Key('SearchChat_${chat.id}'),
+                            me: c.me,
+                            getUser: c.getUser,
+                            onJoin: () => c.joinCall(chat.id),
+                            onDrop: () => c.dropCall(chat.id),
+                            inCall: () => c.inCall(chat.id),
+                          ),
+                        );
+                      } else if (element is ContactElement) {
+                        child = SearchUserTile(
+                          key: Key('SearchContact_${element.contact.id}'),
+                          contact: element.contact,
+                          onTap: () => c.openChat(contact: element.contact),
+                        );
+                      } else if (element is UserElement) {
+                        child = SearchUserTile(
+                          key: Key('SearchUser_${element.user.id}'),
+                          user: element.user,
+                          onTap: () => c.openChat(user: element.user),
+                        );
+                      } else if (element is DividerElement) {
+                        child = Center(
+                          child: Container(
+                            margin: const EdgeInsets.fromLTRB(10, 2, 10, 2),
+                            padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
+                            width: double.infinity,
+                            child: Center(
+                              child: Text(
+                                element.category.name.capitalizeFirst!,
+                                style: style.systemMessageStyle.copyWith(
+                                  color: Colors.black,
+                                  fontSize: 15,
+                                ),
+                              ),
+                            ),
+                          ),
+                        );
+                      } else {
+                        child = const SizedBox();
+                      }
+
+                      return AnimationConfiguration.staggeredList(
+                        position: i,
+                        duration: const Duration(milliseconds: 375),
+                        child: SlideAnimation(
+                          horizontalOffset: 50,
+                          child: FadeInAnimation(
+                            child: Padding(
+                              padding: EdgeInsets.only(
+                                top: i == 0 ? 3 : 0,
+                                bottom: i == c.elements.length - 1 ? 4 : 0,
+                              ),
+                              child: child,
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                );
+              } else {
+                child = Center(
+                  key: const Key('NothingFound'),
+                  child: Text('label_nothing_found'.l10n),
+                );
+              }
+            } else {
+              if (c.chats.isEmpty) {
+                child = Center(
+                  key: const Key('NoChats'),
+                  child: Text('label_no_chats'.l10n),
+                );
+              } else {
+                child = AnimationLimiter(
+                  key: const Key('Chats'),
+                  child: ListView.builder(
+                    controller: ScrollController(),
+                    itemCount: c.chats.length,
+                    itemBuilder: (_, i) {
+                      final RxChat chat = c.chats[i];
+                      return AnimationConfiguration.staggeredList(
+                        position: i,
+                        duration: const Duration(milliseconds: 375),
+                        child: SlideAnimation(
+                          horizontalOffset: 50,
+                          child: FadeInAnimation(
+                            child: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 10),
+                              child: RecentChatTile(
+                                chat,
+                                key: Key('RecentChat_${chat.id}'),
+                                me: c.me,
+                                getUser: c.getUser,
+                                onJoin: () => c.joinCall(chat.id),
+                                onDrop: () => c.dropCall(chat.id),
+                                onLeave: () => c.leaveChat(chat.id),
+                                onHide: () => c.hideChat(chat.id),
+                                inCall: () => c.inCall(chat.id),
+                                onMute: () => c.muteChat(chat.id),
+                                onUnmute: () => c.unmuteChat(chat.id),
+                                onFavorite: () => c.favoriteChat(chat.id),
+                                onUnfavorite: () => c.unfavoriteChat(chat.id),
+                              ),
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                );
+              }
+            }
+
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 5),
+              child: ContextMenuInterceptor(
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 250),
+                  child: child,
+                ),
+              ),
+            );
           }),
         );
       },

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -197,78 +197,80 @@ class ChatsTabView extends StatelessWidget {
                     child: CircularProgressIndicator(),
                   );
                 } else if (c.elements.isNotEmpty) {
-                  child = ListView.builder(
-                    key: const Key('Search'),
-                    controller: ScrollController(),
-                    itemCount: c.elements.length,
-                    itemBuilder: (_, i) {
-                      final ListElement element = c.elements[i];
-                      final Widget child;
+                  child = AnimationLimiter(
+                    child: ListView.builder(
+                      key: const Key('Search'),
+                      controller: ScrollController(),
+                      itemCount: c.elements.length,
+                      itemBuilder: (_, i) {
+                        final ListElement element = c.elements[i];
+                        final Widget child;
 
-                      if (element is ChatElement) {
-                        final RxChat chat = element.chat;
-                        child = Padding(
-                          padding: const EdgeInsets.only(left: 10, right: 10),
-                          child: RecentChatTile(
-                            chat,
-                            key: Key('SearchChat_${chat.id}'),
-                            me: c.me,
-                            getUser: c.getUser,
-                            onJoin: () => c.joinCall(chat.id),
-                            onDrop: () => c.dropCall(chat.id),
-                            inCall: () => c.inCall(chat.id),
-                          ),
-                        );
-                      } else if (element is ContactElement) {
-                        child = SearchUserTile(
-                          key: Key('SearchContact_${element.contact.id}'),
-                          contact: element.contact,
-                          onTap: () => c.openChat(contact: element.contact),
-                        );
-                      } else if (element is UserElement) {
-                        child = SearchUserTile(
-                          key: Key('SearchUser_${element.user.id}'),
-                          user: element.user,
-                          onTap: () => c.openChat(user: element.user),
-                        );
-                      } else if (element is DividerElement) {
-                        child = Center(
-                          child: Container(
-                            margin: const EdgeInsets.fromLTRB(10, 2, 10, 2),
-                            padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
-                            width: double.infinity,
-                            child: Center(
-                              child: Text(
-                                element.category.name.capitalizeFirst!,
-                                style: style.systemMessageStyle.copyWith(
-                                  color: Colors.black,
-                                  fontSize: 15,
+                        if (element is ChatElement) {
+                          final RxChat chat = element.chat;
+                          child = Padding(
+                            padding: const EdgeInsets.only(left: 10, right: 10),
+                            child: RecentChatTile(
+                              chat,
+                              key: Key('SearchChat_${chat.id}'),
+                              me: c.me,
+                              getUser: c.getUser,
+                              onJoin: () => c.joinCall(chat.id),
+                              onDrop: () => c.dropCall(chat.id),
+                              inCall: () => c.inCall(chat.id),
+                            ),
+                          );
+                        } else if (element is ContactElement) {
+                          child = SearchUserTile(
+                            key: Key('SearchContact_${element.contact.id}'),
+                            contact: element.contact,
+                            onTap: () => c.openChat(contact: element.contact),
+                          );
+                        } else if (element is UserElement) {
+                          child = SearchUserTile(
+                            key: Key('SearchUser_${element.user.id}'),
+                            user: element.user,
+                            onTap: () => c.openChat(user: element.user),
+                          );
+                        } else if (element is DividerElement) {
+                          child = Center(
+                            child: Container(
+                              margin: const EdgeInsets.fromLTRB(10, 2, 10, 2),
+                              padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
+                              width: double.infinity,
+                              child: Center(
+                                child: Text(
+                                  element.category.name.capitalizeFirst!,
+                                  style: style.systemMessageStyle.copyWith(
+                                    color: Colors.black,
+                                    fontSize: 15,
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                        );
-                      } else {
-                        child = const SizedBox();
-                      }
+                          );
+                        } else {
+                          child = const SizedBox();
+                        }
 
-                      return AnimationConfiguration.staggeredList(
-                        position: i,
-                        duration: const Duration(milliseconds: 375),
-                        child: SlideAnimation(
-                          horizontalOffset: 50,
-                          child: FadeInAnimation(
-                            child: Padding(
-                              padding: EdgeInsets.only(
-                                top: i == 0 ? 3 : 0,
-                                bottom: i == c.elements.length - 1 ? 4 : 0,
+                        return AnimationConfiguration.staggeredList(
+                          position: i,
+                          duration: const Duration(milliseconds: 375),
+                          child: SlideAnimation(
+                            horizontalOffset: 50,
+                            child: FadeInAnimation(
+                              child: Padding(
+                                padding: EdgeInsets.only(
+                                  top: i == 0 ? 3 : 0,
+                                  bottom: i == c.elements.length - 1 ? 4 : 0,
+                                ),
+                                child: child,
                               ),
-                              child: child,
                             ),
                           ),
-                        ),
-                      );
-                    },
+                        );
+                      },
+                    ),
                   );
                 } else {
                   child = Center(

--- a/lib/ui/page/home/tab/chats/widget/search_user_tile.dart
+++ b/lib/ui/page/home/tab/chats/widget/search_user_tile.dart
@@ -51,14 +51,12 @@ class SearchUserTile extends StatelessWidget {
       final ChatId? chatId = user?.user.value.dialog?.id ??
           contact?.user.value?.user.value.dialog?.id;
 
-      final UserId? userId = contact?.user.value?.id ?? user?.id;
+      final UserId? userId = user?.id ?? contact?.user.value?.id;
 
-      final bool selected = router.routes.lastWhereOrNull(
-                  (e) => e.startsWith('${Routes.chat}/$chatId')) !=
-              null ||
-          router.routes.lastWhereOrNull(
-                  (e) => e.startsWith('${Routes.user}/$userId')) !=
-              null;
+      final bool selected = router.routes.lastWhereOrNull((e) =>
+              e.startsWith('${Routes.chat}/$chatId') ||
+              e.startsWith('${Routes.user}/$userId')) !=
+          null;
 
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 3),

--- a/lib/ui/page/home/tab/chats/widget/search_user_tile.dart
+++ b/lib/ui/page/home/tab/chats/widget/search_user_tile.dart
@@ -59,7 +59,7 @@ class SearchUserTile extends StatelessWidget {
           null;
 
       return Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 3),
+        padding: const EdgeInsets.symmetric(horizontal: 10),
         child: ContactTile(
           key: key,
           contact: contact,

--- a/lib/ui/page/home/tab/chats/widget/search_user_tile.dart
+++ b/lib/ui/page/home/tab/chats/widget/search_user_tile.dart
@@ -51,9 +51,14 @@ class SearchUserTile extends StatelessWidget {
       final ChatId? chatId = user?.user.value.dialog?.id ??
           contact?.user.value?.user.value.dialog?.id;
 
-      final bool selected = router.routes
-              .lastWhereOrNull((e) => e.startsWith('${Routes.chat}/$chatId')) !=
-          null;
+      final UserId? userId = contact?.user.value?.id ?? user?.id;
+
+      final bool selected = router.routes.lastWhereOrNull(
+                  (e) => e.startsWith('${Routes.chat}/$chatId')) !=
+              null ||
+          router.routes.lastWhereOrNull(
+                  (e) => e.startsWith('${Routes.user}/$userId')) !=
+              null;
 
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 3),

--- a/lib/ui/page/home/tab/contacts/controller.dart
+++ b/lib/ui/page/home/tab/contacts/controller.dart
@@ -61,7 +61,7 @@ class ContactsTabController extends GetxController {
   /// Reactive list of favorited [ChatContact]s.
   final RxList<RxChatContact> favorites = RxList();
 
-  /// [SearchController] for searching the [User]s and [ChatContact]s.
+  /// [SearchController] for searching [User]s and [ChatContact]s.
   final Rx<SearchController?> search = Rx(null);
 
   /// [ListElement]s representing the [search] results visually.

--- a/lib/ui/page/home/tab/contacts/controller.dart
+++ b/lib/ui/page/home/tab/contacts/controller.dart
@@ -73,7 +73,7 @@ class ContactsTabController extends GetxController {
   /// Address book used to get [ChatContact]s list.
   final ContactService _contactService;
 
-  /// [User]s service fetching the [User]s in [getUser] method.
+  /// [User]s service used in [SearchController].
   final UserService _userService;
 
   /// Call service used to start a [ChatCall].

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -132,41 +132,34 @@ class ContactsTabView extends StatelessWidget {
               Widget child;
 
               if (c.search.value != null) {
-                child = Container(
+                child = WidgetButton(
                   key: const Key('CloseSearch'),
-                  alignment: Alignment.center,
-                  width: 29.69,
-                  height: 21,
-                  child: WidgetButton(
-                    onPressed: () {
-                      if (c.search.value?.query.isNotEmpty == true) {
-                        c.toggleSearch(false);
-                      }
-                    },
-                    child: SvgLoader.asset(
-                      'assets/icons/close_primary.svg',
-                      height: 15,
-                      width: 15,
-                    ),
+                  onPressed: () {
+                    if (c.search.value?.query.isNotEmpty == true) {
+                      c.toggleSearch(false);
+                    }
+                  },
+                  child: SvgLoader.asset(
+                    'assets/icons/close_primary.svg',
+                    height: 15,
+                    width: 15,
                   ),
                 );
               } else {
-                child = Container(
-                  alignment: Alignment.center,
-                  width: 29.69,
-                  height: 21,
-                  child: WidgetButton(
-                    onPressed: c.toggleSorting,
-                    child: SvgLoader.asset(
-                      'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
-                      width: 29.69,
-                      height: 21,
-                    ),
+                child = WidgetButton(
+                  onPressed: c.toggleSorting,
+                  child: SvgLoader.asset(
+                    'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
+                    width: 29.69,
+                    height: 21,
                   ),
                 );
               }
-              return Padding(
-                padding: const EdgeInsets.only(left: 12, right: 18),
+              return Container(
+                alignment: Alignment.center,
+                width: 29.69,
+                height: 21,
+                margin: const EdgeInsets.only(left: 12, right: 18),
                 child: AnimatedSwitcher(
                   duration: 250.milliseconds,
                   child: child,

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -201,64 +201,67 @@ class ContactsTabView extends StatelessWidget {
                 child: CircularProgressIndicator(),
               );
             } else if (c.elements.isNotEmpty) {
-              child = ListView.builder(
-                key: const Key('Search'),
-                controller: ScrollController(),
-                itemCount: c.elements.length,
-                itemBuilder: (_, i) {
-                  final ListElement element = c.elements[i];
-                  final Widget child;
+              child = AnimationLimiter(
+                child: ListView.builder(
+                  key: const Key('Search'),
+                  controller: ScrollController(),
+                  itemCount: c.elements.length,
+                  itemBuilder: (_, i) {
+                    final ListElement element = c.elements[i];
+                    final Widget child;
 
-                  if (element is ContactElement) {
-                    child = SearchUserTile(
-                      key: Key('SearchContact_${element.contact.id}'),
-                      contact: element.contact,
-                      onTap: () => router.user(element.contact.user.value!.id),
-                    );
-                  } else if (element is UserElement) {
-                    child = SearchUserTile(
-                      key: Key('SearchUser_${element.user.id}'),
-                      user: element.user,
-                      onTap: () => router.user(element.user.id),
-                    );
-                  } else if (element is DividerElement) {
-                    child = Center(
-                      child: Container(
-                        margin: const EdgeInsets.fromLTRB(10, 2, 10, 2),
-                        padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
-                        width: double.infinity,
-                        child: Center(
-                          child: Text(
-                            element.category.name.capitalizeFirst!,
-                            style: style.systemMessageStyle.copyWith(
-                              color: Colors.black,
-                              fontSize: 15,
+                    if (element is ContactElement) {
+                      child = SearchUserTile(
+                        key: Key('SearchContact_${element.contact.id}'),
+                        contact: element.contact,
+                        onTap: () =>
+                            router.user(element.contact.user.value!.id),
+                      );
+                    } else if (element is UserElement) {
+                      child = SearchUserTile(
+                        key: Key('SearchUser_${element.user.id}'),
+                        user: element.user,
+                        onTap: () => router.user(element.user.id),
+                      );
+                    } else if (element is DividerElement) {
+                      child = Center(
+                        child: Container(
+                          margin: const EdgeInsets.fromLTRB(10, 2, 10, 2),
+                          padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
+                          width: double.infinity,
+                          child: Center(
+                            child: Text(
+                              element.category.name.capitalizeFirst!,
+                              style: style.systemMessageStyle.copyWith(
+                                color: Colors.black,
+                                fontSize: 15,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    );
-                  } else {
-                    child = const SizedBox();
-                  }
+                      );
+                    } else {
+                      child = const SizedBox();
+                    }
 
-                  return AnimationConfiguration.staggeredList(
-                    position: i,
-                    duration: const Duration(milliseconds: 375),
-                    child: SlideAnimation(
-                      horizontalOffset: 50,
-                      child: FadeInAnimation(
-                        child: Padding(
-                          padding: EdgeInsets.only(
-                            top: i == 0 ? 3 : 0,
-                            bottom: i == c.elements.length - 1 ? 4 : 0,
+                    return AnimationConfiguration.staggeredList(
+                      position: i,
+                      duration: const Duration(milliseconds: 375),
+                      child: SlideAnimation(
+                        horizontalOffset: 50,
+                        child: FadeInAnimation(
+                          child: Padding(
+                            padding: EdgeInsets.only(
+                              top: i == 0 ? 3 : 0,
+                              bottom: i == c.elements.length - 1 ? 4 : 0,
+                            ),
+                            child: child,
                           ),
-                          child: child,
                         ),
                       ),
-                    ),
-                  );
-                },
+                    );
+                  },
+                ),
               );
             } else {
               child = Center(
@@ -278,22 +281,24 @@ class ContactsTabView extends StatelessWidget {
                 ...c.contacts,
               ];
 
-              child = ListView.builder(
-                controller: ScrollController(),
-                itemCount: c.favorites.length + c.contacts.length,
-                itemBuilder: (_, i) {
-                  final RxChatContact contact = contacts[i];
-                  return AnimationConfiguration.staggeredList(
-                    position: i,
-                    duration: const Duration(milliseconds: 375),
-                    child: SlideAnimation(
-                      horizontalOffset: 50,
-                      child: FadeInAnimation(
-                        child: Obx(() => _contact(context, contact, c)),
+              child = AnimationLimiter(
+                child: ListView.builder(
+                  controller: ScrollController(),
+                  itemCount: c.favorites.length + c.contacts.length,
+                  itemBuilder: (_, i) {
+                    final RxChatContact contact = contacts[i];
+                    return AnimationConfiguration.staggeredList(
+                      position: i,
+                      duration: const Duration(milliseconds: 375),
+                      child: SlideAnimation(
+                        horizontalOffset: 50,
+                        child: FadeInAnimation(
+                          child: Obx(() => _contact(context, contact, c)),
+                        ),
                       ),
-                    ),
-                  );
-                },
+                    );
+                  },
+                ),
               );
             }
           }

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -147,6 +147,7 @@ class ContactsTabView extends StatelessWidget {
                 );
               } else {
                 child = WidgetButton(
+                  key: Key('SortBy${c.sortByName ? 'Abc' : 'SortByTime'}'),
                   onPressed: c.toggleSorting,
                   child: SvgLoader.asset(
                     'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
@@ -267,7 +268,7 @@ class ContactsTabView extends StatelessWidget {
             } else {
               if (c.contacts.isEmpty && c.favorites.isEmpty) {
                 child = Center(
-                  key: const Key('NoChats'),
+                  key: const Key('NoContacts'),
                   child: Text('label_no_chats'.l10n),
                 );
               } else {
@@ -275,8 +276,10 @@ class ContactsTabView extends StatelessWidget {
                   controller: ScrollController(),
                   itemCount: c.favorites.length + c.contacts.length,
                   itemBuilder: (_, i) {
-                    final RxChatContact contact =
-                        [...c.favorites, ...c.contacts][i];
+                    final RxChatContact contact = [
+                      ...c.favorites,
+                      ...c.contacts,
+                    ][i];
                     return AnimationConfiguration.staggeredList(
                       position: i,
                       duration: const Duration(milliseconds: 375),

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -28,7 +28,6 @@ import '/ui/page/home/tab/chats/controller.dart';
 import '/ui/page/home/tab/chats/widget/search_user_tile.dart';
 import '/ui/page/home/widget/app_bar.dart';
 import '/ui/page/home/widget/contact_tile.dart';
-import '/ui/widget/animations.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/menu_interceptor/menu_interceptor.dart';
 import '/ui/widget/svg/svg.dart';

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -16,7 +16,14 @@
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
 import 'package:get/get.dart';
+import 'package:messenger/themes.dart';
+import 'package:messenger/ui/page/home/tab/chats/controller.dart';
+import 'package:messenger/ui/page/home/tab/chats/widget/search_user_tile.dart';
+import 'package:messenger/ui/widget/animations.dart';
+import 'package:messenger/ui/widget/text_field.dart';
+import 'package:messenger/util/platform_utils.dart';
 
 import '/domain/repository/contact.dart';
 import '/l10n/l10n.dart';
@@ -24,7 +31,6 @@ import '/routes.dart';
 import '/ui/page/home/page/user/controller.dart';
 import '/ui/page/home/widget/contact_tile.dart';
 import '/ui/page/home/widget/app_bar.dart';
-import '/ui/page/home/widget/user_search_bar/view.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/menu_interceptor/menu_interceptor.dart';
 import '/ui/widget/svg/svg.dart';
@@ -37,6 +43,8 @@ class ContactsTabView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final Style style = Theme.of(context).extension<Style>()!;
+
     return GetBuilder(
       key: const Key('ContactsTab'),
       init: ContactsTabController(
@@ -44,56 +52,290 @@ class ContactsTabView extends StatelessWidget {
         Get.find(),
         Get.find(),
         Get.find(),
+        Get.find(),
       ),
       builder: (ContactsTabController c) => Scaffold(
         appBar: CustomAppBar(
-          title: Text('label_contacts'.l10n),
+          title: Obx(() {
+            final Widget child;
+
+            if (c.search.value != null) {
+              child = Theme(
+                data: Theme.of(context).copyWith(
+                  shadowColor: const Color(0x55000000),
+                  iconTheme: const IconThemeData(color: Colors.blue),
+                  inputDecorationTheme: InputDecorationTheme(
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(25),
+                      borderSide: BorderSide.none,
+                    ),
+                    errorBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(25),
+                      borderSide: BorderSide.none,
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(25),
+                      borderSide: BorderSide.none,
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(25),
+                      borderSide: BorderSide.none,
+                    ),
+                    disabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(25),
+                      borderSide: BorderSide.none,
+                    ),
+                    focusedErrorBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(25),
+                      borderSide: BorderSide.none,
+                    ),
+                    focusColor: Colors.white,
+                    fillColor: Colors.white,
+                    hoverColor: Colors.transparent,
+                    filled: true,
+                    isDense: true,
+                    contentPadding: EdgeInsets.fromLTRB(
+                      15,
+                      PlatformUtils.isDesktop ? 30 : 23,
+                      15,
+                      0,
+                    ),
+                  ),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  child: Transform.translate(
+                    offset: const Offset(0, 1),
+                    child: ReactiveTextField(
+                      key: const Key('SearchField'),
+                      state: c.search.value!.search,
+                      hint: 'label_search'.l10n,
+                      maxLines: 1,
+                      filled: false,
+                      dense: true,
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      style: style.boldBody.copyWith(fontSize: 17),
+                      onChanged: () => c.search.value?.query.value =
+                          c.search.value?.search.text ?? '',
+                    ),
+                  ),
+                ),
+              );
+            } else {
+              child = Text('label_contacts'.l10n);
+            }
+
+            return AnimatedSwitcher(duration: 250.milliseconds, child: child);
+          }),
           actions: [
-            Padding(
-              padding: const EdgeInsets.only(left: 12, right: 14, top: 2),
-              child: WidgetButton(
-                onPressed: c.toggleSorting,
-                child: Obx(() {
-                  return SvgLoader.asset(
+            Obx(() {
+              Widget child;
+
+              if (c.search.value != null) {
+                child = WidgetButton(
+                  key: const Key('CloseSearch'),
+                  onPressed: () {
+                    if (c.search.value?.query.isNotEmpty == true) {
+                      c.toggleSearch(false);
+                    }
+                  },
+                  child: SvgLoader.asset(
+                    'assets/icons/close_primary.svg',
+                    height: 15,
+                  ),
+                );
+              } else {
+                child = WidgetButton(
+                  onPressed: c.toggleSorting,
+                  child: SvgLoader.asset(
                     'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
                     width: 29.69,
                     height: 21,
-                  );
-                }),
-              ),
-            ),
+                  ),
+                );
+              }
+              return Padding(
+                padding: c.search.value != null
+                    ? const EdgeInsets.only(left: 12, right: 18)
+                    : const EdgeInsets.only(left: 12, right: 14, top: 2),
+                child: ElasticAnimatedSwitcher(
+                  // duration: 250.milliseconds,
+                  child: child,
+                ),
+              );
+            }),
           ],
+          // actions: [
+          //   Obx(() {
+          //     if (c.search.value != null) {
+          //       return Padding(
+          //         padding: const EdgeInsets.only(left: 12, right: 18),
+          //         child: WidgetButton(
+          //           key: const Key('CloseSearch'),
+          //           onPressed: () {
+          //             if (c.search.value?.query.isNotEmpty == true) {
+          //               c.toggleSearch(false);
+          //             }
+          //           },
+          //           child: SvgLoader.asset(
+          //             'assets/icons/close_primary.svg',
+          //             height: 15,
+          //           ),
+          //         ),
+          //       );
+          //     } else {
+          //       return Padding(
+          //         padding: const EdgeInsets.only(left: 12, right: 14, top: 2),
+          //         child: WidgetButton(
+          //           onPressed: c.toggleSorting,
+          //           child: SvgLoader.asset(
+          //             'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
+          //             width: 29.69,
+          //             height: 21,
+          //           ),
+          //         ),
+          //       );
+          //     }
+          //   }),
+          // ],
           leading: [
             Padding(
               padding: const EdgeInsets.only(left: 20, right: 12),
-              child: WidgetButton(
-                child: SvgLoader.asset('assets/icons/search.svg', width: 17.77),
-              ),
+              child: Obx(() {
+                return AnimatedSwitcher(
+                  duration: 250.milliseconds,
+                  child: WidgetButton(
+                    key: const Key('SearchButton'),
+                    onPressed: c.search.value != null ? null : c.toggleSearch,
+                    child: SvgLoader.asset(
+                      'assets/icons/search.svg',
+                      width: 17.77,
+                    ),
+                  ),
+                );
+              }),
             ),
           ],
         ),
-        body: Obx(
-          () => UserSearchBar(
-            onUserTap: (user) => router.user(user.id),
-            // TODO: Show an `add` icon only if user is not in contacts already.
-            //       E.g. by looking if `MyUser.contacts` field is empty or not.
-            trailingIcon: const Icon(Icons.person_add),
-            onTrailingTap: c.addToContacts,
-            body: c.contactsReady.value
-                ? c.favorites.isEmpty && c.contacts.isEmpty
-                    ? Center(child: Text('label_no_contacts'.l10n))
-                    : ContextMenuInterceptor(
-                        child: ListView(
-                          controller: ScrollController(),
-                          children: [
-                            ...c.favorites.map((e) => _contact(context, e, c)),
-                            ...c.contacts.map((e) => _contact(context, e, c))
-                          ],
+        body: Obx(() {
+          if (c.contactsReady.value) {
+            final Widget? child;
+
+            if (c.search.value?.search.isEmpty.value == false) {
+              if (c.search.value!.searchStatus.value.isLoading &&
+                  c.elements.isEmpty) {
+                child = const Center(
+                  key: Key('Loading'),
+                  child: CircularProgressIndicator(),
+                );
+              } else if (c.elements.isNotEmpty) {
+                child = ListView.builder(
+                  key: const Key('Search'),
+                  controller: ScrollController(),
+                  itemCount: c.elements.length,
+                  itemBuilder: (_, i) {
+                    final ListElement element = c.elements[i];
+                    final Widget child;
+
+                    if (element is ContactElement) {
+                      child = SearchUserTile(
+                        key: Key('SearchContact_${element.contact.id}'),
+                        contact: element.contact,
+                        onTap: () =>
+                            router.user(element.contact.user.value!.id),
+                      );
+                    } else if (element is UserElement) {
+                      child = SearchUserTile(
+                        key: Key('SearchUser_${element.user.id}'),
+                        user: element.user,
+                        onTap: () => router.user(element.user.id),
+                      );
+                    } else if (element is DividerElement) {
+                      child = Center(
+                        child: Container(
+                          margin: const EdgeInsets.fromLTRB(10, 2, 10, 2),
+                          padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
+                          width: double.infinity,
+                          child: Center(
+                            child: Text(
+                              element.category.name.capitalizeFirst!,
+                              style: style.systemMessageStyle.copyWith(
+                                color: Colors.black,
+                                fontSize: 15,
+                              ),
+                            ),
+                          ),
                         ),
-                      )
-                : const Center(child: CircularProgressIndicator()),
-          ),
-        ),
+                      );
+                    } else {
+                      child = const SizedBox();
+                    }
+
+                    return AnimationConfiguration.staggeredList(
+                      position: i,
+                      duration: const Duration(milliseconds: 375),
+                      child: SlideAnimation(
+                        horizontalOffset: 50,
+                        child: FadeInAnimation(
+                          child: Padding(
+                            padding: EdgeInsets.only(
+                              top: i == 0 ? 3 : 0,
+                              bottom: i == c.elements.length - 1 ? 4 : 0,
+                            ),
+                            child: child,
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                );
+              } else {
+                child = Center(
+                  key: const Key('NothingFound'),
+                  child: Text('label_nothing_found'.l10n),
+                );
+              }
+            } else {
+              if (c.contacts.isEmpty && c.favorites.isEmpty) {
+                child = Center(
+                  key: const Key('NoChats'),
+                  child: Text('label_no_chats'.l10n),
+                );
+              } else {
+                child = ListView.builder(
+                  controller: ScrollController(),
+                  itemCount: c.favorites.length + c.contacts.length,
+                  itemBuilder: (_, i) {
+                    final RxChatContact contact =
+                        [...c.favorites, ...c.contacts][i];
+                    return AnimationConfiguration.staggeredList(
+                      position: i,
+                      duration: const Duration(milliseconds: 375),
+                      child: SlideAnimation(
+                        horizontalOffset: 50,
+                        child: FadeInAnimation(
+                          child: Obx(() => _contact(context, contact, c)),
+                        ),
+                      ),
+                    );
+                  },
+                );
+              }
+            }
+
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 5),
+              child: ContextMenuInterceptor(
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 250),
+                  child: child,
+                ),
+              ),
+            );
+          }
+
+          return const Center(child: CircularProgressIndicator());
+        }),
       ),
     );
   }

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -18,23 +18,23 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
 import 'package:get/get.dart';
-import 'package:messenger/themes.dart';
-import 'package:messenger/ui/page/home/tab/chats/controller.dart';
-import 'package:messenger/ui/page/home/tab/chats/widget/search_user_tile.dart';
-import 'package:messenger/ui/widget/animations.dart';
-import 'package:messenger/ui/widget/text_field.dart';
-import 'package:messenger/util/platform_utils.dart';
 
 import '/domain/repository/contact.dart';
 import '/l10n/l10n.dart';
 import '/routes.dart';
+import '/themes.dart';
 import '/ui/page/home/page/user/controller.dart';
-import '/ui/page/home/widget/contact_tile.dart';
+import '/ui/page/home/tab/chats/controller.dart';
+import '/ui/page/home/tab/chats/widget/search_user_tile.dart';
 import '/ui/page/home/widget/app_bar.dart';
+import '/ui/page/home/widget/contact_tile.dart';
+import '/ui/widget/animations.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/menu_interceptor/menu_interceptor.dart';
 import '/ui/widget/svg/svg.dart';
+import '/ui/widget/text_field.dart';
 import '/ui/widget/widget_button.dart';
+import '/util/platform_utils.dart';
 import 'controller.dart';
 
 /// View of the `HomeTab.contacts` tab.
@@ -132,72 +132,48 @@ class ContactsTabView extends StatelessWidget {
               Widget child;
 
               if (c.search.value != null) {
-                child = WidgetButton(
+                child = Container(
                   key: const Key('CloseSearch'),
-                  onPressed: () {
-                    if (c.search.value?.query.isNotEmpty == true) {
-                      c.toggleSearch(false);
-                    }
-                  },
-                  child: SvgLoader.asset(
-                    'assets/icons/close_primary.svg',
-                    height: 15,
+                  alignment: Alignment.center,
+                  width: 29.69,
+                  height: 21,
+                  child: WidgetButton(
+                    onPressed: () {
+                      if (c.search.value?.query.isNotEmpty == true) {
+                        c.toggleSearch(false);
+                      }
+                    },
+                    child: SvgLoader.asset(
+                      'assets/icons/close_primary.svg',
+                      height: 15,
+                      width: 15,
+                    ),
                   ),
                 );
               } else {
-                child = WidgetButton(
-                  onPressed: c.toggleSorting,
-                  child: SvgLoader.asset(
-                    'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
-                    width: 29.69,
-                    height: 21,
+                child = Container(
+                  alignment: Alignment.center,
+                  width: 29.69,
+                  height: 21,
+                  child: WidgetButton(
+                    onPressed: c.toggleSorting,
+                    child: SvgLoader.asset(
+                      'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
+                      width: 29.69,
+                      height: 21,
+                    ),
                   ),
                 );
               }
               return Padding(
-                padding: c.search.value != null
-                    ? const EdgeInsets.only(left: 12, right: 18)
-                    : const EdgeInsets.only(left: 12, right: 14, top: 2),
-                child: ElasticAnimatedSwitcher(
-                  // duration: 250.milliseconds,
+                padding: const EdgeInsets.only(left: 12, right: 18),
+                child: AnimatedSwitcher(
+                  duration: 250.milliseconds,
                   child: child,
                 ),
               );
             }),
           ],
-          // actions: [
-          //   Obx(() {
-          //     if (c.search.value != null) {
-          //       return Padding(
-          //         padding: const EdgeInsets.only(left: 12, right: 18),
-          //         child: WidgetButton(
-          //           key: const Key('CloseSearch'),
-          //           onPressed: () {
-          //             if (c.search.value?.query.isNotEmpty == true) {
-          //               c.toggleSearch(false);
-          //             }
-          //           },
-          //           child: SvgLoader.asset(
-          //             'assets/icons/close_primary.svg',
-          //             height: 15,
-          //           ),
-          //         ),
-          //       );
-          //     } else {
-          //       return Padding(
-          //         padding: const EdgeInsets.only(left: 12, right: 14, top: 2),
-          //         child: WidgetButton(
-          //           onPressed: c.toggleSorting,
-          //           child: SvgLoader.asset(
-          //             'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
-          //             width: 29.69,
-          //             height: 21,
-          //           ),
-          //         ),
-          //       );
-          //     }
-          //   }),
-          // ],
           leading: [
             Padding(
               padding: const EdgeInsets.only(left: 20, right: 12),

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -146,7 +146,7 @@ class ContactsTabView extends StatelessWidget {
                 );
               } else {
                 child = WidgetButton(
-                  key: Key('SortBy${c.sortByName ? 'Abc' : 'SortByTime'}'),
+                  key: Key('SortBy${c.sortByName ? 'Abc' : 'Time'}'),
                   onPressed: c.toggleSorting,
                   child: SvgLoader.asset(
                     'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
@@ -271,14 +271,15 @@ class ContactsTabView extends StatelessWidget {
                   child: Text('label_no_contacts'.l10n),
                 );
               } else {
+                final List<RxChatContact> contacts = [
+                  ...c.favorites,
+                  ...c.contacts,
+                ];
                 child = ListView.builder(
                   controller: ScrollController(),
                   itemCount: c.favorites.length + c.contacts.length,
                   itemBuilder: (_, i) {
-                    final RxChatContact contact = [
-                      ...c.favorites,
-                      ...c.contacts,
-                    ][i];
+                    final RxChatContact contact = contacts[i];
                     return AnimationConfiguration.staggeredList(
                       position: i,
                       duration: const Duration(milliseconds: 375),

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -128,7 +128,7 @@ class ContactsTabView extends StatelessWidget {
           }),
           actions: [
             Obx(() {
-              Widget child;
+              final Widget child;
 
               if (c.search.value != null) {
                 child = WidgetButton(
@@ -187,126 +187,126 @@ class ContactsTabView extends StatelessWidget {
           ],
         ),
         body: Obx(() {
-          if (c.contactsReady.value) {
-            final Widget? child;
-
-            if (c.search.value?.search.isEmpty.value == false) {
-              if (c.search.value!.searchStatus.value.isLoading &&
-                  c.elements.isEmpty) {
-                child = const Center(
-                  key: Key('Loading'),
-                  child: CircularProgressIndicator(),
-                );
-              } else if (c.elements.isNotEmpty) {
-                child = ListView.builder(
-                  key: const Key('Search'),
-                  controller: ScrollController(),
-                  itemCount: c.elements.length,
-                  itemBuilder: (_, i) {
-                    final ListElement element = c.elements[i];
-                    final Widget child;
-
-                    if (element is ContactElement) {
-                      child = SearchUserTile(
-                        key: Key('SearchContact_${element.contact.id}'),
-                        contact: element.contact,
-                        onTap: () =>
-                            router.user(element.contact.user.value!.id),
-                      );
-                    } else if (element is UserElement) {
-                      child = SearchUserTile(
-                        key: Key('SearchUser_${element.user.id}'),
-                        user: element.user,
-                        onTap: () => router.user(element.user.id),
-                      );
-                    } else if (element is DividerElement) {
-                      child = Center(
-                        child: Container(
-                          margin: const EdgeInsets.fromLTRB(10, 2, 10, 2),
-                          padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
-                          width: double.infinity,
-                          child: Center(
-                            child: Text(
-                              element.category.name.capitalizeFirst!,
-                              style: style.systemMessageStyle.copyWith(
-                                color: Colors.black,
-                                fontSize: 15,
-                              ),
-                            ),
-                          ),
-                        ),
-                      );
-                    } else {
-                      child = const SizedBox();
-                    }
-
-                    return AnimationConfiguration.staggeredList(
-                      position: i,
-                      duration: const Duration(milliseconds: 375),
-                      child: SlideAnimation(
-                        horizontalOffset: 50,
-                        child: FadeInAnimation(
-                          child: Padding(
-                            padding: EdgeInsets.only(
-                              top: i == 0 ? 3 : 0,
-                              bottom: i == c.elements.length - 1 ? 4 : 0,
-                            ),
-                            child: child,
-                          ),
-                        ),
-                      ),
-                    );
-                  },
-                );
-              } else {
-                child = Center(
-                  key: const Key('NothingFound'),
-                  child: Text('label_nothing_found'.l10n),
-                );
-              }
-            } else {
-              if (c.contacts.isEmpty && c.favorites.isEmpty) {
-                child = Center(
-                  key: const Key('NoContacts'),
-                  child: Text('label_no_contacts'.l10n),
-                );
-              } else {
-                final List<RxChatContact> contacts = [
-                  ...c.favorites,
-                  ...c.contacts,
-                ];
-                child = ListView.builder(
-                  controller: ScrollController(),
-                  itemCount: c.favorites.length + c.contacts.length,
-                  itemBuilder: (_, i) {
-                    final RxChatContact contact = contacts[i];
-                    return AnimationConfiguration.staggeredList(
-                      position: i,
-                      duration: const Duration(milliseconds: 375),
-                      child: SlideAnimation(
-                        horizontalOffset: 50,
-                        child: FadeInAnimation(
-                          child: Obx(() => _contact(context, contact, c)),
-                        ),
-                      ),
-                    );
-                  },
-                );
-              }
-            }
-
-            return Padding(
-              padding: const EdgeInsets.symmetric(vertical: 5),
-              child: ContextMenuInterceptor(
-                child: AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 250),
-                  child: child,
-                ),
-              ),
-            );
+          if (!c.contactsReady.value) {
+            return const Center(child: CircularProgressIndicator());
           }
 
-          return const Center(child: CircularProgressIndicator());
+          final Widget? child;
+
+          if (c.search.value?.search.isEmpty.value == false) {
+            if (c.search.value!.searchStatus.value.isLoading &&
+                c.elements.isEmpty) {
+              child = const Center(
+                key: Key('Loading'),
+                child: CircularProgressIndicator(),
+              );
+            } else if (c.elements.isNotEmpty) {
+              child = ListView.builder(
+                key: const Key('Search'),
+                controller: ScrollController(),
+                itemCount: c.elements.length,
+                itemBuilder: (_, i) {
+                  final ListElement element = c.elements[i];
+                  final Widget child;
+
+                  if (element is ContactElement) {
+                    child = SearchUserTile(
+                      key: Key('SearchContact_${element.contact.id}'),
+                      contact: element.contact,
+                      onTap: () => router.user(element.contact.user.value!.id),
+                    );
+                  } else if (element is UserElement) {
+                    child = SearchUserTile(
+                      key: Key('SearchUser_${element.user.id}'),
+                      user: element.user,
+                      onTap: () => router.user(element.user.id),
+                    );
+                  } else if (element is DividerElement) {
+                    child = Center(
+                      child: Container(
+                        margin: const EdgeInsets.fromLTRB(10, 2, 10, 2),
+                        padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
+                        width: double.infinity,
+                        child: Center(
+                          child: Text(
+                            element.category.name.capitalizeFirst!,
+                            style: style.systemMessageStyle.copyWith(
+                              color: Colors.black,
+                              fontSize: 15,
+                            ),
+                          ),
+                        ),
+                      ),
+                    );
+                  } else {
+                    child = const SizedBox();
+                  }
+
+                  return AnimationConfiguration.staggeredList(
+                    position: i,
+                    duration: const Duration(milliseconds: 375),
+                    child: SlideAnimation(
+                      horizontalOffset: 50,
+                      child: FadeInAnimation(
+                        child: Padding(
+                          padding: EdgeInsets.only(
+                            top: i == 0 ? 3 : 0,
+                            bottom: i == c.elements.length - 1 ? 4 : 0,
+                          ),
+                          child: child,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              );
+            } else {
+              child = Center(
+                key: const Key('NothingFound'),
+                child: Text('label_nothing_found'.l10n),
+              );
+            }
+          } else {
+            if (c.contacts.isEmpty && c.favorites.isEmpty) {
+              child = Center(
+                key: const Key('NoContacts'),
+                child: Text('label_no_contacts'.l10n),
+              );
+            } else {
+              final List<RxChatContact> contacts = [
+                ...c.favorites,
+                ...c.contacts,
+              ];
+
+              child = ListView.builder(
+                controller: ScrollController(),
+                itemCount: c.favorites.length + c.contacts.length,
+                itemBuilder: (_, i) {
+                  final RxChatContact contact = contacts[i];
+                  return AnimationConfiguration.staggeredList(
+                    position: i,
+                    duration: const Duration(milliseconds: 375),
+                    child: SlideAnimation(
+                      horizontalOffset: 50,
+                      child: FadeInAnimation(
+                        child: Obx(() => _contact(context, contact, c)),
+                      ),
+                    ),
+                  );
+                },
+              );
+            }
+          }
+
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 5),
+            child: ContextMenuInterceptor(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 250),
+                child: child,
+              ),
+            ),
+          );
         }),
       ),
     );

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -269,7 +269,7 @@ class ContactsTabView extends StatelessWidget {
               if (c.contacts.isEmpty && c.favorites.isEmpty) {
                 child = Center(
                   key: const Key('NoContacts'),
-                  child: Text('label_no_chats'.l10n),
+                  child: Text('label_no_contacts'.l10n),
                 );
               } else {
                 child = ListView.builder(

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -186,6 +186,7 @@ class ContactsTabView extends StatelessWidget {
             ),
           ],
         ),
+        extendBodyBehindAppBar: true,
         body: Obx(() {
           if (!c.contactsReady.value) {
             return const Center(child: CircularProgressIndicator());
@@ -202,8 +203,8 @@ class ContactsTabView extends StatelessWidget {
               );
             } else if (c.elements.isNotEmpty) {
               child = AnimationLimiter(
+                key: const Key('Search'),
                 child: ListView.builder(
-                  key: const Key('Search'),
                   controller: ScrollController(),
                   itemCount: c.elements.length,
                   itemBuilder: (_, i) {
@@ -249,15 +250,7 @@ class ContactsTabView extends StatelessWidget {
                       duration: const Duration(milliseconds: 375),
                       child: SlideAnimation(
                         horizontalOffset: 50,
-                        child: FadeInAnimation(
-                          child: Padding(
-                            padding: EdgeInsets.only(
-                              top: i == 0 ? 3 : 0,
-                              bottom: i == c.elements.length - 1 ? 4 : 0,
-                            ),
-                            child: child,
-                          ),
-                        ),
+                        child: FadeInAnimation(child: child),
                       ),
                     );
                   },

--- a/test/e2e/features/home/contacts_searching/.feature
+++ b/test/e2e/features/home/contacts_searching/.feature
@@ -1,0 +1,31 @@
+# Copyright © 2022 IT ENGINEERING MANAGEMENT INC, <https://github.com/team113>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0 as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+# more details.
+#
+# You should have received a copy of the GNU Affero General Public License v3.0
+# along with this program. If not, see
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+Feature: Contacts searching
+
+  Scenario: User and contact can be found
+    Given I am Alice
+    And users Bob and Charlie
+    And contact Charlie
+
+    When I tap `ContactsButton` button
+    Then I tap `SearchButton` button
+
+    When I fill `SearchField` field with "Bob"
+    Then I see user Bob in search results
+
+    When I fill `SearchField` field with "Charlie"
+    Then I see contact Charlie in search results

--- a/test/e2e/features/home/contacts_searching/.feature
+++ b/test/e2e/features/home/contacts_searching/.feature
@@ -20,7 +20,6 @@ Feature: Contacts searching
     Given I am Alice
     And users Bob and Charlie
     And contact Charlie
-    And I have "Example" group with Bob
 
     When I tap `ContactsButton` button
     Then I tap `SearchButton` button

--- a/test/e2e/features/home/contacts_searching/.feature
+++ b/test/e2e/features/home/contacts_searching/.feature
@@ -20,6 +20,7 @@ Feature: Contacts searching
     Given I am Alice
     And users Bob and Charlie
     And contact Charlie
+    And I have "Example" group with Bob
 
     When I tap `ContactsButton` button
     Then I tap `SearchButton` button

--- a/test/e2e/steps/long_press_chat.dart
+++ b/test/e2e/steps/long_press_chat.dart
@@ -27,13 +27,22 @@ import '../world/custom_world.dart';
 final StepDefinitionGeneric longPressChat = when1<String, CustomWorld>(
   'I long press {string} chat',
   (name, context) async {
-    await context.world.appDriver.waitForAppToSettle();
-    final finder = context.world.appDriver.findBy(
-      'RecentChat_${context.world.groups[name]}',
-      FindType.key,
-    );
+    await context.world.appDriver.waitUntil(() async {
+      await context.world.appDriver.waitForAppToSettle();
 
-    await context.world.appDriver.nativeDriver.longPress(finder);
-    await context.world.appDriver.waitForAppToSettle();
+      try {
+        final finder = context.world.appDriver.findBy(
+          'RecentChat_${context.world.groups[name]}',
+          FindType.key,
+        );
+
+        await context.world.appDriver.nativeDriver.longPress(finder);
+        await context.world.appDriver.waitForAppToSettle();
+
+        return true;
+      } catch (e) {
+        return false;
+      }
+    });
   },
 );


### PR DESCRIPTION
Resolves #259




## Synopsis

На вкладке чатов уже есть поиск, на вкладке контактов - пока заглушка.




## Solution

Нужно реализовать поиск на вкладке контактов по контактам и глобальным пользователям. Клики по тайликам должны открывать страницы этих пользователей (и тайлик соответственно подсвечиваться синим).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
