### PR TITLE
Add search exiting on escape presses (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All user visible changes to this project will be documented in this file. This p
     - Chats tab:
         - Chat muting/unmuting. ([#251], [#172], [#63])
         - Favorite chats. ([#218], [#209])
-        - Searching. ([#206], [#205])
+        - Searching. ([#310], [#206], [#205])
     - Home page:
         - Quick status changing menu. ([#275], [#204], [#203])
     - Media panel:
@@ -29,7 +29,7 @@ All user visible changes to this project will be documented in this file. This p
         - Screen share display choosing on desktop. ([#228], [#222])
     - Contacts tab:
         - Favorite contacts. ([#285], [#237], [#223])
-        - Searching. ([#260], [#259])
+        - Searching. ([#310], [#260], [#259])
     - User page:
         - Blacklisting. ([#277], [#234], [#229])
     - Window's size and position persistence. ([#274], [#263])
@@ -137,6 +137,7 @@ All user visible changes to this project will be documented in this file. This p
 [#292]: /../../issues/292
 [#293]: /../../pull/293
 [#300]: /../../pull/300
+[#310]: /../../pull/310
 
 
 

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -539,11 +539,16 @@ class ChatsTabController extends GetxController {
     }
   }
 
-  /// Handles the [LogicalKeyboardKey.escape] event.
+  /// Closes the [searching] on the [LogicalKeyboardKey.escape] events.
+  ///
+  /// Intended to be used as a [HardwareKeyboard] listener.
   bool _escapeListener(KeyEvent e) {
-    if (e.logicalKey == LogicalKeyboardKey.escape) {
+    if (e is KeyDownEvent && e.logicalKey == LogicalKeyboardKey.escape) {
       if (searching.value) {
         closeSearch(!groupCreating.value);
+        return true;
+      } else if (groupCreating.value) {
+        closeGroupCreating();
         return true;
       }
     }

--- a/lib/ui/page/home/tab/contacts/controller.dart
+++ b/lib/ui/page/home/tab/contacts/controller.dart
@@ -413,9 +413,11 @@ class ContactsTabController extends GetxController {
     }
   }
 
-  /// Handles the [LogicalKeyboardKey.escape] event.
+  /// Closes the [search]ing on the [LogicalKeyboardKey.escape] events.
+  ///
+  /// Intended to be used as a [HardwareKeyboard] listener.
   bool _escapeListener(KeyEvent e) {
-    if (e.logicalKey == LogicalKeyboardKey.escape) {
+    if (e is KeyDownEvent && e.logicalKey == LogicalKeyboardKey.escape) {
       if (search.value != null) {
         toggleSearch(false);
         return true;


### PR DESCRIPTION
Resolves #299




## Synopsis

На вкладке чатов и на вкладке контактов есть поиск. Хочется добавить выход из режима поиска по нажатию эскейпа на клавиатуре.




## Solution

Добавить выход из режима поиска по нажатию на эскейп.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
