### PR TITLE
Сhat does not open if the draft contains a response to the message (#376)

### DIFF
--- a/lib/domain/model/chat_item_quote.dart
+++ b/lib/domain/model/chat_item_quote.dart
@@ -43,14 +43,20 @@ abstract class ChatItemQuote {
         at: item.at,
         attachments: item.attachments,
         text: item.text,
+        original: item,
       );
     } else if (item is ChatCall) {
-      return ChatCallQuote(author: item.authorId, at: item.at);
+      return ChatCallQuote(
+        author: item.authorId,
+        at: item.at,
+        original: item,
+      );
     } else if (item is ChatInfo) {
       return ChatInfoQuote(
         author: item.authorId,
         at: item.at,
         action: item.action,
+        original: item,
       );
     } else if (item is ChatForward) {
       return item.quote;

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -541,7 +541,10 @@ class ChatController extends GetxController {
 
       send.field.unchecked = draft?.text?.val ?? send.field.text;
       send.field.unsubmit();
-      send.replied.value = List.from(draft?.repliesTo ?? []);
+      send.replied.value = List.from(
+        draft?.repliesTo.map((e) => e.original).where((e) => e != null) ??
+            <ChatItem>[],
+      );
 
       for (Attachment e in draft?.attachments ?? []) {
         send.attachments.add(MapEntry(GlobalKey(), e));

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -542,8 +542,7 @@ class ChatController extends GetxController {
       send.field.unchecked = draft?.text?.val ?? send.field.text;
       send.field.unsubmit();
       send.replied.value = List.from(
-        draft?.repliesTo.map((e) => e.original).where((e) => e != null) ??
-            <ChatItem>[],
+        draft?.repliesTo.map((e) => e.original).whereNotNull() ?? <ChatItem>[],
       );
 
       for (Attachment e in draft?.attachments ?? []) {

--- a/lib/ui/page/home/page/chat/forward/controller.dart
+++ b/lib/ui/page/home/page/chat/forward/controller.dart
@@ -131,12 +131,14 @@ class ChatForwardController extends GetxController {
           final ChatMessageText? text =
               send.field.text.isEmpty ? null : ChatMessageText(send.field.text);
 
+          final List<ChatItemQuoteInput> quotes = send.quotes.reversed.toList();
+
           final List<Future<void>> futures = [
             ...searchResults.value!.chats.map((e) {
               return _chatService.forwardChatItems(
                 from,
                 e.chat.value.id,
-                send.quotes,
+                quotes,
                 text: text,
                 attachments: attachments,
               );
@@ -147,7 +149,7 @@ class ChatForwardController extends GetxController {
               return _chatService.forwardChatItems(
                 from,
                 dialog,
-                send.quotes,
+                quotes,
                 text: text,
                 attachments: attachments,
               );
@@ -158,7 +160,7 @@ class ChatForwardController extends GetxController {
               return _chatService.forwardChatItems(
                 from,
                 dialog,
-                send.quotes,
+                quotes,
                 text: text,
                 attachments: attachments,
               );

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -691,12 +691,12 @@ class _ChatViewState extends State<ChatView>
                       .removeWhere((i) => i.id == element.note.value!.value.id);
                 }
               } else {
-                for (Rx<ChatItem> e in element.forwards.reversed) {
-                  c.send.replied.insert(0, e.value);
-                }
-
                 if (element.note.value != null) {
                   c.send.replied.insert(0, element.note.value!.value);
+                }
+
+                for (Rx<ChatItem> e in element.forwards) {
+                  c.send.replied.insert(0, e.value);
                 }
               }
             },


### PR DESCRIPTION
Resolves #376 




## Synopsis

Если у чата черновик содержит в себе ответ на сообщение, то при в ходе в этот чат он не загрузится. В консоль выдается ошибка Unhandled Exception: type 'ChatMessageQuote' is not a subtype of type 'ChatItem'.




## Solution

Баг будет исправлен.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
