### PR TITLE
Delete appearance of change password view when password is setting (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ All user visible changes to this project will be documented in this file. This p
         - Incoming ringtone fading in. ([#375], [#367])
         - Participants dialing indication. ([#286], [#281])
 
+### Fixed
+
+- UI:
+    - Profile page:
+        - Change password modal flickering. ([#380], [#377])
+
 [#17]: /../../issues/17
 [#118]: /../../pull/118
 [#258]: /../../issues/258
@@ -48,6 +54,8 @@ All user visible changes to this project will be documented in this file. This p
 [#362]: /../../pull/362
 [#356]: /../../pull/356
 [#375]: /../../pull/375
+[#377]: /../../issues/377
+[#380]: /../../pull/380
 
 
 

--- a/lib/ui/page/home/page/my_profile/password/controller.dart
+++ b/lib/ui/page/home/page/my_profile/password/controller.dart
@@ -149,7 +149,6 @@ class ChangePasswordController extends GetxController {
               myUser.value!.hasPassword ? UserPassword(oldPassword.text) : null,
           newPassword: UserPassword(newPassword.text),
         );
-        hasPassword = myUser.value?.hasPassword ?? false;
         stage.value = hadPassword
             ? ChangePasswordFlowStage.changed
             : ChangePasswordFlowStage.set;

--- a/lib/ui/page/home/page/my_profile/password/controller.dart
+++ b/lib/ui/page/home/page/my_profile/password/controller.dart
@@ -60,7 +60,7 @@ class ChangePasswordController extends GetxController {
   /// Indicator whether the [repeatPassword] should be obscured.
   final RxBool obscureRepeatPassword = RxBool(true);
 
-  /// Indicator whether the [MyUser] has a password.
+  /// Indicator whether [MyUser] has a password set.
   late bool hasPassword;
 
   /// [MyUserService] updating the [MyUser]'s password.

--- a/lib/ui/page/home/page/my_profile/password/controller.dart
+++ b/lib/ui/page/home/page/my_profile/password/controller.dart
@@ -60,6 +60,9 @@ class ChangePasswordController extends GetxController {
   /// Indicator whether the [repeatPassword] should be obscured.
   final RxBool obscureRepeatPassword = RxBool(true);
 
+  /// Indicator whether the [MyUser] has a password.
+  late bool hasPassword;
+
   /// [MyUserService] updating the [MyUser]'s password.
   final MyUserService _myUserService;
 
@@ -105,6 +108,8 @@ class ChangePasswordController extends GetxController {
       onSubmitted: (s) => changePassword(),
     );
 
+    hasPassword = myUser.value?.hasPassword ?? false;
+
     super.onInit();
   }
 
@@ -144,6 +149,7 @@ class ChangePasswordController extends GetxController {
               myUser.value!.hasPassword ? UserPassword(oldPassword.text) : null,
           newPassword: UserPassword(newPassword.text),
         );
+        hasPassword = myUser.value?.hasPassword ?? false;
         stage.value = hadPassword
             ? ChangePasswordFlowStage.changed
             : ChangePasswordFlowStage.set;

--- a/lib/ui/page/home/page/my_profile/password/view.dart
+++ b/lib/ui/page/home/page/my_profile/password/view.dart
@@ -94,42 +94,36 @@ class ChangePasswordView extends StatelessWidget {
                   controller: c.scrollController,
                   shrinkWrap: true,
                   children: [
-                    Obx(() {
-                      if (c.myUser.value?.hasPassword != true) {
-                        return Padding(
-                          padding: const EdgeInsets.only(bottom: 25),
-                          child: Text(
-                            'label_password_not_set_info'.l10n,
-                            style: thin?.copyWith(
-                              fontSize: 15,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
+                    if (!c.hasPassword)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 25),
+                        child: Text(
+                          'label_password_not_set_info'.l10n,
+                          style: thin?.copyWith(
+                            fontSize: 15,
+                            color: Theme.of(context).colorScheme.primary,
                           ),
-                        );
-                      }
-
-                      return const SizedBox();
-                    }),
-                    Obx(() {
-                      if (c.myUser.value?.hasPassword == true) {
-                        return Padding(
-                          padding: const EdgeInsets.only(bottom: 16),
-                          child: ReactiveTextField(
-                            state: c.oldPassword,
-                            label: 'label_current_password'.l10n,
-                            obscure: c.obscurePassword.value,
-                            onSuffixPressed: c.obscurePassword.toggle,
-                            treatErrorAsStatus: false,
-                            trailing: SvgLoader.asset(
-                              'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
-                              width: 17.07,
-                            ),
+                        ),
+                      )
+                    else
+                      const SizedBox(),
+                    if (c.hasPassword == true)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 16),
+                        child: ReactiveTextField(
+                          state: c.oldPassword,
+                          label: 'label_current_password'.l10n,
+                          obscure: c.obscurePassword.value,
+                          onSuffixPressed: c.obscurePassword.toggle,
+                          treatErrorAsStatus: false,
+                          trailing: SvgLoader.asset(
+                            'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
+                            width: 17.07,
                           ),
-                        );
-                      }
-
-                      return const SizedBox();
-                    }),
+                        ),
+                      )
+                    else
+                      const SizedBox(),
                     ReactiveTextField(
                       key: const Key('NewPasswordField'),
                       state: c.newPassword,
@@ -195,7 +189,7 @@ class ChangePasswordView extends StatelessWidget {
                 ModalPopupHeader(
                   header: Center(
                     child: Text(
-                      c.myUser.value?.hasPassword == true &&
+                      c.hasPassword &&
                               c.stage.value != ChangePasswordFlowStage.set
                           ? 'label_change_password'.l10n
                           : 'label_set_password'.l10n,

--- a/lib/ui/page/home/page/my_profile/password/view.dart
+++ b/lib/ui/page/home/page/my_profile/password/view.dart
@@ -107,7 +107,7 @@ class ChangePasswordView extends StatelessWidget {
                       )
                     else
                       const SizedBox(),
-                    if (c.hasPassword == true)
+                    if (c.hasPassword)
                       Padding(
                         padding: const EdgeInsets.only(bottom: 16),
                         child: ReactiveTextField(

--- a/lib/ui/page/home/page/my_profile/password/view.dart
+++ b/lib/ui/page/home/page/my_profile/password/view.dart
@@ -106,8 +106,6 @@ class ChangePasswordView extends StatelessWidget {
                         ),
                       )
                     else
-                      const SizedBox(),
-                    if (c.hasPassword)
                       Padding(
                         padding: const EdgeInsets.only(bottom: 16),
                         child: ReactiveTextField(
@@ -121,9 +119,7 @@ class ChangePasswordView extends StatelessWidget {
                             width: 17.07,
                           ),
                         ),
-                      )
-                    else
-                      const SizedBox(),
+                      ),
                     ReactiveTextField(
                       key: const Key('NewPasswordField'),
                       state: c.newPassword,


### PR DESCRIPTION
Resolves #377




## Synopsis

При установке пароля, на один кадр может мигнуть меню для смены пароля.




## Solution

Убрать мигание меню для смены пароля.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
