### PR TITLE
Add `ContextMenu` to mobile group-`Call`s (#329)

### DIFF
--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -75,8 +75,9 @@ Widget mobileCall(CallController c, BuildContext context) {
         Obx(() {
           if (c.isDialog && c.primary.length == 1 && c.secondary.length == 1) {
             return FloatingFit<Participant>(
-              primary: c.primary.first,
-              panel: c.secondary.first,
+              primary: c.primaryParticipant ?? c.primary.first,
+              panel: c.secondaryParticipant ?? c.secondary.first,
+              onSwap: c.updateDialogParticipant,
               fit: !c.minimized.isFalse,
               intersection: c.dockRect,
               onManipulated: (bool m) => c.secondaryManipulated.value = m,

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -121,6 +121,12 @@ class CallController extends GetxController {
   /// [Participant]s to display in the secondary view.
   final RxList<Participant> secondary = RxList();
 
+  /// [Participant] of the call-dialog to display in the fit view.
+  Participant? primaryParticipant;
+
+  /// [Participant] of the call-dialog to display in the secondary view.
+  Participant? secondaryParticipant;
+
   /// Indicator whether the view is mobile or desktop.
   late bool isMobile;
 
@@ -1600,6 +1606,12 @@ class CallController extends GetxController {
     }
 
     applySecondaryConstraints();
+  }
+
+  /// Updates the [Participant]s of the call-dialog.
+  void updateDialogParticipant(Participant primary, Participant secondary) {
+    primaryParticipant = primary;
+    secondaryParticipant = secondary;
   }
 
   /// Returns corrected according to secondary constraints [width] value.

--- a/lib/ui/page/call/widget/animated_cliprrect.dart
+++ b/lib/ui/page/call/widget/animated_cliprrect.dart
@@ -1,0 +1,64 @@
+// Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'package:flutter/material.dart';
+
+/// Animated translation of the provided [child] on the [borderRadius] changes.
+class AnimatedClipRRect extends ImplicitlyAnimatedWidget {
+  const AnimatedClipRRect({
+    super.key,
+    super.curve,
+    required super.duration,
+    super.onEnd,
+    required this.child,
+    this.borderRadius = BorderRadius.zero,
+  });
+
+  /// [BorderRadius] to apply to the [child].
+  final BorderRadius borderRadius;
+
+  /// [Widget] to borderRadius changes.
+  final Widget child;
+
+  @override
+  ImplicitlyAnimatedWidgetState<AnimatedClipRRect> createState() =>
+      _AnimatedClipRRectState();
+}
+
+/// State of an [AnimatedClipRRect] maintaining its [_borderRadius].
+class _AnimatedClipRRectState
+    extends ImplicitlyAnimatedWidgetState<AnimatedClipRRect> {
+  /// [Tween] to drive animation.
+  Tween<BorderRadius>? _borderRadius;
+
+  @override
+  void forEachTween(TweenVisitor<dynamic> visitor) {
+    _borderRadius = visitor(
+      _borderRadius,
+      widget.borderRadius,
+      (dynamic value) => Tween<BorderRadius>(begin: value as BorderRadius),
+    ) as Tween<BorderRadius>?;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: _borderRadius?.evaluate(animation),
+      child: widget.child,
+    );
+  }
+}

--- a/lib/ui/page/call/widget/floating_fit/view.dart
+++ b/lib/ui/page/call/widget/floating_fit/view.dart
@@ -41,6 +41,7 @@ class FloatingFit<T> extends StatefulWidget {
     this.fit = false,
     this.intersection,
     this.onManipulated,
+    this.onSwap,
   });
 
   /// Builder building the provided item.
@@ -66,6 +67,9 @@ class FloatingFit<T> extends StatefulWidget {
 
   /// Callback, called when floating panel is being manipulated in some way.
   final void Function(bool)? onManipulated;
+
+  /// Callback, called when [primary] and [panel]ed items swap.
+  final void Function(T, T)? onSwap;
 
   @override
   State<FloatingFit> createState() => _FloatingFitState<T>();
@@ -358,6 +362,8 @@ class _FloatingFitState<T> extends State<FloatingFit<T>> {
 
     _paneled = primary;
     _primary = paneled;
+
+    widget.onSwap?.call(_primary.item, _paneled.item);
 
     setState(() {});
   }

--- a/lib/ui/page/call/widget/swappable_fit.dart
+++ b/lib/ui/page/call/widget/swappable_fit.dart
@@ -136,7 +136,6 @@ class _SwappableFitState<T> extends State<SwappableFit<T>> {
                       width: size,
                       height: size,
                       child: GestureDetector(
-                        onLongPress: () => _center(e.item),
                         child: e.entry == null
                             ? KeyedSubtree(
                                 key: e.itemKey,
@@ -158,13 +157,6 @@ class _SwappableFitState<T> extends State<SwappableFit<T>> {
                   return true;
                 }).map((e) {
                   return GestureDetector(
-                    onLongPress: () {
-                      if (_centered == e.item) {
-                        _uncenter();
-                      } else {
-                        _center(e.item);
-                      }
-                    },
                     child: e.entry == null
                         ? KeyedSubtree(
                             key: e.itemKey,

--- a/lib/ui/widget/context_menu/region.dart
+++ b/lib/ui/widget/context_menu/region.dart
@@ -33,7 +33,7 @@ import 'mobile.dart';
 /// - [FloatingContextMenu] on mobile.
 class ContextMenuRegion extends StatefulWidget {
   const ContextMenuRegion({
-    Key? key,
+    super.key,
     required this.child,
     this.enabled = true,
     this.moveDownwards = true,
@@ -45,7 +45,9 @@ class ContextMenuRegion extends StatefulWidget {
     this.width = 260,
     this.margin = EdgeInsets.zero,
     this.indicateOpenedMenu = false,
-  }) : super(key: key);
+    this.unconstrained = false,
+    this.changingChild,
+  });
 
   /// Widget to wrap this region over.
   final Widget child;
@@ -90,6 +92,13 @@ class ContextMenuRegion extends StatefulWidget {
   /// above the [child] when a [ContextMenu] is opened.
   final bool indicateOpenedMenu;
 
+  /// Indicator whether the [child] should be unconstrained.
+  final bool unconstrained;
+
+  /// Builder building a different children depending on whether the
+  /// [ContextMenu] is displayed.
+  final Widget Function(bool)? changingChild;
+
   @override
   State<ContextMenuRegion> createState() => _ContextMenuRegionState();
 }
@@ -99,6 +108,9 @@ class _ContextMenuRegionState extends State<ContextMenuRegion> {
   /// Indicator whether a [ColoredBox] should be displayed above the provided
   /// child.
   bool _darkened = false;
+
+  /// Indicator whether [ContextMenu] is displayed.
+  bool _displayed = false;
 
   @override
   Widget build(BuildContext context) {
@@ -134,7 +146,17 @@ class _ContextMenuRegionState extends State<ContextMenuRegion> {
                   moveDownwards: widget.moveDownwards,
                   actions: widget.actions,
                   margin: widget.margin,
-                  child: child,
+                  unconstrained: widget.unconstrained,
+                  onOpened: () => _displayed = true,
+                  onClosed: () => _displayed = false,
+                  child: Builder(
+                    builder: (_) {
+                      if (widget.changingChild != null) {
+                        return widget.changingChild!.call(_displayed);
+                      }
+                      return child;
+                    },
+                  ),
                 )
               : GestureDetector(
                   behavior: HitTestBehavior.translucent,


### PR DESCRIPTION
Resolves #329




## Synopsis

В групповом мобильном звонке отображается `SwappableFit` виджет. Логика и поведение этого виджета были изменены, нужно их обновить и перенести с new-design-preview.




## Solution

Перенести с new-design-preview:
1. По лонг тапу на видео участника в мобильном групповом звонке должно открываться контекстное меню с определёнными действиями.
2. Переключение видео по центру в `SwappableFit` теперь не осуществляется по лонг тапу, вместо этого в контекстном меню есть пунктики `Center`/`Uncenter`.
3. Соответственно само контекстное меню теперь в мобильном звонке должно вывозить зажатого участника в центр со скруглёнными краями.

Исправить баг, связанные с мобильным звонком: если переворачивать устройство, то виджеты `SwappableFit` и `FloatingFit `перестраиваются, что вызывает сброс состояния расстановки видео, которое было.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
