### PR TITLE
Fix `hashFile` failing due to missing permissions on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,10 @@ jobs:
           chromedriver --port=4444 --enable-chrome-logs --disable-dev-shm-usage &
           make test.e2e start-app=yes device=web-server pull=yes no-cache=yes
 
+      # Clear the cache since `hashFile` may fail due to missing permissions:
+      # https://github.com/actions/runner/issues/449
+      - run: rm -rf .cache
+
   test-unit:
     name: Unit tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Synopsis

Latest versions of [`flutter-action`](https://github.com/subosito/flutter-action) introduce use of `hashFile` in its post run phase. 

However `hashFile` fails with the following debug output:

```
##[debug][Error: EACCES: permission denied, scandir '/home/runner/work/messenger/messenger/.cache/baza/cache/nginx-client-body'] {
##[debug]  errno: -13,
##[debug]  code: 'EACCES',
##[debug]STDOUT/STDERR stream read finished.
##[debug]STDOUT/STDERR stream read finished.
##[debug]  syscall: 'scandir',
##[debug]  path: '/home/runner/work/messenger/messenger/.cache/baza/cache/nginx-client-body'
##[debug]}
##[debug]Finished process 6509 with exit code 1, and elapsed time 00:00:00.0748440.
Error: subosito/flutter-action/v2/action.yml (Line: 54, Col: 23):
Error: The template is not valid. subosito/flutter-action/v2/action.yml (Line: 53, Col: 14): hashFiles('**/pubspec.lock') failed. Fail to hash files under directory '/home/runner/work/messenger/messenger',subosito/flutter-action/v2/action.yml (Line: 54, Col: 23): hashFiles('**/pubspec.lock') failed. Fail to hash files under directory '/home/runner/work/messenger/messenger'
```

`hashFile` has no permissions to `.cache/baza/cache/nginx-client-body` folder being created in the `make e2e start-app=yes` step.




## Solution

Add `rm -rf .cache` step in the `test-e2e` job on CI.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
