### PR TITLE
Don't create `Chat` when it doesn't exist unless a `ChatMessage` is posted (#113)

### DIFF
--- a/lib/domain/model/chat.dart
+++ b/lib/domain/model/chat.dart
@@ -18,6 +18,7 @@
 import 'package:collection/collection.dart';
 import 'package:get/get.dart';
 import 'package:hive/hive.dart';
+import 'package:uuid/uuid.dart';
 
 import '../model_type_id.dart';
 import '/api/backend/schema.dart' show ChatKind;
@@ -244,6 +245,12 @@ class LastChatRead {
 @HiveType(typeId: ModelTypeId.chatId)
 class ChatId extends NewType<String> {
   const ChatId(String val) : super(val);
+
+  /// Constructs a dummy [ChatId].
+  factory ChatId.local() => ChatId('local_${const Uuid().v4()}');
+
+  /// Indicates whether this [ChatId] is a dummy ID.
+  bool get isLocal => val.startsWith('local_');
 }
 
 /// Name of a [Chat].

--- a/lib/domain/repository/chat.dart
+++ b/lib/domain/repository/chat.dart
@@ -25,6 +25,7 @@ import '../model/chat.dart';
 import '../model/chat_item.dart';
 import '../model/chat_item_quote.dart';
 import '../model/mute_duration.dart';
+import '../model/my_user.dart';
 import '../model/native_file.dart';
 import '../model/user.dart';
 import '../model/user_call_cover.dart';
@@ -70,6 +71,13 @@ abstract class AbstractChatRepository {
   /// Creates a dialog [Chat] between the given [responderId] and the
   /// authenticated [MyUser].
   Future<RxChat> createDialogChat(UserId responderId);
+
+  /// Creates a local dialog [Chat] between the given [responder] and the
+  /// authenticated [MyUser].
+  Future<Chat> createLocalDialogChat(User responder);
+
+  /// Replaces a [local] dialog [Chat] with an remote.
+  Future<RxChat> replaceLocalDialog(RxChat local);
 
   /// Creates a group [Chat] with the provided members and the authenticated
   /// [MyUser], optionally [name]d.

--- a/lib/domain/service/chat.dart
+++ b/lib/domain/service/chat.dart
@@ -69,6 +69,15 @@ class ChatService extends DisposableService {
   Future<RxChat> createDialogChat(UserId responderId) =>
       _chatRepository.createDialogChat(responderId);
 
+  /// Creates a local dialog [Chat] between the given [responder] and the
+  /// authenticated [MyUser].
+  Future<Chat> createLocalDialogChat(User responder) =>
+      _chatRepository.createLocalDialogChat(responder);
+
+  /// Replaces a [local] dialog [Chat] with an remote.
+  Future<RxChat> replaceLocalDialog(RxChat local) =>
+      _chatRepository.replaceLocalDialog(local);
+
   /// Creates a group [Chat] with the provided members and the authenticated
   /// [MyUser], optionally [name]d.
   Future<RxChat> createGroupChat(List<UserId> memberIds, {ChatName? name}) =>

--- a/lib/provider/hive/draft.dart
+++ b/lib/provider/hive/draft.dart
@@ -89,4 +89,16 @@ class DraftHiveProvider extends HiveBaseProvider<ChatMessage> {
 
   /// Removes a [ChatMessage] from [Hive] by the provided [id].
   Future<void> remove(ChatId id) => deleteSafe(id.val);
+
+  /// Moves the element at the [oldKey] to the [newKey] replacing the existing
+  /// element, if any.
+  ///
+  /// No-op, if element at the [oldKey] doesn't exist.
+  Future<void> move(ChatId oldKey, ChatId newKey) async {
+    ChatMessage? draft = get(oldKey);
+    if(draft != null) {
+      remove(oldKey);
+      put(newKey, draft);
+    }
+  }
 }

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -263,7 +263,7 @@ class HiveRxChat extends RxChat {
 
   /// Subscribes to the remote updates of the [chat] if not subscribed already.
   void subscribe() {
-    if (!_remoteSubscriptionInitialized) {
+    if (!_remoteSubscriptionInitialized && !id.isLocal) {
       _initRemoteSubscription(id);
     }
   }
@@ -308,6 +308,10 @@ class HiveRxChat extends RxChat {
 
   @override
   Future<void> fetchMessages() async {
+    if(id.isLocal) {
+      return;
+    }
+
     if (!status.value.isLoading) {
       status.value = RxStatus.loadingMore();
     }
@@ -654,7 +658,7 @@ class HiveRxChat extends RxChat {
     }
 
     members
-        .removeWhere((k, _) => !chat.value.members.any((m) => m.user.id == k));
+        .removeWhere((k, _) => chat.value.members.none((m) => m.user.id == k));
 
     if (chat.value.name == null) {
       var users = members.values.take(3);

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -208,13 +208,21 @@ class UserController extends GetxController {
     }
   }
 
-  // TODO: No [Chat] should be created.
   /// Opens a [Chat]-dialog with this [user].
   ///
   /// Creates a new one if it doesn't exist.
   Future<void> openChat() async {
     Chat? dialog = user?.user.value.dialog;
-    dialog ??= (await _chatService.createDialogChat(user!.id)).chat.value;
+
+    if (user!.id == me) {
+      dialog ??= (await _chatService.createDialogChat(user!.id)).chat.value;
+    } else {
+      if (dialog?.id.isLocal ?? false) {
+        dialog = (await _chatService.get(dialog!.id))?.chat.value;
+      }
+      dialog ??= await _chatService.createLocalDialogChat(user!.user.value);
+    }
+
     router.chat(dialog.id, push: true);
   }
 


### PR DESCRIPTION
Resolves #113




## Synopsis

Чат должен создаваться только после отправки первого сообщения либо начала звонка.




## Solution

Необходимый функционал будет добален.




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
