### PR TITLE
Redesign status in `Menu` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ All user visible changes to this project will be documented in this file. This p
     - Home page:
         - Redesigned chats tab. ([#142])
         - Redesigned introduction and logout modals. ([#249])
-        - Redesigned menu tab. ([#244], [#243])
+        - Redesigned menu tab. ([#313], [#244], [#243])
     - Media panel:
         - Video resizing when dragged. ([#191], [#190])
         - Redesigned mobile interface. ([#287], [#246])
@@ -147,6 +147,7 @@ All user visible changes to this project will be documented in this file. This p
 [#300]: /../../pull/300
 [#305]: /../../pull/305
 [#310]: /../../pull/310
+[#313]: /../../pull/313
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -104,7 +104,7 @@ btn_call_remote_video_on = Enable incoming video
 btn_call_remote_video_on_desc =
     Enable
     incoming video
-btn_call_remove_participant = Kick participant
+btn_call_remove_participant = Remove from call
 btn_call_screen_off = Stop screen sharing
 btn_call_screen_off_desc =
     Stop screen
@@ -113,7 +113,7 @@ btn_call_screen_on = Share screen
 btn_call_screen_on_desc =
     Share
     screen
-btn_call_settings = Settings
+btn_call_settings = Call settings
 btn_call_switch_camera = Switch camera
 btn_call_switch_camera_desc =
     Switch
@@ -281,8 +281,8 @@ err_wrong_members_count = No more that 100 members is allowed
 err_wrong_items_count = Wrong items count
 err_wrong_old_password = Wrong password.
 err_wrong_recovery_code = Provided code is wrong.
-err_you_already_add_this_email = E-mail is already added.
-err_you_already_add_this_phone = Phone number is already added.
+err_you_already_add_this_email = Indicated E-mail has been added already.
+err_you_already_add_this_phone = Indicated phone has been added already.
 err_you_already_has_unconfirmed_email = You already have an unconfirmed E-mail.
 err_you_already_has_unconfirmed_phone = You already have an unconfirmed phone.
 err_you_are_blacklisted = You are blacklisted
@@ -359,7 +359,7 @@ label_attachments = [{$count} { $count ->
     }]
 label_audio_call = Audio call
 label_audio_notifications = Audio notifications
-label_away = Away
+label_away = away
 label_background = Background
 label_biography = Biography
 label_biography_hint = Write about yourself
@@ -422,9 +422,9 @@ label_direct_chat_link_description =
     Users who came via a direct link to
     the chat are automatically added to your chat list. Regardless of your
     privacy settings they can:
-    - visit your profile,
-    - send you messages,
-    - make calls
+    - visit your profile;
+    - send you messages;
+    - call you.
 
     After the chat created by this link is deleted, your privacy
     settings are respected.
@@ -463,7 +463,7 @@ label_gallery = Gallery
 label_group_created = Group created
 label_hello = Hello!
 label_hello_reply = Yay, hello :)
-label_hidden = Status is hidden
+label_hidden = Last seen recently
 label_hint_drag_n_drop_buttons =
     Add and remove elements of the control panel by drag-and-drop.
 label_hint_drag_n_drop_video =
@@ -501,7 +501,7 @@ label_media = Media
 label_media_camera = Camera
 label_media_microphone = Microphone
 label_media_no_device_available = No device is available
-label_media_output = Output
+label_media_output = Audio output
 label_media_section_hint = Audio and video devices
 label_media_settings = Media settings
 label_menu = Menu
@@ -534,8 +534,8 @@ label_nobody = No one
 label_nothing_found = Nothing was found
 label_notifications = Notifications
 label_num = Gapopa ID
-label_offline = Offline
-label_online = Online
+label_offline = offline
+label_online = online
 label_open_calls_in_app = Display calls in the application.
 label_open_calls_in_window = Display calls in a separate window.
 label_or_register = or register
@@ -561,7 +561,7 @@ label_phone_visible = Your phone is visible to:{" "}
 label_photo = Photo
 label_presence = Presence
 label_presence_away = Away
-label_presence_hidden = Hidden
+label_presence_hidden = Don't show
 label_presence_present = Online
 label_profile = Profile
 label_public_information = Public information

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -197,6 +197,7 @@ btn_submit = Submit
 btn_unblock = Unblock
 btn_unmute = Unmute
 btn_unmute_chat = Unmute chat
+btn_upload = Upload
 btn_video_call = Video call
 btn_write_message = Write a message
 btn_your_profile = Your profile

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -104,7 +104,7 @@ btn_call_remote_video_on = Включить входящее видео
 btn_call_remote_video_on_desc =
     Включить
     входящее видео
-btn_call_remove_participant = Выгнать участника
+btn_call_remove_participant = Удалить из звонка
 btn_call_screen_off = Завершить демонстрацию экрана
 btn_call_screen_off_desc =
     Завершить
@@ -113,7 +113,7 @@ btn_call_screen_on = Демонстрация экрана
 btn_call_screen_on_desc =
     Демонстрация
     экрана
-btn_call_settings = Настройки
+btn_call_settings = Настройки звонка
 btn_call_switch_camera = Переключить камеру
 btn_call_switch_camera_desc =
     Переключить
@@ -134,7 +134,7 @@ btn_call_video_on_desc =
     камеру
 btn_change = Сменить
 btn_change_avatar = Изменить аватар
-btn_change_password = Изменить пароль
+btn_change_password = Сменить пароль
 btn_clear_chat = Очистить чат
 btn_close = Закрыть
 btn_confirm = Подтвердить
@@ -227,7 +227,7 @@ err_could_not_download = При загрузке произошла ошибка
 err_data_transfer =
     Ошибка передачи данных. Пожалуйста, проверьте Ваше подключение к сети.
 err_dimensions_too_big = Слишком большое разрешение
-err_email_occupied = Почта уже привязана к другому аккаунту
+err_email_occupied = Указанный E-mail привязан к другому аккаунту. Пожалуйста, сначала аннулируйте предыдущую верификацию.
 err_incorrect_chat_name = Некорректное имя
 err_incorrect_email = Некорректный E-mail.
 err_incorrect_input = Некорректный формат.
@@ -237,7 +237,7 @@ err_incorrect_phone = Некорректный номер телефона.
 err_input_empty = Поле не должно быть пустым.
 err_invalid_crop_coordinates = Неверные координаты обрезки
 err_invalid_crop_points = Неверные точки обрезки
-err_login_occupied = Логин уже занят
+err_login_occupied = Данный логин уже занят.
 err_message_was_read = Сообщение было прочитано
 err_network = Ошибка подключения к серверу
 err_no_filename = Файл должен иметь имя
@@ -283,8 +283,8 @@ err_wrong_items_count = Неправильное количество сообщ
 err_wrong_members_count = Участников не может быть больше 100
 err_wrong_old_password = Неправильный пароль.
 err_wrong_recovery_code = Неверный код.
-err_you_already_add_this_email = E-mail уже добавлен.
-err_you_already_add_this_phone = Номер телефона уже добавлен.
+err_you_already_add_this_email = Вы уже добавили указанный E-mail.
+err_you_already_add_this_phone = Вы уже добавили указанный номер телефона.
 err_you_already_has_unconfirmed_email = Вы имеете неподтвержденный E-mail.
 err_you_already_has_unconfirmed_phone = Вы имеете неподтвержденный телефон.
 err_you_are_blacklisted = Вы в чёрном списке
@@ -374,7 +374,7 @@ label_attachments = [{$count} { $count ->
     }]
 label_audio_call = Аудиозвонок
 label_audio_notifications = Звуковые уведомления
-label_away = Нет на месте
+label_away = отошёл
 label_background = Бэкграунд
 label_biography = Биография
 label_biography_hint = Несколько слов о Вас
@@ -410,7 +410,7 @@ label_chat_call_unanswered = Неотвеченный звонок
 label_chat_members = Участники
 label_chat_monolog = Сохранённые сообщения
 label_chats = Чаты
-label_confirm = Confirm
+label_confirm = Подтвердить
 label_confirmation_code = Код подтверждения
 label_contact = Контакт
 label_contact_information = Контактная информация
@@ -437,10 +437,9 @@ label_direct_chat_link_description =
     Пользователи, пришедшие по прямой
     ссылке на чат, добавляются в Ваш список чатов автоматически.
     Они имеют возможность, независимо от настроек конфиденциальности:
-
-    - просматривать Ваш профиль,
-    - отправлять Вам сообщения,
-    - совершать звонки
+    - просматривать Ваш профиль;
+    - отправлять Вам сообщения;
+    - звонить Вам.
 
     После удаления чата, созданного по прямой ссылке на чат,
     применяются Ваши настройки конфиденциальности.
@@ -480,7 +479,7 @@ label_gallery = Галерея
 label_group_created = Группа создана
 label_hello = Привет!
 label_hello_reply = Оу, привет :)
-label_hidden = Статус скрыт
+label_hidden = Был(а) недавно
 label_hint_drag_n_drop_buttons =
     Элементы панели управления могут быть добавлены и удалены простым перетаскиванием.
 label_hint_drag_n_drop_video =
@@ -518,7 +517,7 @@ label_media = Медиа
 label_media_camera = Камера
 label_media_microphone = Микрофон
 label_media_no_device_available = Нет доступных устройств
-label_media_output = Устройство выхода
+label_media_output = Устройство аудио вывода
 label_media_section_hint = Аудио и видео устройства
 label_media_settings = Настройки медиа
 label_menu = Меню
@@ -554,8 +553,8 @@ label_nobody = Никто
 label_nothing_found = Ничего не найдено
 label_notifications = Уведомления
 label_num = Gapopa ID
-label_offline = Офлайн
-label_online = Онлайн
+label_offline = офлайн
+label_online = онлайн
 label_open_calls_in_app = Отображать звонки в окне приложения.
 label_open_calls_in_window = Отображать звонки в отдельном окне.
 label_or_register = или регистрация
@@ -581,7 +580,7 @@ label_phone_visible = Ваш номер телефона видят:{" "}
 label_photo = Фото
 label_presence = Отображение статуса
 label_presence_away = Отошёл
-label_presence_hidden = Скрыт
+label_presence_hidden = Не показывать
 label_presence_present = Онлайн
 label_profile = Профиль
 label_public_information = Публичная информация

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -197,6 +197,7 @@ btn_submit = Применить
 btn_unblock = Разблокировать
 btn_unmute = Включить звук
 btn_unmute_chat = Включить звук
+btn_upload = Загрузить
 btn_video_call = Видеозвонок
 btn_write_message = Написать сообщение
 btn_your_profile = Ваш профиль

--- a/lib/api/backend/graphql/mutation/contact/FavoriteChatContact.graphql
+++ b/lib/api/backend/graphql/mutation/contact/FavoriteChatContact.graphql
@@ -15,7 +15,7 @@
 # along with this program. If not, see
 # <https://www.gnu.org/licenses/agpl-3.0.html>.
 
-mutation FavoriteChatContact($id: ChatContactId!, $pos: ChatContactPosition!){
+mutation FavoriteChatContact($id: ChatContactId!, $pos: ChatContactPosition!) {
     favoriteChatContact(id: $id, pos: $pos) {
         __typename
         ... on ChatContactEventsVersioned {

--- a/lib/domain/repository/my_user.dart
+++ b/lib/domain/repository/my_user.dart
@@ -17,13 +17,13 @@
 
 import 'package:get/get.dart';
 
-import '../model/my_user.dart';
-import '../model/user.dart';
 import '/api/backend/schema.dart' show Presence;
 import '/domain/model/gallery_item.dart';
 import '/domain/model/image_gallery_item.dart';
 import '/domain/model/mute_duration.dart';
+import '/domain/model/my_user.dart';
 import '/domain/model/native_file.dart';
+import '/domain/model/user.dart';
 import '/domain/repository/user.dart';
 
 /// [MyUser] repository interface.

--- a/lib/domain/service/call.dart
+++ b/lib/domain/service/call.dart
@@ -145,6 +145,8 @@ class CallService extends DisposableService {
       call.value.dispose();
     }
 
+    deviceId ??= WebUtils.getCall(chatId)?.deviceId;
+
     if (deviceId != null) {
       await _callsRepo.leave(chatId, deviceId);
     } else {

--- a/lib/provider/gql/components/contact.dart
+++ b/lib/provider/gql/components/contact.dart
@@ -223,8 +223,7 @@ abstract class ContactGraphQlMixin {
   /// [ChatContact] has such name already.
   Future<ChatContactEventsVersionedMixin> changeContactName(
       ChatContactId id, UserName name) async {
-    UpdateChatContactNameArguments variables =
-        UpdateChatContactNameArguments(id: id, name: name);
+    final variables = UpdateChatContactNameArguments(id: id, name: name);
     final QueryResult result = await client.mutate(
       MutationOptions(
         operationName: 'UpdateChatContactName',

--- a/lib/provider/gql/components/user.dart
+++ b/lib/provider/gql/components/user.dart
@@ -886,7 +886,7 @@ abstract class UserGraphQlMixin {
   /// ### Idempotent
   ///
   /// Succeeds as no-op (and returns no [MyUserEvent]) if the authenticated
-  /// [MyUser] is muted already `until` the specified datetime (or unmuted).
+  /// [MyUser] is muted already `until` the specified [DateTime] (or unmuted).
   Future<MyUserEventsVersionedMixin?> toggleMyUserMute(Muting? mute) async {
     final variables = ToggleMyUserMuteArguments(mute: mute);
     final QueryResult result = await client.mutate(

--- a/lib/provider/gql/exceptions.dart
+++ b/lib/provider/gql/exceptions.dart
@@ -398,7 +398,7 @@ class DeclineChatCallException
   final DeclineChatCallErrorCode code;
 
   @override
-  String toString() => 'LeaveChatCallException($code)';
+  String toString() => 'DeclineChatCallException($code)';
 
   @override
   String toMessage() {

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -687,20 +687,22 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
             .firstWhereOrNull((e) => e.user.id == m.memberId)
             ?.user;
 
-        avatars.add(
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 1),
-            child: FutureBuilder<RxUser?>(
-              future: widget.getUser?.call(user!.id),
-              builder: (context, snapshot) {
-                if (snapshot.hasData) {
-                  return AvatarWidget.fromRxUser(snapshot.data, radius: 10);
-                }
-                return AvatarWidget.fromUser(user, radius: 10);
-              },
+        if (user != null) {
+          avatars.add(
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 1),
+              child: FutureBuilder<RxUser?>(
+                future: widget.getUser?.call(user.id),
+                builder: (context, snapshot) {
+                  if (snapshot.hasData) {
+                    return AvatarWidget.fromRxUser(snapshot.data, radius: 10);
+                  }
+                  return AvatarWidget.fromUser(user, radius: 10);
+                },
+              ),
             ),
-          ),
-        );
+          );
+        }
       }
 
       if (widget.reads.length > maxAvatars) {

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1250,20 +1250,22 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
             .firstWhereOrNull((e) => e.user.id == m.memberId)
             ?.user;
 
-        avatars.add(
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 1),
-            child: FutureBuilder<RxUser?>(
-              future: widget.getUser?.call(user!.id),
-              builder: (context, snapshot) {
-                if (snapshot.hasData) {
-                  return AvatarWidget.fromRxUser(snapshot.data, radius: 10);
-                }
-                return AvatarWidget.fromUser(user, radius: 10);
-              },
+        if (user != null) {
+          avatars.add(
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 1),
+              child: FutureBuilder<RxUser?>(
+                future: widget.getUser?.call(user.id),
+                builder: (context, snapshot) {
+                  if (snapshot.hasData) {
+                    return AvatarWidget.fromRxUser(snapshot.data, radius: 10);
+                  }
+                  return AvatarWidget.fromUser(user, radius: 10);
+                },
+              ),
             ),
-          ),
-        );
+          );
+        }
       }
 
       if (widget.reads.length > maxAvatars) {

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -128,7 +128,7 @@ class MyProfileController extends GetxController {
   Rx<MediaSettings?> get media => _settingsRepo.mediaSettings;
 
   @override
-  void onInit() async {
+  void onInit() {
     try {
       _jason = Jason();
       _mediaManager = _jason?.mediaManager();

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -1013,23 +1013,27 @@ Widget _background(BuildContext context, MyProfileController c) {
           ),
         ),
         Obx(() {
-          if (c.background.value == null) {
-            return const SizedBox();
-          }
-
           return Padding(
             padding: const EdgeInsets.only(top: 10),
             child: Center(
-              child: WidgetButton(
-                onPressed:
-                    c.background.value == null ? null : c.removeBackground,
-                child: Text(
-                  'btn_delete'.l10n,
-                  style: TextStyle(
-                    color: Theme.of(context).colorScheme.secondary,
-                    fontSize: 11,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  WidgetButton(
+                    onPressed: c.background.value == null
+                        ? c.pickBackground
+                        : c.removeBackground,
+                    child: Text(
+                      c.background.value == null
+                          ? 'btn_upload'.l10n
+                          : 'btn_delete'.l10n,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.secondary,
+                        fontSize: 11,
+                      ),
+                    ),
                   ),
-                ),
+                ],
               ),
             ),
           );
@@ -1244,7 +1248,7 @@ Widget _downloads(BuildContext context, MyProfileController c) {
           asset: 'windows',
           width: 21.93,
           height: 22,
-          title: 'Windows'.l10n,
+          title: 'Windows',
           link: 'messenger-windows.zip',
         ),
         const SizedBox(height: 8),
@@ -1252,7 +1256,7 @@ Widget _downloads(BuildContext context, MyProfileController c) {
           asset: 'apple',
           width: 23,
           height: 29,
-          title: 'macOS'.l10n,
+          title: 'macOS',
           link: 'messenger-macos.zip',
         ),
         const SizedBox(height: 8),
@@ -1260,7 +1264,7 @@ Widget _downloads(BuildContext context, MyProfileController c) {
           asset: 'linux',
           width: 18.85,
           height: 22,
-          title: 'Linux'.l10n,
+          title: 'Linux',
           link: 'messenger-linux.zip',
         ),
         const SizedBox(height: 8),
@@ -1268,14 +1272,14 @@ Widget _downloads(BuildContext context, MyProfileController c) {
           asset: 'apple',
           width: 23,
           height: 29,
-          title: 'iOS'.l10n,
+          title: 'iOS',
         ),
         const SizedBox(height: 8),
         button(
           asset: 'google',
           width: 20.33,
           height: 22.02,
-          title: 'Android'.l10n,
+          title: 'Android',
           link: 'messenger-android.apk',
         ),
       ],

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -33,6 +33,8 @@ import '/domain/service/chat.dart';
 import '/domain/service/contact.dart';
 import '/domain/service/user.dart';
 import '/l10n/l10n.dart';
+import '/provider/gql/exceptions.dart'
+    show FavoriteChatContactException, UnfavoriteChatContactException;
 import '/routes.dart';
 import '/util/message_popup.dart';
 import '/util/obs/obs.dart';
@@ -71,7 +73,7 @@ class UserController extends GetxController {
   final RxBool isMuted = RxBool(false);
 
   /// Temporary indicator whether the [user] is favorite.
-  final RxBool inFavorites = RxBool(false);
+  late final RxBool inFavorites;
 
   /// Indicator whether this [user] is already in the contacts list of the
   /// authenticated [MyUser].
@@ -118,6 +120,11 @@ class UserController extends GetxController {
               .any((e) => e.contact.value.users.every((m) => m.id == id)),
     );
 
+    inFavorites = RxBool(
+      _contactService.favorites.values
+          .any((e) => e.contact.value.users.every((m) => m.id == id)),
+    );
+
     _contactsSubscription = _contactService.contacts.changes.listen((e) {
       switch (e.op) {
         case OperationKind.added:
@@ -142,13 +149,14 @@ class UserController extends GetxController {
       switch (e.op) {
         case OperationKind.added:
           if (e.value?.contact.value.users.every((e) => e.id == id) == true) {
+            inFavorites.value = true;
             inContacts.value = true;
           }
           break;
 
         case OperationKind.removed:
           if (e.value?.contact.value.users.every((e) => e.id == id) == true) {
-            inContacts.value = false;
+            inFavorites.value = false;
           }
           break;
 
@@ -239,6 +247,41 @@ class UserController extends GetxController {
 
   /// Removes the [user] from the blacklist of the authenticated [MyUser].
   Future<void> unblacklist() => _userService.unblacklistUser(id);
+
+  /// Marks the [user] as favorited.
+  Future<void> favoriteContact() async {
+    try {
+      RxChatContact? contact = _contactService.contacts.values.firstWhereOrNull(
+        (e) => e.contact.value.users.every((m) => m.id == user?.id),
+      );
+      if (contact != null) {
+        await _contactService.favoriteChatContact(contact.id);
+      }
+    } on FavoriteChatContactException catch (e) {
+      MessagePopup.error(e);
+    } catch (e) {
+      MessagePopup.error(e);
+      rethrow;
+    }
+  }
+
+  /// Removes the [user] from the favorites.
+  Future<void> unfavoriteContact() async {
+    try {
+      RxChatContact? contact =
+          _contactService.favorites.values.firstWhereOrNull(
+        (e) => e.contact.value.users.every((m) => m.id == user?.id),
+      );
+      if (contact != null) {
+        await _contactService.unfavoriteChatContact(contact.id);
+      }
+    } on UnfavoriteChatContactException catch (e) {
+      MessagePopup.error(e);
+    } catch (e) {
+      MessagePopup.error(e);
+      rethrow;
+    }
+  }
 
   /// Fetches the [user] value from the [_userService].
   Future<void> _fetchUser() async {

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -48,149 +48,147 @@ class UserView extends StatelessWidget {
       tag: id.val,
       builder: (UserController c) {
         return Obx(() {
-          if (c.status.value.isSuccess) {
+          if (!c.status.value.isSuccess) {
             return Scaffold(
-              appBar: CustomAppBar(
-                title: Row(
-                  children: [
-                    Material(
-                      elevation: 6,
-                      type: MaterialType.circle,
-                      shadowColor: const Color(0x55000000),
-                      color: Colors.white,
-                      child: Center(
-                        child: AvatarWidget.fromRxUser(c.user, radius: 17),
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    Flexible(
-                      child: DefaultTextStyle.merge(
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        child: Obx(() {
-                          final String? status = c.user?.user.value.getStatus();
-                          final UserTextStatus? text =
-                              c.user?.user.value.status;
-                          final StringBuffer buffer = StringBuffer();
-
-                          if (status != null || text != null) {
-                            buffer.write(text ?? '');
-
-                            if (status != null && text != null) {
-                              buffer.write('space_vertical_space'.l10n);
-                            }
-
-                            buffer.write(status ?? '');
-                          }
-
-                          final String subtitle = buffer.toString();
-
-                          return Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                  '${c.user?.user.value.name?.val ?? c.user?.user.value.num.val}'),
-                              if (subtitle.isNotEmpty)
-                                Text(
-                                  subtitle,
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .caption
-                                      ?.copyWith(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .primary,
-                                      ),
-                                )
-                            ],
-                          );
-                        }),
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                  ],
-                ),
-                padding: const EdgeInsets.only(left: 4, right: 20),
-                leading: const [StyledBackButton()],
-                actions: [
-                  WidgetButton(
-                    onPressed: c.openChat,
-                    child: Transform.translate(
-                      offset: const Offset(0, 1),
-                      child: SvgLoader.asset(
-                        'assets/icons/chat.svg',
-                        width: 20.12,
-                        height: 21.62,
-                      ),
-                    ),
-                  ),
-                  if (!context.isNarrow) ...[
-                    const SizedBox(width: 28),
-                    WidgetButton(
-                      onPressed: () => c.call(true),
-                      child: SvgLoader.asset(
-                        'assets/icons/chat_video_call.svg',
-                        height: 17,
-                      ),
-                    ),
-                  ],
-                  const SizedBox(width: 28),
-                  WidgetButton(
-                    onPressed: () => c.call(false),
-                    child: SvgLoader.asset(
-                      'assets/icons/chat_audio_call.svg',
-                      height: 19,
-                    ),
-                  ),
-                ],
+              appBar: const CustomAppBar(
+                padding: EdgeInsets.only(left: 4, right: 20),
+                leading: [StyledBackButton()],
               ),
-              body: Scrollbar(
-                controller: c.scrollController,
-                child: Obx(() {
-                  return ListView(
-                    key: const Key('UserColumn'),
-                    controller: c.scrollController,
-                    children: [
-                      const SizedBox(height: 8),
-                      Block(
-                        title: 'label_public_information'.l10n,
-                        children: [
-                          AvatarWidget.fromRxUser(
-                            c.user,
-                            radius: 100,
-                            showBadge: false,
-                          ),
-                          const SizedBox(height: 15),
-                          _name(c, context),
-                          _status(c, context),
-                          _presence(c, context),
-                        ],
-                      ),
-                      Block(
-                        title: 'label_contact_information'.l10n,
-                        children: [_num(c, context)],
-                      ),
-                      Block(
-                        title: 'label_actions'.l10n,
-                        children: [_actions(c, context)],
-                      ),
-                    ],
-                  );
-                }),
+              body: Center(
+                child: c.status.value.isEmpty
+                    ? Text('err_unknown_user'.l10n)
+                    : const CircularProgressIndicator(),
               ),
             );
           }
 
           return Scaffold(
-            appBar: const CustomAppBar(
-              padding: EdgeInsets.only(left: 4, right: 20),
-              leading: [StyledBackButton()],
+            appBar: CustomAppBar(
+              title: Row(
+                children: [
+                  Material(
+                    elevation: 6,
+                    type: MaterialType.circle,
+                    shadowColor: const Color(0x55000000),
+                    color: Colors.white,
+                    child: Center(
+                      child: AvatarWidget.fromRxUser(c.user, radius: 17),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Flexible(
+                    child: DefaultTextStyle.merge(
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      child: Obx(() {
+                        final String? status = c.user?.user.value.getStatus();
+                        final UserTextStatus? text = c.user?.user.value.status;
+                        final StringBuffer buffer = StringBuffer();
+
+                        if (status != null || text != null) {
+                          buffer.write(text ?? '');
+
+                          if (status != null && text != null) {
+                            buffer.write('space_vertical_space'.l10n);
+                          }
+
+                          buffer.write(status ?? '');
+                        }
+
+                        final String subtitle = buffer.toString();
+
+                        return Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                                '${c.user?.user.value.name?.val ?? c.user?.user.value.num.val}'),
+                            if (subtitle.isNotEmpty)
+                              Text(
+                                subtitle,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .caption
+                                    ?.copyWith(
+                                      color:
+                                          Theme.of(context).colorScheme.primary,
+                                    ),
+                              )
+                          ],
+                        );
+                      }),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                ],
+              ),
+              padding: const EdgeInsets.only(left: 4, right: 20),
+              leading: const [StyledBackButton()],
+              actions: [
+                WidgetButton(
+                  onPressed: c.openChat,
+                  child: Transform.translate(
+                    offset: const Offset(0, 1),
+                    child: SvgLoader.asset(
+                      'assets/icons/chat.svg',
+                      width: 20.12,
+                      height: 21.62,
+                    ),
+                  ),
+                ),
+                if (!context.isNarrow) ...[
+                  const SizedBox(width: 28),
+                  WidgetButton(
+                    onPressed: () => c.call(true),
+                    child: SvgLoader.asset(
+                      'assets/icons/chat_video_call.svg',
+                      height: 17,
+                    ),
+                  ),
+                ],
+                const SizedBox(width: 28),
+                WidgetButton(
+                  onPressed: () => c.call(false),
+                  child: SvgLoader.asset(
+                    'assets/icons/chat_audio_call.svg',
+                    height: 19,
+                  ),
+                ),
+              ],
             ),
-            body: Center(
-              child: c.status.value.isEmpty
-                  ? Text('err_unknown_user'.l10n)
-                  : const CircularProgressIndicator(),
+            body: Scrollbar(
+              controller: c.scrollController,
+              child: Obx(() {
+                return ListView(
+                  key: const Key('UserColumn'),
+                  controller: c.scrollController,
+                  children: [
+                    const SizedBox(height: 8),
+                    Block(
+                      title: 'label_public_information'.l10n,
+                      children: [
+                        AvatarWidget.fromRxUser(
+                          c.user,
+                          radius: 100,
+                          showBadge: false,
+                        ),
+                        const SizedBox(height: 15),
+                        _name(c, context),
+                        _status(c, context),
+                        _presence(c, context),
+                      ],
+                    ),
+                    Block(
+                      title: 'label_contact_information'.l10n,
+                      children: [_num(c, context)],
+                    ),
+                    Block(
+                      title: 'label_actions'.l10n,
+                      children: [_actions(c, context)],
+                    ),
+                  ],
+                );
+              }),
             ),
           );
         });
@@ -260,7 +258,8 @@ class UserView extends StatelessWidget {
             text: c.inFavorites.value
                 ? 'btn_delete_from_favorites'.l10n
                 : 'btn_add_to_favorites'.l10n,
-            onPressed: c.inFavorites,
+            onPressed:
+                c.inFavorites.value ? c.unfavoriteContact : c.favoriteContact,
           ),
           action(
             text:

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -357,13 +357,17 @@ class ChatsTabController extends GetxController {
   /// takes part in an [OngoingCall] in a [Chat] identified by the provided
   /// [id].
   bool inCall(ChatId id) {
+    if (WebUtils.containsCall(id)) {
+      return true;
+    }
+
     final Rx<OngoingCall>? call = _callService.calls[id];
     if (call != null) {
       return call.value.state.value == OngoingCallState.active ||
           call.value.state.value == OngoingCallState.joining;
     }
 
-    return WebUtils.containsCall(id);
+    return false;
   }
 
   /// Drops an [OngoingCall] in a [Chat] identified by its [id], if any.

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -205,8 +205,8 @@ class RecentChatTile extends StatelessWidget {
     if (chat.ongoingCall != null) {
       final Widget trailing = WidgetButton(
         key: inCall?.call() == true
-            ? const Key('JoinCallButton')
-            : const Key('DropCallButton'),
+            ? const Key('DropCallButton')
+            : const Key('JoinCallButton'),
         onPressed: inCall?.call() == true ? onDrop : onJoin,
         child: Container(
           padding: const EdgeInsets.all(4),

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -207,8 +207,8 @@ class ContactsTabView extends StatelessWidget {
                 child: Scrollbar(
                   controller: c.scrollController,
                   child: ListView.builder(
-                    itemCount: c.elements.length,
                     controller: c.scrollController,
+                    itemCount: c.elements.length,
                     itemBuilder: (_, i) {
                       final ListElement element = c.elements[i];
                       final Widget child;

--- a/lib/ui/page/home/tab/menu/status/view.dart
+++ b/lib/ui/page/home/tab/menu/status/view.dart
@@ -83,6 +83,7 @@ class StatusView extends StatelessWidget {
                           state: c.status,
                           label: 'label_status'.l10n,
                           filled: true,
+                          maxLength: 25,
                           onSuffixPressed: c.status.text.isEmpty
                               ? null
                               : () {

--- a/lib/ui/page/home/tab/menu/view.dart
+++ b/lib/ui/page/home/tab/menu/view.dart
@@ -295,7 +295,6 @@ class MenuTabView extends StatelessWidget {
                       } else {
                         return const SizedBox();
                       }
-
                       break;
 
                     case ProfileTab.danger:

--- a/lib/ui/page/home/tab/menu/view.dart
+++ b/lib/ui/page/home/tab/menu/view.dart
@@ -22,7 +22,6 @@ import '/l10n/l10n.dart';
 import '/routes.dart';
 import '/themes.dart';
 import '/ui/page/home/page/chat/widget/back_button.dart';
-import '/ui/page/home/page/my_profile/controller.dart';
 import '/ui/page/home/tab/menu/status/view.dart';
 import '/ui/page/home/widget/app_bar.dart';
 import '/ui/page/home/widget/avatar.dart';
@@ -45,34 +44,33 @@ class MenuTabView extends StatelessWidget {
         return Scaffold(
           extendBodyBehindAppBar: true,
           appBar: CustomAppBar(
-            title: Row(
-              children: [
-                Material(
-                  elevation: 6,
-                  type: MaterialType.circle,
-                  shadowColor: const Color(0x55000000),
-                  color: Colors.white,
-                  child: InkWell(
-                    onTap: context.isNarrow &&
-                            ModalRoute.of(context)?.canPop == true
-                        ? Navigator.of(context).pop
-                        : null,
-                    customBorder: const CircleBorder(),
-                    child: Center(
-                      child: Obx(() {
-                        return AvatarWidget.fromMyUser(
-                          c.myUser.value,
-                          radius: 17,
-                          badge: false,
-                        );
-                      }),
+            title: WidgetButton(
+              onPressed: () => StatusView.show(context),
+              child: Row(
+                children: [
+                  Material(
+                    elevation: 6,
+                    type: MaterialType.circle,
+                    shadowColor: const Color(0x55000000),
+                    color: Colors.white,
+                    child: InkWell(
+                      onTap: context.isNarrow &&
+                              ModalRoute.of(context)?.canPop == true
+                          ? Navigator.of(context).pop
+                          : null,
+                      customBorder: const CircleBorder(),
+                      child: Center(
+                        child: Obx(() {
+                          return AvatarWidget.fromMyUser(
+                            c.myUser.value,
+                            radius: 17,
+                          );
+                        }),
+                      ),
                     ),
                   ),
-                ),
-                const SizedBox(width: 10),
-                Flexible(
-                  child: WidgetButton(
-                    onPressed: () => StatusView.show(context),
+                  const SizedBox(width: 10),
+                  Flexible(
                     child: DefaultTextStyle.merge(
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
@@ -89,14 +87,14 @@ class MenuTabView extends StatelessWidget {
                             ),
                             Obx(() {
                               return Text(
-                                c.myUser.value?.presence.localizedString() ??
-                                    'dot'.l10n * 3,
+                                c.myUser.value?.status?.val ??
+                                    'label_online'.l10n,
                                 style: Theme.of(context)
                                     .textTheme
                                     .caption
                                     ?.copyWith(
                                       color:
-                                          c.myUser.value?.presence.getColor(),
+                                          Theme.of(context).colorScheme.primary,
                                     ),
                               );
                             }),
@@ -105,13 +103,13 @@ class MenuTabView extends StatelessWidget {
                       }),
                     ),
                   ),
-                ),
-                const SizedBox(width: 10),
-              ],
+                  const SizedBox(width: 10),
+                ],
+              ),
             ),
             leading: context.isNarrow
                 ? const [StyledBackButton()]
-                : const [SizedBox(width: 23)],
+                : const [SizedBox(width: 30)],
           ),
           body: Padding(
             padding: const EdgeInsets.symmetric(vertical: 5),

--- a/lib/ui/widget/modal_popup.dart
+++ b/lib/ui/widget/modal_popup.dart
@@ -50,7 +50,7 @@ abstract class ModalPopup {
   }) {
     final Style style = Theme.of(context).extension<Style>()!;
 
-    if (context.isNarrow) {
+    if (context.isMobile) {
       return showModalBottomSheet(
         context: context,
         barrierColor: style.barrierColor,


### PR DESCRIPTION
## Synopsis

Menu tab contains the chosen presence displayed in its header, which looks outdated.




## Solution

Redesign the header to display the chosen text status, if any, or `online` label otherwise. Also improve some l10n phrases.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
