### PR TITLE
Upgrade to 0.1.0-beta.8.1 backend version

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -6935,6 +6935,10 @@ type Query {
   Use the `noFavorite` argument to exclude favorited `Chat`s from the
   returned result.
 
+  Use the `withOngoingCalls` argument to only include `Chat`s with ongoing
+  `ChatCall`s into the returned result (`true`), or to exclude them
+  (`false`).
+
   ## Authentication
 
   Mandatory.
@@ -6975,6 +6979,13 @@ type Query {
 
     """Indicator whether favorite `Chat`s should be excluded from the result."""
     noFavorite: Boolean = false
+
+    """
+    Indicator whether only `Chat`s with ongoing calls should be included into
+    the result (`true`), or whether they should be excluded from the result (`false`).
+    `null` means omitting filtering by this criteria.
+    """
+    withOngoingCalls: Boolean = null
   ): RecentChatsConnection!
 
   """
@@ -8165,6 +8176,14 @@ type Subscription {
     Indicator whether updates regarding favorite `Chat`s should be excluded from the result.
     """
     noFavorite: Boolean = false
+
+    """
+    Indicator whether only updates regarding `Chat`s with ongoing calls should
+    be included into the result (`true`), or whether they should be excluded
+    from the result (`false`).
+    `null` means omitting filtering by this criteria.
+    """
+    withOngoingCalls: Boolean = null
   ): RecentChatsTopEvents!
 
   """


### PR DESCRIPTION
## Synopsis

0.1.0-beta.8.1 backend has been released with no breaking changes.



## Changelog

### Added

- GraphQL API:
    - Queries:
        - `withOngoingCalls` argument to `recentChats`.
    - Subscriptions:
        - `withOngoingCalls` argument to `recentChatsTopEvents`.
- FCM notifications:
    - Webpush settings.

### Changed

- FCM notifications:
    - `notification.image` to first attachment.

### Fixed

- GraphQL API:
    - Queries:
        - `ChatMembersDialedConcrete.members` being empty for 3 or more `ChatMember`s.
    - Mutations:
        - `updateChatAvatar` not resetting `Chat`-monolog's avatar;
        - `joinChatCall` not updating `ChatCall` heartbeat;
    - Subscriptions:
        - Finished `chatCallEvents` triggering `ChatCall` heartbeat timeout after `User` re-joined `ChatCall`.


## Solution

- [ ] Update GraphQL schema




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
