### PR TITLE
Implement `ChatItem`s grouping in `Chat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All user visible changes to this project will be documented in this file. This p
         - Redesigned gallery. ([#212], [#199])
         - Date headers disappearing when not scrolling. ([#221], [#215])
         - Redesigned forwarding modal. ([#189], [#181])
+        - Nearby messages grouping. ([#337])
     - Chats tab:
         - Redesigned attachments preview. ([#217], [#214])
         - Redesigned group creating. ([#247], [#238])
@@ -161,6 +162,7 @@ All user visible changes to this project will be documented in this file. This p
 [#323]: /../../pull/323
 [#328]: /../../issues/328
 [#332]: /../../pull/332
+[#337]: /../../pull/337
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -255,7 +255,7 @@ err_incorrect_phone = Incorrect phone number.
 err_input_empty = Must not be empty.
 err_invalid_crop_coordinates = Invalid crop coordinates
 err_invalid_crop_points = Invalid crop points
-err_login_occupied = Login already occupied
+err_login_occupied = This login is already taken.
 err_message_was_read = Message was read
 err_network = Connection to the server refused
 err_no_filename = File should have a name
@@ -370,7 +370,6 @@ label_all = All
 label_app_background = Application background
 label_application = Application
 label_are_you_sure_no = No
-label_are_you_sure_want_to_log_out = Are you sure you want to log out from account{" "}
 label_are_you_sure_yes = Yes
 label_attachments = [{$count} { $count ->
     [1] attachment

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -384,7 +384,6 @@ label_all = Все
 label_app_background = Фон приложения
 label_application = Приложение
 label_are_you_sure_no = Нет
-label_are_you_sure_want_to_log_out = Вы действительно хотите выйти из аккаунта{" "}
 label_are_you_sure_yes = Да
 label_attachments = [{$count} { $count ->
     [1] прикрепление
@@ -603,7 +602,7 @@ label_phone_confirmation_code_was_send =
 label_phone_number = Номер телефона
 label_phone_visible = Ваш номер телефона видят:{" "}
 label_photo = Фото
-label_presence = Отображение статуса
+label_presence = Присутствие
 label_presence_away = Отошёл
 label_presence_hidden = Не показывать
 label_presence_present = Онлайн

--- a/lib/domain/model/application_settings.dart
+++ b/lib/domain/model/application_settings.dart
@@ -29,8 +29,10 @@ class ApplicationSettings extends HiveObject {
     this.locale,
     this.showIntroduction,
     this.sideBarWidth,
-    this.sortContactsByName = true,
     this.callButtons = const [],
+    this.showDragAndDropVideosHint = false,
+    this.showDragAndDropButtonsHint = false,
+    this.sortContactsByName = true,
   });
 
   /// Indicator whether [OngoingCall]s are preferred to be displayed in the

--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -400,7 +400,6 @@ class OngoingCall {
 
             call.value = node.call;
             call.refresh();
-
             break;
 
           case ChatCallEventsKind.event:
@@ -579,10 +578,7 @@ class OngoingCall {
         if (enabled) {
           screenShareState.value = LocalTrackState.enabling;
           try {
-            if (deviceId != screenDevice.value) {
-              await _updateSettings(screenDevice: deviceId);
-            }
-
+            await _updateSettings(screenDevice: deviceId);
             await _room?.enableVideo(MediaSourceKind.Display);
             screenShareState.value = LocalTrackState.enabled;
             if (!isActive || members.length <= 1) {
@@ -1289,7 +1285,9 @@ class OngoingCall {
         await _mediaSettingsGuard.acquire();
         _removeLocalTracks(
           audioDevice == null ? MediaKind.Video : MediaKind.Audio,
-          MediaSourceKind.Device,
+          screenDevice == null
+              ? MediaSourceKind.Device
+              : MediaSourceKind.Display,
         );
 
         MediaStreamSettings settings = _mediaStreamSettings(

--- a/lib/ui/page/auth/view.dart
+++ b/lib/ui/page/auth/view.dart
@@ -26,7 +26,9 @@ import '/config.dart';
 import '/l10n/l10n.dart';
 import '/routes.dart';
 import '/ui/page/home/page/my_profile/language/controller.dart';
+import '/ui/page/home/page/my_profile/widget/download_button.dart';
 import '/ui/page/login/view.dart';
+import '/ui/widget/modal_popup.dart';
 import '/ui/widget/outlined_rounded_button.dart';
 import '/ui/widget/svg/svg.dart';
 import '/util/platform_utils.dart';
@@ -186,7 +188,7 @@ class AuthView extends StatelessWidget {
                   width: 22 * 0.7,
                 ),
               ),
-              onPressed: () {},
+              onPressed: () => _download(context),
             ),
           if (isAndroidWeb)
             OutlinedRoundedButton(
@@ -198,7 +200,7 @@ class AuthView extends StatelessWidget {
                   width: 22 * 0.7,
                 ),
               ),
-              onPressed: () {},
+              onPressed: () => _download(context),
             ),
           if (isDesktopWeb)
             OutlinedRoundedButton(
@@ -219,7 +221,7 @@ class AuthView extends StatelessWidget {
                               width: 22 * 0.7,
                             )
                           : null,
-              onPressed: () {},
+              onPressed: () => _download(context),
             ),
           const SizedBox(height: 20),
           language,
@@ -268,6 +270,78 @@ class AuthView extends StatelessWidget {
           ],
         );
       },
+    );
+  }
+
+  /// Opens a [ModalPopup] listing the buttons for downloading the application.
+  Future<void> _download(BuildContext context) async {
+    await ModalPopup.show(
+      context: context,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ModalPopupHeader(
+            header: Center(
+              child: Text(
+                'btn_download'.l10n,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyText1
+                    ?.copyWith(color: Colors.black, fontSize: 18),
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Flexible(
+            child: ListView(
+              padding: ModalPopup.padding(context),
+              shrinkWrap: true,
+              children: const [
+                DownloadButton(
+                  asset: 'windows',
+                  width: 21.93,
+                  height: 22,
+                  title: 'Windows',
+                  link: 'messenger-windows.zip',
+                ),
+                SizedBox(height: 8),
+                DownloadButton(
+                  asset: 'apple',
+                  width: 23,
+                  height: 29,
+                  title: 'macOS',
+                  link: 'messenger-macos.zip',
+                ),
+                SizedBox(height: 8),
+                DownloadButton(
+                  asset: 'linux',
+                  width: 18.85,
+                  height: 22,
+                  title: 'Linux',
+                  link: 'messenger-linux.zip',
+                ),
+                SizedBox(height: 8),
+                DownloadButton(
+                  asset: 'apple',
+                  width: 23,
+                  height: 29,
+                  title: 'iOS',
+                  link: 'messenger-ios.zip',
+                ),
+                SizedBox(height: 8),
+                DownloadButton(
+                  asset: 'google',
+                  width: 20.33,
+                  height: 22.02,
+                  title: 'Android',
+                  link: 'messenger-android.apk',
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 18),
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -891,7 +891,15 @@ class CallController extends GetxController {
       await _currentCall.value.setScreenShareEnabled(false);
     } else {
       if (_currentCall.value.displays.length > 1) {
-        await ScreenShareView.show(context, _currentCall);
+        final MediaDisplayInfo? display =
+            await ScreenShareView.show(context, _currentCall);
+
+        if (display != null) {
+          await _currentCall.value.setScreenShareEnabled(
+            true,
+            deviceId: display.deviceId(),
+          );
+        }
       } else {
         await _currentCall.value.setScreenShareEnabled(true);
       }

--- a/lib/ui/page/call/screen_share/controller.dart
+++ b/lib/ui/page/call/screen_share/controller.dart
@@ -106,16 +106,10 @@ class ScreenShareController extends GetxController {
   void onClose() {
     _callsSubscription?.cancel();
     _displaysSubscription?.cancel();
+
+    freeTracks();
     _mediaManager.free();
     _jason.free();
-
-    for (RtcVideoRenderer t in renderers.values) {
-      t.dispose();
-    }
-
-    for (LocalMediaTrack t in _localTracks) {
-      t.free();
-    }
 
     super.onClose();
   }
@@ -133,6 +127,19 @@ class ScreenShareController extends GetxController {
     renderer.srcObject = tracks.first.getTrack();
 
     renderers[display] = renderer;
+  }
+
+  /// Disposes the [renderers] and frees the [LocalMediaTrack]s being used.
+  void freeTracks() {
+    for (RtcVideoRenderer t in renderers.values) {
+      t.dispose();
+    }
+    renderers.clear();
+
+    for (LocalMediaTrack t in _localTracks) {
+      t.free();
+    }
+    _localTracks.clear();
   }
 
   /// Constructs the [MediaStreamSettings] with the provided [screenDevice].

--- a/lib/ui/page/call/screen_share/view.dart
+++ b/lib/ui/page/call/screen_share/view.dart
@@ -39,8 +39,11 @@ class ScreenShareView extends StatelessWidget {
   static const double videoSize = 200;
 
   /// Displays a [ScreenShareView] wrapped in a [ModalPopup].
-  static Future<T?> show<T>(BuildContext context, Rx<OngoingCall> call) {
-    return ModalPopup.show<T>(
+  static Future<MediaDisplayInfo?> show<T>(
+    BuildContext context,
+    Rx<OngoingCall> call,
+  ) {
+    return ModalPopup.show<MediaDisplayInfo?>(
       context: context,
       child: ScreenShareView(call),
     );
@@ -63,40 +66,40 @@ class ScreenShareView extends StatelessWidget {
         return Obx(() {
           return ConfirmDialog(
             title: 'label_start_screen_sharing'.l10n,
-            variants: call.value.displays
-                .map(
-                  (e) => ConfirmDialogVariant(
-                    onProceed: () => call.value
-                        .setScreenShareEnabled(true, deviceId: e.deviceId()),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Container(
-                          constraints: const BoxConstraints(
-                            maxWidth: videoSize,
-                            maxHeight: videoSize,
-                          ),
-                          child: AnimatedSize(
-                            duration: 200.milliseconds,
-                            child: c.renderers[e] != null
-                                ? RtcVideoView(
-                                    c.renderers[e]!,
-                                    source: MediaSourceKind.Display,
-                                    mirror: false,
-                                    fit: BoxFit.contain,
-                                    enableContextMenu: false,
-                                    respectAspectRatio: true,
-                                    framelessBuilder: () => framelessBuilder,
-                                  )
-                                : framelessBuilder,
-                          ),
-                        ),
-                      ],
+            variants: call.value.displays.map((e) {
+              return ConfirmDialogVariant(
+                onProceed: () {
+                  c.freeTracks();
+                  return e;
+                },
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Container(
+                      constraints: const BoxConstraints(
+                        maxWidth: videoSize,
+                        maxHeight: videoSize,
+                      ),
+                      child: AnimatedSize(
+                        duration: 200.milliseconds,
+                        child: c.renderers[e] != null
+                            ? RtcVideoView(
+                                c.renderers[e]!,
+                                source: MediaSourceKind.Display,
+                                mirror: false,
+                                fit: BoxFit.contain,
+                                enableContextMenu: false,
+                                respectAspectRatio: true,
+                                framelessBuilder: () => framelessBuilder,
+                              )
+                            : framelessBuilder,
+                      ),
                     ),
-                  ),
-                )
-                .toList(),
+                  ],
+                ),
+              );
+            }).toList(),
           );
         });
       },

--- a/lib/ui/page/call/widget/animated_transition.dart
+++ b/lib/ui/page/call/widget/animated_transition.dart
@@ -27,7 +27,7 @@ class AnimatedTransition extends StatefulWidget {
     required this.child,
     this.onEnd,
     this.curve,
-    this.animationDuration = const Duration(milliseconds: 200),
+    this.duration = const Duration(milliseconds: 200),
   }) : super(key: key);
 
   /// Initial [Rect] this [child] takes.
@@ -46,7 +46,7 @@ class AnimatedTransition extends StatefulWidget {
   final Curve? curve;
 
   /// [Duration] of the animation.
-  final Duration animationDuration;
+  final Duration duration;
 
   @override
   State<AnimatedTransition> createState() => AnimatedTransitionState();
@@ -76,7 +76,7 @@ class AnimatedTransitionState extends State<AnimatedTransition>
       children: [
         AnimatedPositioned.fromRect(
           rect: rect,
-          duration: widget.animationDuration,
+          duration: widget.duration,
           curve: widget.curve ?? Curves.linear,
           onEnd: widget.onEnd,
           child: widget.child,

--- a/lib/ui/page/call/widget/dock.dart
+++ b/lib/ui/page/call/widget/dock.dart
@@ -485,7 +485,7 @@ class _DockState<T extends Object> extends State<Dock<T>> {
       builder: (_) => AnimatedTransition(
         beginRect: beginRect,
         endRect: endRect,
-        animationDuration: jumpDuration,
+        duration: jumpDuration,
         onEnd: () {
           onEnd();
           _removeOverlay();

--- a/lib/ui/page/call/widget/floating_fit/view.dart
+++ b/lib/ui/page/call/widget/floating_fit/view.dart
@@ -185,8 +185,9 @@ class _FloatingFitState<T> extends State<FloatingFit<T>> {
               child: Container(
                 width: width,
                 height: height,
-                decoration: const BoxDecoration(
-                  boxShadow: [
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  boxShadow: const [
                     CustomBoxShadow(
                       color: Color(0x44000000),
                       blurRadius: 9,
@@ -326,6 +327,7 @@ class _FloatingFitState<T> extends State<FloatingFit<T>> {
       return AnimatedTransition(
         beginRect: paneled.itemKey.globalPaintBounds ?? Rect.zero,
         endRect: primary.itemKey.globalPaintBounds ?? Rect.largest,
+        duration: const Duration(milliseconds: 400),
         curve: Curves.ease,
         onEnd: () {
           paneled.entry?.remove();
@@ -342,6 +344,7 @@ class _FloatingFitState<T> extends State<FloatingFit<T>> {
       return AnimatedTransition(
         beginRect: primary.itemKey.globalPaintBounds ?? Rect.zero,
         endRect: paneled.itemKey.globalPaintBounds ?? Rect.largest,
+        duration: const Duration(milliseconds: 400),
         curve: Curves.ease,
         onEnd: () {
           primary.entry?.remove();

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -564,8 +564,10 @@ class _ChatViewState extends State<ChatView>
             ),
             reads: c.chat!.members.length > 10
                 ? []
-                : c.chat!.reads
-                    .where((m) => m.at == e.value.at && m.memberId != c.me),
+                : c.chat!.reads.where((m) =>
+                    m.at == e.value.at &&
+                    m.memberId != c.me &&
+                    m.memberId != e.value.authorId),
             user: u.data,
             getUser: c.getUser,
             animation: _animation,
@@ -608,7 +610,8 @@ class _ChatViewState extends State<ChatView>
                 ? []
                 : c.chat!.reads.where((m) =>
                     m.at == element.forwards.last.value.at &&
-                    m.memberId != c.me),
+                    m.memberId != c.me &&
+                    m.memberId != element.authorId),
             user: u.data,
             getUser: c.getUser,
             animation: _animation,

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -558,6 +558,10 @@ class _ChatViewState extends State<ChatView>
             item: e,
             me: c.me!,
             avatar: !previousSame,
+            margin: EdgeInsets.only(
+              top: previousSame ? 1.5 : 6,
+              bottom: nextSame ? 1.5 : 6,
+            ),
             reads: c.chat!.members.length > 10
                 ? []
                 : c.chat!.reads

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -515,6 +515,40 @@ class _ChatViewState extends State<ChatView>
         throw Exception('Unreachable');
       }
 
+      ListElement? previous;
+      if (i > 0) {
+        previous = c.elements.values.elementAt(i - 1);
+      }
+
+      ListElement? next;
+      if (i < c.elements.length - 1) {
+        next = c.elements.values.elementAt(i + 1);
+      }
+
+      bool previousSame = false;
+      if (previous != null) {
+        previousSame = (previous is ChatMessageElement &&
+                previous.item.value.authorId == e.value.authorId &&
+                e.value.at.val.difference(previous.item.value.at.val) <=
+                    const Duration(minutes: 30)) ||
+            (previous is ChatCallElement &&
+                previous.item.value.authorId == e.value.authorId &&
+                e.value.at.val.difference(previous.item.value.at.val) <=
+                    const Duration(minutes: 30));
+      }
+
+      bool nextSame = false;
+      if (next != null) {
+        nextSame = (next is ChatMessageElement &&
+                next.item.value.authorId == e.value.authorId &&
+                e.value.at.val.difference(next.item.value.at.val) <=
+                    const Duration(minutes: 30)) ||
+            (next is ChatCallElement &&
+                next.item.value.authorId == e.value.authorId &&
+                e.value.at.val.difference(next.item.value.at.val) <=
+                    const Duration(minutes: 30));
+      }
+
       return Padding(
         padding: EdgeInsets.fromLTRB(8, 0, 8, isLast ? 8 : 0),
         child: FutureBuilder<RxUser?>(
@@ -523,6 +557,7 @@ class _ChatViewState extends State<ChatView>
             chat: c.chat!.chat,
             item: e,
             me: c.me!,
+            avatar: !previousSame,
             reads: c.chat!.members.length > 10
                 ? []
                 : c.chat!.reads

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -64,11 +64,12 @@ import 'video_thumbnail/video_thumbnail.dart';
 class ChatItemWidget extends StatefulWidget {
   const ChatItemWidget({
     Key? key,
-    required this.chat,
     required this.item,
+    required this.chat,
     required this.me,
-    this.reads = const [],
     this.user,
+    this.avatar = true,
+    this.reads = const [],
     this.getUser,
     this.animation,
     this.onHide,
@@ -95,6 +96,9 @@ class ChatItemWidget extends StatefulWidget {
 
   /// [User] posted this [item].
   final RxUser? user;
+
+  /// Indicator whether this [ChatItemWidget] should display an [AvatarWidget].
+  final bool avatar;
 
   /// [LastChatRead] to display under this [ChatItem].
   final Iterable<LastChatRead> reads;
@@ -682,7 +686,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
             AvatarWidget.colors.length];
 
     double avatarOffset = 0;
-    if ((!_fromMe && widget.chat.value?.isGroup == true) &&
+    if ((!_fromMe && widget.chat.value?.isGroup == true && widget.avatar) &&
         msg.repliesTo.isNotEmpty) {
       for (ChatItem reply in msg.repliesTo) {
         if (reply is ChatMessage) {
@@ -772,7 +776,9 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                       ),
                     );
                   }),
-                if (!_fromMe && widget.chat.value?.isGroup == true)
+                if (!_fromMe &&
+                    widget.chat.value?.isGroup == true &&
+                    widget.avatar)
                   Padding(
                     padding: EdgeInsets.fromLTRB(
                       12,
@@ -798,7 +804,9 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                     child: Padding(
                       padding: EdgeInsets.fromLTRB(
                         12,
-                        (!_fromMe && widget.chat.value?.isGroup == true)
+                        !_fromMe &&
+                                widget.chat.value?.isGroup == true &&
+                                widget.avatar
                             ? 0
                             : 10,
                         9,
@@ -834,14 +842,18 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                     borderRadius: BorderRadius.only(
                       topLeft: text != null ||
                               msg.repliesTo.isNotEmpty ||
-                              (!_fromMe && widget.chat.value?.isGroup == true)
+                              (!_fromMe &&
+                                  widget.chat.value?.isGroup == true &&
+                                  widget.avatar)
                           ? Radius.zero
                           : files.isEmpty
                               ? const Radius.circular(15)
                               : Radius.zero,
                       topRight: text != null ||
                               msg.repliesTo.isNotEmpty ||
-                              (!_fromMe && widget.chat.value?.isGroup == true)
+                              (!_fromMe &&
+                                  widget.chat.value?.isGroup == true &&
+                                  widget.avatar)
                           ? Radius.zero
                           : files.isEmpty
                               ? const Radius.circular(15)
@@ -1392,7 +1404,10 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                   child: InkWell(
                     customBorder: const CircleBorder(),
                     onTap: () => router.user(item.authorId, push: true),
-                    child: AvatarWidget.fromRxUser(widget.user, radius: 15),
+                    child: Opacity(
+                      opacity: widget.avatar ? 1 : 0,
+                      child: AvatarWidget.fromRxUser(widget.user, radius: 17),
+                    ),
                   ),
                 ),
               Flexible(
@@ -1568,18 +1583,21 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                             child,
                             if (avatars.isNotEmpty)
                               Transform.translate(
-                                offset: const Offset(-12, -4),
+                                offset: Offset(-12, widget.avatar ? -7 : -7),
                                 child: WidgetButton(
                                   onPressed: () => ChatItemReads.show(
                                     context,
                                     reads: widget.reads,
                                     getUser: widget.getUser,
                                   ),
-                                  child: Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: avatars,
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(bottom: 2),
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.center,
+                                      children: avatars,
+                                    ),
                                   ),
                                 ),
                               ),

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1587,7 +1587,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                             child,
                             if (avatars.isNotEmpty)
                               Transform.translate(
-                                offset: Offset(-12, widget.avatar ? -7 : -7),
+                                offset: Offset(-12, -widget.margin.bottom),
                                 child: WidgetButton(
                                   onPressed: () => ChatItemReads.show(
                                     context,

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -69,6 +69,7 @@ class ChatItemWidget extends StatefulWidget {
     required this.me,
     this.user,
     this.avatar = true,
+    this.margin = const EdgeInsets.fromLTRB(0, 6, 0, 6),
     this.reads = const [],
     this.getUser,
     this.animation,
@@ -99,6 +100,9 @@ class ChatItemWidget extends StatefulWidget {
 
   /// Indicator whether this [ChatItemWidget] should display an [AvatarWidget].
   final bool avatar;
+
+  /// [EdgeInsets] being margin to apply to this [ChatItemWidget].
+  final EdgeInsets margin;
 
   /// [LastChatRead] to display under this [ChatItem].
   final Iterable<LastChatRead> reads;
@@ -724,7 +728,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
     return _rounded(
       context,
       Container(
-        padding: const EdgeInsets.fromLTRB(5, 6, 2, 6),
+        padding: widget.margin.add(const EdgeInsets.fromLTRB(5, 0, 2, 0)),
         child: IntrinsicWidth(
           child: AnimatedContainer(
             duration: const Duration(milliseconds: 500),
@@ -1005,7 +1009,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
     return _rounded(
       context,
       Padding(
-        padding: const EdgeInsets.fromLTRB(5, 6, 5, 6),
+        padding: widget.margin.add(const EdgeInsets.fromLTRB(5, 1, 5, 1)),
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 500),
           decoration: BoxDecoration(

--- a/lib/ui/page/home/page/my_profile/camera_switch/controller.dart
+++ b/lib/ui/page/home/page/my_profile/camera_switch/controller.dart
@@ -45,10 +45,10 @@ class CameraSwitchController extends GetxController {
   final Rx<RtcVideoRenderer?> renderer = Rx<RtcVideoRenderer?>(null);
 
   /// Client for communicating with the [_mediaManager].
-  late final Jason? _jason;
+  Jason? _jason;
 
   /// Handle to a media manager tracking all the connected devices.
-  late final MediaManagerHandle? _mediaManager;
+  MediaManagerHandle? _mediaManager;
 
   /// [LocalMediaTrack] of the currently selected [camera] device.
   LocalMediaTrack? _localTrack;
@@ -84,7 +84,9 @@ class CameraSwitchController extends GetxController {
   @override
   void onClose() {
     _mediaManager?.free();
+    _mediaManager = null;
     _jason?.free();
+    _jason = null;
     renderer.value?.dispose();
     _localTrack?.free();
     _cameraWorker?.dispose();

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -93,10 +93,10 @@ class MyProfileController extends GetxController {
   final AbstractSettingsRepository _settingsRepo;
 
   /// Client for communicating with the [_mediaManager].
-  late final Jason? _jason;
+  Jason? _jason;
 
   /// Handle to a media manager tracking all the connected devices.
-  late final MediaManagerHandle? _mediaManager;
+  MediaManagerHandle? _mediaManager;
 
   /// [Timer] to set the `RxStatus.empty` status of the [name] field.
   Timer? _nameTimer;
@@ -397,7 +397,9 @@ class MyProfileController extends GetxController {
   @override
   void onClose() {
     _mediaManager?.free();
+    _mediaManager = null;
     _jason?.free();
+    _jason = null;
     _myUserWorker?.dispose();
     _profileWorker?.dispose();
     super.onClose();

--- a/lib/ui/page/home/page/my_profile/microphone_switch/controller.dart
+++ b/lib/ui/page/home/page/my_profile/microphone_switch/controller.dart
@@ -42,10 +42,10 @@ class MicrophoneSwitchController extends GetxController {
   InputDevices devices = RxList<MediaDeviceInfo>([]);
 
   /// Client for communicating with the [_mediaManager].
-  late final Jason? _jason;
+  Jason? _jason;
 
   /// Handle to a media manager tracking all the connected devices.
-  late final MediaManagerHandle? _mediaManager;
+  MediaManagerHandle? _mediaManager;
 
   @override
   void onInit() async {
@@ -68,7 +68,9 @@ class MicrophoneSwitchController extends GetxController {
   @override
   void onClose() {
     _mediaManager?.free();
+    _mediaManager = null;
     _jason?.free();
+    _jason = null;
     super.onClose();
   }
 

--- a/lib/ui/page/home/page/my_profile/output_switch/controller.dart
+++ b/lib/ui/page/home/page/my_profile/output_switch/controller.dart
@@ -42,10 +42,10 @@ class OutputSwitchController extends GetxController {
   RxnString output;
 
   /// Client for communicating with the [_mediaManager].
-  late final Jason? _jason;
+  Jason? _jason;
 
   /// Handle to a media manager tracking all the connected devices.
-  late final MediaManagerHandle? _mediaManager;
+  MediaManagerHandle? _mediaManager;
 
   @override
   void onInit() async {
@@ -71,7 +71,9 @@ class OutputSwitchController extends GetxController {
   @override
   void onClose() {
     _mediaManager?.free();
+    _mediaManager = null;
     _jason?.free();
+    _jason = null;
     super.onClose();
   }
 

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -43,7 +43,6 @@ import '/ui/widget/text_field.dart';
 import '/ui/widget/widget_button.dart';
 import '/util/message_popup.dart';
 import '/util/platform_utils.dart';
-import '/util/web/web_utils.dart';
 import 'add_email/view.dart';
 import 'add_phone/view.dart';
 import 'blacklist/view.dart';
@@ -56,6 +55,7 @@ import 'microphone_switch/view.dart';
 import 'output_switch/view.dart';
 import 'password/view.dart';
 import 'widget/copyable.dart';
+import 'widget/download_button.dart';
 
 /// View of the [Routes.me] page.
 class MyProfileView extends StatelessWidget {
@@ -1188,91 +1188,42 @@ Widget _notifications(BuildContext context, MyProfileController c) {
 
 /// Returns the contents of a [ProfileTab.download] section.
 Widget _downloads(BuildContext context, MyProfileController c) {
-  Widget button({
-    required String asset,
-    required double width,
-    required double height,
-    required String title,
-    String? link,
-  }) {
-    return FieldButton(
-      text: 'space'.l10n * 4 + title,
-      textAlign: TextAlign.center,
-      onPressed: link == null
-          ? null
-          : () {
-              WebUtils.download('${Config.origin}/artifacts/$link', link);
-            },
-      onTrailingPressed: () {
-        if (link != null) {
-          Clipboard.setData(
-            ClipboardData(text: '${Config.origin}/artifacts/$link'),
-          );
-          MessagePopup.success('label_copied_to_clipboard'.l10n);
-        }
-      },
-      prefix: Padding(
-        padding: const EdgeInsets.only(left: 16),
-        child: Transform.scale(
-          scale: 2,
-          child: SvgLoader.asset(
-            'assets/icons/$asset.svg',
-            width: width / 2,
-            height: height / 2,
-          ),
-        ),
-      ),
-      trailing: Transform.translate(
-        offset: const Offset(0, -1),
-        child: Transform.scale(
-          scale: 1.15,
-          child: SvgLoader.asset(
-            'assets/icons/copy.svg',
-            height: 15,
-          ),
-        ),
-      ),
-      style: TextStyle(
-        color: Theme.of(context).colorScheme.secondary,
-      ),
-    );
-  }
-
   return _dense(
     Column(
-      children: [
-        button(
+      children: const [
+        DownloadButton(
           asset: 'windows',
           width: 21.93,
           height: 22,
           title: 'Windows',
           link: 'messenger-windows.zip',
         ),
-        const SizedBox(height: 8),
-        button(
+        SizedBox(height: 8),
+        DownloadButton(
           asset: 'apple',
           width: 23,
           height: 29,
           title: 'macOS',
           link: 'messenger-macos.zip',
         ),
-        const SizedBox(height: 8),
-        button(
+        SizedBox(height: 8),
+        DownloadButton(
           asset: 'linux',
           width: 18.85,
           height: 22,
           title: 'Linux',
           link: 'messenger-linux.zip',
         ),
-        const SizedBox(height: 8),
-        button(
+        SizedBox(height: 8),
+        DownloadButton(
           asset: 'apple',
           width: 23,
           height: 29,
           title: 'iOS',
+          link: 'messenger-ios.zip',
         ),
-        const SizedBox(height: 8),
-        button(
+        SizedBox(height: 8),
+        DownloadButton(
           asset: 'google',
           width: 20.33,
           height: 22.02,

--- a/lib/ui/page/home/page/my_profile/widget/download_button.dart
+++ b/lib/ui/page/home/page/my_profile/widget/download_button.dart
@@ -1,3 +1,20 @@
+// Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/ui/page/home/page/my_profile/widget/download_button.dart
+++ b/lib/ui/page/home/page/my_profile/widget/download_button.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '/config.dart';
+import '/l10n/l10n.dart';
+import '/ui/widget/svg/svg.dart';
+import '/util/message_popup.dart';
+import '/util/web/web_utils.dart';
+import 'field_button.dart';
+
+/// [FieldButton] stylized with the provided [asset] and [title] downloading a
+/// file by the specified [link] when pressed.
+class DownloadButton extends StatelessWidget {
+  const DownloadButton({
+    super.key,
+    required this.asset,
+    required this.width,
+    required this.height,
+    required this.title,
+    this.link,
+  });
+
+  /// Asset to display as a prefix to this [DownloadButton].
+  final String asset;
+
+  /// Width of the [asset].
+  final double width;
+
+  /// Height of the [asset].
+  final double height;
+
+  /// Title of this [DownloadButton].
+  final String title;
+
+  /// Relative link to the downloadable asset.
+  final String? link;
+
+  @override
+  Widget build(BuildContext context) {
+    return FieldButton(
+      text: 'space'.l10n * 4 + title,
+      textAlign: TextAlign.center,
+      onPressed: link == null
+          ? null
+          : () => WebUtils.download('${Config.origin}/artifacts/$link', link!),
+      onTrailingPressed: () {
+        if (link != null) {
+          Clipboard.setData(
+            ClipboardData(text: '${Config.origin}/artifacts/$link'),
+          );
+          MessagePopup.success('label_copied'.l10n);
+        }
+      },
+      prefix: Padding(
+        padding: const EdgeInsets.only(left: 16),
+        child: Transform.scale(
+          scale: 2,
+          child: SvgLoader.asset(
+            'assets/icons/$asset.svg',
+            width: width / 2,
+            height: height / 2,
+          ),
+        ),
+      ),
+      trailing: Transform.translate(
+        offset: const Offset(0, -1),
+        child: Transform.scale(
+          scale: 1.15,
+          child: SvgLoader.asset('assets/icons/copy.svg', height: 15),
+        ),
+      ),
+      style: TextStyle(color: Theme.of(context).colorScheme.secondary),
+    );
+  }
+}

--- a/lib/ui/page/home/page/my_profile/widget/download_button.dart
+++ b/lib/ui/page/home/page/my_profile/widget/download_button.dart
@@ -30,21 +30,21 @@ import 'field_button.dart';
 class DownloadButton extends StatelessWidget {
   const DownloadButton({
     super.key,
-    required this.asset,
-    required this.width,
-    required this.height,
+    this.asset,
+    this.width,
+    this.height,
     required this.title,
     this.link,
   });
 
   /// Asset to display as a prefix to this [DownloadButton].
-  final String asset;
+  final String? asset;
 
   /// Width of the [asset].
-  final double width;
+  final double? width;
 
   /// Height of the [asset].
-  final double height;
+  final double? height;
 
   /// Title of this [DownloadButton].
   final String title;
@@ -68,17 +68,19 @@ class DownloadButton extends StatelessWidget {
           MessagePopup.success('label_copied'.l10n);
         }
       },
-      prefix: Padding(
-        padding: const EdgeInsets.only(left: 16),
-        child: Transform.scale(
-          scale: 2,
-          child: SvgLoader.asset(
-            'assets/icons/$asset.svg',
-            width: width / 2,
-            height: height / 2,
-          ),
-        ),
-      ),
+      prefix: asset == null
+          ? null
+          : Padding(
+              padding: const EdgeInsets.only(left: 16),
+              child: Transform.scale(
+                scale: 2,
+                child: SvgLoader.asset(
+                  'assets/icons/$asset.svg',
+                  width: width == null ? null : width! / 2,
+                  height: height == null ? null : height! / 2,
+                ),
+              ),
+            ),
       trailing: Transform.translate(
         offset: const Offset(0, -1),
         child: Transform.scale(

--- a/lib/ui/page/home/widget/confirm_dialog.dart
+++ b/lib/ui/page/home/widget/confirm_dialog.dart
@@ -24,11 +24,11 @@ import '/ui/widget/modal_popup.dart';
 import '/ui/widget/outlined_rounded_button.dart';
 
 /// Variant of a [ConfirmDialog].
-class ConfirmDialogVariant {
+class ConfirmDialogVariant<T> {
   const ConfirmDialogVariant({required this.child, this.onProceed});
 
   /// Callback, called when this [ConfirmDialogVariant] is submitted.
-  final void Function()? onProceed;
+  final T? Function()? onProceed;
 
   /// [Widget] representing this [ConfirmDialogVariant].
   final Widget child;
@@ -221,8 +221,7 @@ class _ConfirmDialogState extends State<ConfirmDialog> {
               style: thin?.copyWith(color: Colors.white),
             ),
             onPressed: () {
-              _variant.onProceed?.call();
-              Navigator.of(context).pop();
+              Navigator.of(context).pop(_variant.onProceed?.call());
             },
             color: Theme.of(context).colorScheme.secondary,
           ),


### PR DESCRIPTION
## Synopsis

В чате сообщения, которые были отправлены одним пользователем в пределах 30-ти минут, должны группироваться визуально и иметь аватар только на первом из списка таких сообщений.




## Solution

Реализовать описанную выше группировку через флажки и отсутпы в `ChatItemWidget`е, которые будут определяться во вьюшке чата при отрисовке с учётом предыдущего и следующего элементов списка.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
