### PR TITLE
Refactor "SvgLoader" static widgets to "SvgImage" factories

### DIFF
--- a/lib/ui/page/auth/view.dart
+++ b/lib/ui/page/auth/view.dart
@@ -60,10 +60,10 @@ class AuthView extends StatelessWidget {
         // flickering.
         List<Widget> header = [
           ...List.generate(10, (i) => 'assets/images/logo/logo000$i.svg')
-              .map((e) => Offstage(child: SvgLoader.asset(e)))
+              .map((e) => Offstage(child: AssetWidget(asset: e)))
               .toList(),
           ...List.generate(10, (i) => 'assets/images/logo/head000$i.svg')
-              .map((e) => Offstage(child: SvgLoader.asset(e)))
+              .map((e) => Offstage(child: AssetWidget(asset: e)))
               .toList(),
           const SizedBox(height: 30),
           Text(
@@ -127,8 +127,9 @@ class AuthView extends StatelessWidget {
                           ),
                         )
                       : Obx(() {
-                          return SvgLoader.asset(
-                            'assets/images/logo/head000${c.logoFrame.value}.svg',
+                          return AssetWidget(
+                            asset:
+                                'assets/images/logo/head000${c.logoFrame.value}.svg',
                             placeholderBuilder: (context) => placeholder,
                             height: 140,
                           );
@@ -159,11 +160,9 @@ class AuthView extends StatelessWidget {
               'btn_start'.l10n,
               style: const TextStyle(color: Colors.white),
             ),
-            leading: Container(
-              child: SvgLoader.asset(
-                'assets/icons/start.svg',
-                width: 25 * 0.7,
-              ),
+            leading: const AssetWidget(
+              asset: 'assets/icons/start.svg',
+              width: 25 * 0.7,
             ),
             onPressed: c.register,
             color: Theme.of(context).colorScheme.secondary,
@@ -172,8 +171,8 @@ class AuthView extends StatelessWidget {
           OutlinedRoundedButton(
             key: const Key('SignInButton'),
             title: Text('btn_login'.l10n),
-            leading: SvgLoader.asset(
-              'assets/icons/sign_in.svg',
+            leading: const AssetWidget(
+              asset: 'assets/icons/sign_in.svg',
               width: 20 * 0.7,
             ),
             onPressed: () => LoginView.show(context),
@@ -182,10 +181,10 @@ class AuthView extends StatelessWidget {
           if (isIosWeb)
             OutlinedRoundedButton(
               title: Text('btn_download'.l10n),
-              leading: Padding(
-                padding: const EdgeInsets.only(bottom: 3 * 0.7),
-                child: SvgLoader.asset(
-                  'assets/icons/apple.svg',
+              leading: const Padding(
+                padding: EdgeInsets.only(bottom: 3 * 0.7),
+                child: AssetWidget(
+                  asset: 'assets/icons/apple.svg',
                   width: 22 * 0.7,
                 ),
               ),
@@ -194,10 +193,10 @@ class AuthView extends StatelessWidget {
           if (isAndroidWeb)
             OutlinedRoundedButton(
               title: Text('btn_download'.l10n),
-              leading: Padding(
-                padding: const EdgeInsets.only(left: 2 * 0.7),
-                child: SvgLoader.asset(
-                  'assets/icons/google.svg',
+              leading: const Padding(
+                padding: EdgeInsets.only(left: 2 * 0.7),
+                child: AssetWidget(
+                  asset: 'assets/icons/google.svg',
                   width: 22 * 0.7,
                 ),
               ),
@@ -207,18 +206,18 @@ class AuthView extends StatelessWidget {
             OutlinedRoundedButton(
               title: Text('btn_download'.l10n),
               leading: PlatformUtils.isMacOS
-                  ? SvgLoader.asset(
-                      'assets/icons/apple.svg',
+                  ? const AssetWidget(
+                      asset: 'assets/icons/apple.svg',
                       width: 22 * 0.7,
                     )
                   : (PlatformUtils.isWindows)
-                      ? SvgLoader.asset(
-                          'assets/icons/windows.svg',
+                      ? const AssetWidget(
+                          asset: 'assets/icons/windows.svg',
                           width: 22 * 0.7,
                         )
                       : (PlatformUtils.isLinux)
-                          ? SvgLoader.asset(
-                              'assets/icons/linux.svg',
+                          ? const AssetWidget(
+                              asset: 'assets/icons/linux.svg',
                               width: 22 * 0.7,
                             )
                           : null,
@@ -238,9 +237,9 @@ class AuthView extends StatelessWidget {
                 color: const Color(0xFFF6F8F9),
               ),
             ),
-            IgnorePointer(
-              child: SvgLoader.asset(
-                'assets/images/background_light.svg',
+            const IgnorePointer(
+              child: AssetWidget(
+                asset: 'assets/images/background_light.svg',
                 width: double.infinity,
                 height: double.infinity,
                 fit: BoxFit.cover,

--- a/lib/ui/page/auth/view.dart
+++ b/lib/ui/page/auth/view.dart
@@ -60,10 +60,10 @@ class AuthView extends StatelessWidget {
         // flickering.
         List<Widget> header = [
           ...List.generate(10, (i) => 'assets/images/logo/logo000$i.svg')
-              .map((e) => Offstage(child: AssetWidget(asset: e)))
+              .map((e) => Offstage(child: SvgImage.asset(e)))
               .toList(),
           ...List.generate(10, (i) => 'assets/images/logo/head000$i.svg')
-              .map((e) => Offstage(child: AssetWidget(asset: e)))
+              .map((e) => Offstage(child: SvgImage.asset(e)))
               .toList(),
           const SizedBox(height: 30),
           Text(
@@ -127,9 +127,8 @@ class AuthView extends StatelessWidget {
                           ),
                         )
                       : Obx(() {
-                          return AssetWidget(
-                            asset:
-                                'assets/images/logo/head000${c.logoFrame.value}.svg',
+                          return SvgImage.asset(
+                            'assets/images/logo/head000${c.logoFrame.value}.svg',
                             placeholderBuilder: (context) => placeholder,
                             height: 140,
                           );
@@ -160,8 +159,8 @@ class AuthView extends StatelessWidget {
               'btn_start'.l10n,
               style: const TextStyle(color: Colors.white),
             ),
-            leading: const AssetWidget(
-              asset: 'assets/icons/start.svg',
+            leading: SvgImage.asset(
+              'assets/icons/start.svg',
               width: 25 * 0.7,
             ),
             onPressed: c.register,
@@ -171,8 +170,8 @@ class AuthView extends StatelessWidget {
           OutlinedRoundedButton(
             key: const Key('SignInButton'),
             title: Text('btn_login'.l10n),
-            leading: const AssetWidget(
-              asset: 'assets/icons/sign_in.svg',
+            leading: SvgImage.asset(
+              'assets/icons/sign_in.svg',
               width: 20 * 0.7,
             ),
             onPressed: () => LoginView.show(context),
@@ -181,10 +180,10 @@ class AuthView extends StatelessWidget {
           if (isIosWeb)
             OutlinedRoundedButton(
               title: Text('btn_download'.l10n),
-              leading: const Padding(
-                padding: EdgeInsets.only(bottom: 3 * 0.7),
-                child: AssetWidget(
-                  asset: 'assets/icons/apple.svg',
+              leading: Padding(
+                padding: const EdgeInsets.only(bottom: 3 * 0.7),
+                child: SvgImage.asset(
+                  'assets/icons/apple.svg',
                   width: 22 * 0.7,
                 ),
               ),
@@ -193,10 +192,10 @@ class AuthView extends StatelessWidget {
           if (isAndroidWeb)
             OutlinedRoundedButton(
               title: Text('btn_download'.l10n),
-              leading: const Padding(
-                padding: EdgeInsets.only(left: 2 * 0.7),
-                child: AssetWidget(
-                  asset: 'assets/icons/google.svg',
+              leading: Padding(
+                padding: const EdgeInsets.only(left: 2 * 0.7),
+                child: SvgImage.asset(
+                  'assets/icons/google.svg',
                   width: 22 * 0.7,
                 ),
               ),
@@ -206,18 +205,18 @@ class AuthView extends StatelessWidget {
             OutlinedRoundedButton(
               title: Text('btn_download'.l10n),
               leading: PlatformUtils.isMacOS
-                  ? const AssetWidget(
-                      asset: 'assets/icons/apple.svg',
+                  ? SvgImage.asset(
+                      'assets/icons/apple.svg',
                       width: 22 * 0.7,
                     )
                   : (PlatformUtils.isWindows)
-                      ? const AssetWidget(
-                          asset: 'assets/icons/windows.svg',
+                      ? SvgImage.asset(
+                          'assets/icons/windows.svg',
                           width: 22 * 0.7,
                         )
                       : (PlatformUtils.isLinux)
-                          ? const AssetWidget(
-                              asset: 'assets/icons/linux.svg',
+                          ? SvgImage.asset(
+                              'assets/icons/linux.svg',
                               width: 22 * 0.7,
                             )
                           : null,
@@ -237,9 +236,9 @@ class AuthView extends StatelessWidget {
                 color: const Color(0xFFF6F8F9),
               ),
             ),
-            const IgnorePointer(
-              child: AssetWidget(
-                asset: 'assets/images/background_light.svg',
+            IgnorePointer(
+              child: SvgImage.asset(
+                'assets/images/background_light.svg',
                 width: double.infinity,
                 height: double.infinity,
                 fit: BoxFit.cover,

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -59,8 +59,8 @@ Widget desktopCall(CallController c, BuildContext context) {
     builder: (context, constraints) {
       // Call stackable content.
       List<Widget> content = [
-        SvgLoader.asset(
-          'assets/images/background_dark.svg',
+        const AssetWidget(
+          asset: 'assets/images/background_dark.svg',
           width: double.infinity,
           height: double.infinity,
           fit: BoxFit.cover,
@@ -1180,8 +1180,9 @@ Widget _titleBar(BuildContext context, CallController c) => Obx(() {
                       hint: c.fullscreen.value
                           ? 'btn_fullscreen_exit'.l10n
                           : 'btn_fullscreen_enter'.l10n,
-                      child: SvgLoader.asset(
-                        'assets/icons/fullscreen_${c.fullscreen.value ? 'exit' : 'enter'}.svg',
+                      child: AssetWidget(
+                        asset:
+                            'assets/icons/fullscreen_${c.fullscreen.value ? 'exit' : 'enter'}.svg',
                         width: 12,
                       ),
                     ),
@@ -1730,8 +1731,8 @@ Widget _secondaryView(CallController c, BuildContext context) {
                         child: Stack(
                           children: [
                             Container(color: const Color(0xFF0A1724)),
-                            SvgLoader.asset(
-                              'assets/images/background_dark.svg',
+                            const AssetWidget(
+                              asset: 'assets/images/background_dark.svg',
                               width: double.infinity,
                               height: double.infinity,
                               fit: BoxFit.cover,
@@ -2078,8 +2079,8 @@ Widget _secondaryView(CallController c, BuildContext context) {
                                     ),
                                     InkResponse(
                                       onTap: isAnyDrag ? null : c.focusAll,
-                                      child: SvgLoader.asset(
-                                        'assets/icons/close.svg',
+                                      child: const AssetWidget(
+                                        asset: 'assets/icons/close.svg',
                                         height: 10.25,
                                       ),
                                     ),

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -59,8 +59,8 @@ Widget desktopCall(CallController c, BuildContext context) {
     builder: (context, constraints) {
       // Call stackable content.
       List<Widget> content = [
-        const AssetWidget(
-          asset: 'assets/images/background_dark.svg',
+        SvgImage.asset(
+          'assets/images/background_dark.svg',
           width: double.infinity,
           height: double.infinity,
           fit: BoxFit.cover,
@@ -1180,9 +1180,8 @@ Widget _titleBar(BuildContext context, CallController c) => Obx(() {
                       hint: c.fullscreen.value
                           ? 'btn_fullscreen_exit'.l10n
                           : 'btn_fullscreen_enter'.l10n,
-                      child: AssetWidget(
-                        asset:
-                            'assets/icons/fullscreen_${c.fullscreen.value ? 'exit' : 'enter'}.svg',
+                      child: SvgImage.asset(
+                        'assets/icons/fullscreen_${c.fullscreen.value ? 'exit' : 'enter'}.svg',
                         width: 12,
                       ),
                     ),
@@ -1731,8 +1730,8 @@ Widget _secondaryView(CallController c, BuildContext context) {
                         child: Stack(
                           children: [
                             Container(color: const Color(0xFF0A1724)),
-                            const AssetWidget(
-                              asset: 'assets/images/background_dark.svg',
+                            SvgImage.asset(
+                              'assets/images/background_dark.svg',
                               width: double.infinity,
                               height: double.infinity,
                               fit: BoxFit.cover,
@@ -2079,8 +2078,8 @@ Widget _secondaryView(CallController c, BuildContext context) {
                                     ),
                                     InkResponse(
                                       onTap: isAnyDrag ? null : c.focusAll,
-                                      child: const AssetWidget(
-                                        asset: 'assets/icons/close.svg',
+                                      child: SvgImage.asset(
+                                        'assets/icons/close.svg',
                                         height: 10.25,
                                       ),
                                     ),

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -61,8 +61,8 @@ Widget mobileCall(CallController c, BuildContext context) {
 
     // Call stackable content.
     List<Widget> content = [
-      SvgLoader.asset(
-        'assets/images/background_dark.svg',
+      const AssetWidget(
+        asset: 'assets/images/background_dark.svg',
         width: double.infinity,
         height: double.infinity,
         fit: BoxFit.cover,

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -61,8 +61,8 @@ Widget mobileCall(CallController c, BuildContext context) {
 
     // Call stackable content.
     List<Widget> content = [
-      const AssetWidget(
-        asset: 'assets/images/background_dark.svg',
+      SvgImage.asset(
+        'assets/images/background_dark.svg',
         width: double.infinity,
         height: double.infinity,
         fit: BoxFit.cover,

--- a/lib/ui/page/call/participant/view.dart
+++ b/lib/ui/page/call/participant/view.dart
@@ -224,9 +224,10 @@ class ParticipantView extends StatelessWidget {
                       height: 30,
                       child: Center(
                         child: inCall && !isRedialed
-                            ? SvgLoader.asset('assets/icons/call_end.svg')
-                            : SvgLoader.asset(
-                                'assets/icons/audio_call_start.svg',
+                            ? const AssetWidget(
+                                asset: 'assets/icons/call_end.svg')
+                            : const AssetWidget(
+                                asset: 'assets/icons/audio_call_start.svg',
                                 width: 13,
                                 height: 13,
                               ),
@@ -269,8 +270,8 @@ class ParticipantView extends StatelessWidget {
                       fontSize: 15,
                     ),
                   )
-                : SvgLoader.asset(
-                    'assets/icons/delete.svg',
+                : const AssetWidget(
+                    asset: 'assets/icons/delete.svg',
                     height: 14 * 1.5,
                   ),
           ),

--- a/lib/ui/page/call/participant/view.dart
+++ b/lib/ui/page/call/participant/view.dart
@@ -224,7 +224,9 @@ class ParticipantView extends StatelessWidget {
                       height: 30,
                       child: Center(
                         child: inCall && !isRedialed
-                            ? SvgImage.asset('assets/icons/call_end.svg')
+                            ? SvgImage.asset(
+                                'assets/icons/call_end.svg',
+                              )
                             : SvgImage.asset(
                                 'assets/icons/audio_call_start.svg',
                                 width: 13,

--- a/lib/ui/page/call/participant/view.dart
+++ b/lib/ui/page/call/participant/view.dart
@@ -224,10 +224,9 @@ class ParticipantView extends StatelessWidget {
                       height: 30,
                       child: Center(
                         child: inCall && !isRedialed
-                            ? const AssetWidget(
-                                asset: 'assets/icons/call_end.svg')
-                            : const AssetWidget(
-                                asset: 'assets/icons/audio_call_start.svg',
+                            ? SvgImage.asset('assets/icons/call_end.svg')
+                            : SvgImage.asset(
+                                'assets/icons/audio_call_start.svg',
                                 width: 13,
                                 height: 13,
                               ),
@@ -270,8 +269,8 @@ class ParticipantView extends StatelessWidget {
                       fontSize: 15,
                     ),
                   )
-                : const AssetWidget(
-                    asset: 'assets/icons/delete.svg',
+                : SvgImage.asset(
+                    'assets/icons/delete.svg',
                     height: 14 * 1.5,
                   ),
           ),

--- a/lib/ui/page/call/widget/call_cover.dart
+++ b/lib/ui/page/call/widget/call_cover.dart
@@ -42,8 +42,8 @@ class CallCoverWidget extends StatelessWidget {
     return Stack(
       children: [
         if (cover == null)
-          const AssetWidget(
-            asset: 'assets/images/background_dark.svg',
+          SvgImage.asset(
+            'assets/images/background_dark.svg',
             width: double.infinity,
             height: double.infinity,
             fit: BoxFit.cover,

--- a/lib/ui/page/call/widget/call_cover.dart
+++ b/lib/ui/page/call/widget/call_cover.dart
@@ -42,8 +42,8 @@ class CallCoverWidget extends StatelessWidget {
     return Stack(
       children: [
         if (cover == null)
-          SvgLoader.asset(
-            'assets/images/background_dark.svg',
+          const AssetWidget(
+            asset: 'assets/images/background_dark.svg',
             width: double.infinity,
             height: double.infinity,
             fit: BoxFit.cover,

--- a/lib/ui/page/call/widget/floating_fit/view.dart
+++ b/lib/ui/page/call/widget/floating_fit/view.dart
@@ -217,8 +217,8 @@ class _FloatingFitState<T> extends State<FloatingFit<T>> {
                 child: Stack(
                   children: [
                     Container(color: const Color(0xFF0A1724)),
-                    SvgLoader.asset(
-                      'assets/images/background_dark.svg',
+                    const AssetWidget(
+                      asset: 'assets/images/background_dark.svg',
                       width: double.infinity,
                       height: double.infinity,
                       fit: BoxFit.cover,

--- a/lib/ui/page/call/widget/floating_fit/view.dart
+++ b/lib/ui/page/call/widget/floating_fit/view.dart
@@ -217,8 +217,8 @@ class _FloatingFitState<T> extends State<FloatingFit<T>> {
                 child: Stack(
                   children: [
                     Container(color: const Color(0xFF0A1724)),
-                    const AssetWidget(
-                      asset: 'assets/images/background_dark.svg',
+                    SvgImage.asset(
+                      'assets/images/background_dark.svg',
                       width: double.infinity,
                       height: double.infinity,
                       fit: BoxFit.cover,

--- a/lib/ui/page/call/widget/hint.dart
+++ b/lib/ui/page/call/widget/hint.dart
@@ -64,7 +64,7 @@ class HintWidget extends StatelessWidget {
               mainAxisSize: MainAxisSize.max,
               children: [
                 const SizedBox(width: 14),
-                SvgLoader.asset('assets/icons/face.svg', height: 13),
+                const AssetWidget(asset: 'assets/icons/face.svg', height: 13),
                 const SizedBox(width: 10),
                 Expanded(
                   child: Text(

--- a/lib/ui/page/call/widget/hint.dart
+++ b/lib/ui/page/call/widget/hint.dart
@@ -64,7 +64,7 @@ class HintWidget extends StatelessWidget {
               mainAxisSize: MainAxisSize.max,
               children: [
                 const SizedBox(width: 14),
-                const AssetWidget(asset: 'assets/icons/face.svg', height: 13),
+                SvgImage.asset('assets/icons/face.svg', height: 13),
                 const SizedBox(width: 10),
                 Expanded(
                   child: Text(

--- a/lib/ui/page/call/widget/participant.dart
+++ b/lib/ui/page/call/widget/participant.dart
@@ -179,10 +179,7 @@ class ParticipantWidget extends StatelessWidget {
           ? CircleAvatar(
               radius: 45,
               backgroundColor: const Color(0xD8818181),
-              child: SvgImage.asset(
-                'assets/icons/hand_up.svg',
-                width: 90,
-              ),
+              child: SvgImage.asset('assets/icons/hand_up.svg', width: 90),
             )
           : Container(),
     );

--- a/lib/ui/page/call/widget/participant.dart
+++ b/lib/ui/page/call/widget/participant.dart
@@ -176,11 +176,11 @@ class ParticipantWidget extends StatelessWidget {
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 150),
       child: isRaised
-          ? const CircleAvatar(
+          ? CircleAvatar(
               radius: 45,
-              backgroundColor: Color(0xD8818181),
-              child: AssetWidget(
-                asset: 'assets/icons/hand_up.svg',
+              backgroundColor: const Color(0xD8818181),
+              child: SvgImage.asset(
+                'assets/icons/hand_up.svg',
                 width: 90,
               ),
             )
@@ -238,10 +238,10 @@ class ParticipantOverlayWidget extends StatelessWidget {
 
       if (isAudioDisabled) {
         additionally.add(
-          const Padding(
-            padding: EdgeInsets.only(left: 3, right: 3),
-            child: AssetWidget(
-              asset: 'assets/icons/audio_off_small.svg',
+          Padding(
+            padding: const EdgeInsets.only(left: 3, right: 3),
+            child: SvgImage.asset(
+              'assets/icons/audio_off_small.svg',
               width: 20.88,
               height: 17,
               fit: BoxFit.fitWidth,
@@ -250,10 +250,10 @@ class ParticipantOverlayWidget extends StatelessWidget {
         );
       } else if (isMuted) {
         additionally.add(
-          const Padding(
-            padding: EdgeInsets.only(left: 2, right: 2),
-            child: AssetWidget(
-              asset: 'assets/icons/microphone_off_small.svg',
+          Padding(
+            padding: const EdgeInsets.only(left: 2, right: 2),
+            child: SvgImage.asset(
+              'assets/icons/microphone_off_small.svg',
               height: 16.5,
             ),
           ),
@@ -267,20 +267,20 @@ class ParticipantOverlayWidget extends StatelessWidget {
 
         if (isVideoDisabled) {
           additionally.add(
-            const Padding(
-              padding: EdgeInsets.only(left: 4, right: 4),
-              child: AssetWidget(
-                asset: 'assets/icons/screen_share_small.svg',
+            Padding(
+              padding: const EdgeInsets.only(left: 4, right: 4),
+              child: SvgImage.asset(
+                'assets/icons/screen_share_small.svg',
                 height: 12,
               ),
             ),
           );
         } else {
           additionally.add(
-            const Padding(
-              padding: EdgeInsets.only(left: 4, right: 4),
-              child: AssetWidget(
-                asset: 'assets/icons/screen_share_small.svg',
+            Padding(
+              padding: const EdgeInsets.only(left: 4, right: 4),
+              child: SvgImage.asset(
+                'assets/icons/screen_share_small.svg',
                 height: 12,
               ),
             ),
@@ -291,10 +291,10 @@ class ParticipantOverlayWidget extends StatelessWidget {
           additionally.add(const SizedBox(width: 4));
         }
         additionally.add(
-          const Padding(
-            padding: EdgeInsets.only(left: 5, right: 5),
-            child: AssetWidget(
-              asset: 'assets/icons/video_off_small.svg',
+          Padding(
+            padding: const EdgeInsets.only(left: 5, right: 5),
+            child: SvgImage.asset(
+              'assets/icons/video_off_small.svg',
               width: 19.8,
               height: 17,
             ),

--- a/lib/ui/page/call/widget/participant.dart
+++ b/lib/ui/page/call/widget/participant.dart
@@ -176,11 +176,11 @@ class ParticipantWidget extends StatelessWidget {
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 150),
       child: isRaised
-          ? CircleAvatar(
+          ? const CircleAvatar(
               radius: 45,
-              backgroundColor: const Color(0xD8818181),
-              child: SvgLoader.asset(
-                'assets/icons/hand_up.svg',
+              backgroundColor: Color(0xD8818181),
+              child: AssetWidget(
+                asset: 'assets/icons/hand_up.svg',
                 width: 90,
               ),
             )
@@ -238,10 +238,10 @@ class ParticipantOverlayWidget extends StatelessWidget {
 
       if (isAudioDisabled) {
         additionally.add(
-          Padding(
-            padding: const EdgeInsets.only(left: 3, right: 3),
-            child: SvgLoader.asset(
-              'assets/icons/audio_off_small.svg',
+          const Padding(
+            padding: EdgeInsets.only(left: 3, right: 3),
+            child: AssetWidget(
+              asset: 'assets/icons/audio_off_small.svg',
               width: 20.88,
               height: 17,
               fit: BoxFit.fitWidth,
@@ -250,10 +250,10 @@ class ParticipantOverlayWidget extends StatelessWidget {
         );
       } else if (isMuted) {
         additionally.add(
-          Padding(
-            padding: const EdgeInsets.only(left: 2, right: 2),
-            child: SvgLoader.asset(
-              'assets/icons/microphone_off_small.svg',
+          const Padding(
+            padding: EdgeInsets.only(left: 2, right: 2),
+            child: AssetWidget(
+              asset: 'assets/icons/microphone_off_small.svg',
               height: 16.5,
             ),
           ),
@@ -267,20 +267,20 @@ class ParticipantOverlayWidget extends StatelessWidget {
 
         if (isVideoDisabled) {
           additionally.add(
-            Padding(
-              padding: const EdgeInsets.only(left: 4, right: 4),
-              child: SvgLoader.asset(
-                'assets/icons/screen_share_small.svg',
+            const Padding(
+              padding: EdgeInsets.only(left: 4, right: 4),
+              child: AssetWidget(
+                asset: 'assets/icons/screen_share_small.svg',
                 height: 12,
               ),
             ),
           );
         } else {
           additionally.add(
-            Padding(
-              padding: const EdgeInsets.only(left: 4, right: 4),
-              child: SvgLoader.asset(
-                'assets/icons/screen_share_small.svg',
+            const Padding(
+              padding: EdgeInsets.only(left: 4, right: 4),
+              child: AssetWidget(
+                asset: 'assets/icons/screen_share_small.svg',
                 height: 12,
               ),
             ),
@@ -291,10 +291,10 @@ class ParticipantOverlayWidget extends StatelessWidget {
           additionally.add(const SizedBox(width: 4));
         }
         additionally.add(
-          Padding(
-            padding: const EdgeInsets.only(left: 5, right: 5),
-            child: SvgLoader.asset(
-              'assets/icons/video_off_small.svg',
+          const Padding(
+            padding: EdgeInsets.only(left: 5, right: 5),
+            child: AssetWidget(
+              asset: 'assets/icons/video_off_small.svg',
               width: 19.8,
               height: 17,
             ),

--- a/lib/ui/page/call/widget/round_button.dart
+++ b/lib/ui/page/call/widget/round_button.dart
@@ -130,8 +130,8 @@ class _RoundFloatingButtonState extends State<RoundFloatingButton> {
                 width: max(widget.assetWidth, 60),
                 height: max(widget.assetWidth, 60),
                 child: Center(
-                  child: SvgLoader.asset(
-                    'assets/icons/${widget.asset}.svg',
+                  child: AssetWidget(
+                    asset: 'assets/icons/${widget.asset}.svg',
                     width: widget.assetWidth,
                   ),
                 ),

--- a/lib/ui/page/call/widget/round_button.dart
+++ b/lib/ui/page/call/widget/round_button.dart
@@ -130,8 +130,8 @@ class _RoundFloatingButtonState extends State<RoundFloatingButton> {
                 width: max(widget.assetWidth, 60),
                 height: max(widget.assetWidth, 60),
                 child: Center(
-                  child: AssetWidget(
-                    asset: 'assets/icons/${widget.asset}.svg',
+                  child: SvgImage.asset(
+                    'assets/icons/${widget.asset}.svg',
                     width: widget.assetWidth,
                   ),
                 ),

--- a/lib/ui/page/call/widget/video_view.dart
+++ b/lib/ui/page/call/widget/video_view.dart
@@ -296,8 +296,8 @@ class _RtcVideoViewState extends State<RtcVideoView> {
                         children: [
                           if (widget.muted) const SizedBox(width: 1),
                           if (widget.muted)
-                            SvgLoader.asset(
-                              'assets/icons/microphone_off_small.svg',
+                            const AssetWidget(
+                              asset: 'assets/icons/microphone_off_small.svg',
                               width: 11,
                             ),
                           Flexible(

--- a/lib/ui/page/call/widget/video_view.dart
+++ b/lib/ui/page/call/widget/video_view.dart
@@ -296,8 +296,8 @@ class _RtcVideoViewState extends State<RtcVideoView> {
                         children: [
                           if (widget.muted) const SizedBox(width: 1),
                           if (widget.muted)
-                            const AssetWidget(
-                              asset: 'assets/icons/microphone_off_small.svg',
+                            SvgImage.asset(
+                              'assets/icons/microphone_off_small.svg',
                               width: 11,
                             ),
                           Flexible(

--- a/lib/ui/page/home/introduction/view.dart
+++ b/lib/ui/page/home/introduction/view.dart
@@ -72,8 +72,9 @@ class IntroductionView extends StatelessWidget {
                   style: thin,
                   onSuffixPressed: c.obscurePassword.toggle,
                   treatErrorAsStatus: false,
-                  trailing: SvgLoader.asset(
-                    'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
+                  trailing: AssetWidget(
+                    asset:
+                        'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -86,8 +87,9 @@ class IntroductionView extends StatelessWidget {
                   style: thin,
                   onSuffixPressed: c.obscureRepeat.toggle,
                   treatErrorAsStatus: false,
-                  trailing: SvgLoader.asset(
-                    'assets/icons/visible_${c.obscureRepeat.value ? 'off' : 'on'}.svg',
+                  trailing: AssetWidget(
+                    asset:
+                        'assets/icons/visible_${c.obscureRepeat.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -185,8 +187,8 @@ class IntroductionView extends StatelessWidget {
                             text: c.num.text,
                             label: 'label_num'.l10n,
                             share: 'Gapopa ID: ${c.myUser.value?.num.val}',
-                            trailing: SvgLoader.asset(
-                              'assets/icons/share.svg',
+                            trailing: const AssetWidget(
+                              asset: 'assets/icons/share.svg',
                               width: 18,
                             ),
                             style: thin,

--- a/lib/ui/page/home/introduction/view.dart
+++ b/lib/ui/page/home/introduction/view.dart
@@ -72,9 +72,8 @@ class IntroductionView extends StatelessWidget {
                   style: thin,
                   onSuffixPressed: c.obscurePassword.toggle,
                   treatErrorAsStatus: false,
-                  trailing: AssetWidget(
-                    asset:
-                        'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
+                  trailing: SvgImage.asset(
+                    'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -87,9 +86,8 @@ class IntroductionView extends StatelessWidget {
                   style: thin,
                   onSuffixPressed: c.obscureRepeat.toggle,
                   treatErrorAsStatus: false,
-                  trailing: AssetWidget(
-                    asset:
-                        'assets/icons/visible_${c.obscureRepeat.value ? 'off' : 'on'}.svg',
+                  trailing: SvgImage.asset(
+                    'assets/icons/visible_${c.obscureRepeat.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -187,8 +185,8 @@ class IntroductionView extends StatelessWidget {
                             text: c.num.text,
                             label: 'label_num'.l10n,
                             share: 'Gapopa ID: ${c.myUser.value?.num.val}',
-                            trailing: const AssetWidget(
-                              asset: 'assets/icons/share.svg',
+                            trailing: SvgImage.asset(
+                              'assets/icons/share.svg',
                               width: 18,
                             ),
                             style: thin,

--- a/lib/ui/page/home/page/chat/info/view.dart
+++ b/lib/ui/page/home/page/chat/info/view.dart
@@ -374,7 +374,9 @@ class ChatInfoView extends StatelessWidget {
                   child: Transform.scale(
                     scale: 1.15,
                     child: const AssetWidget(
-                        asset: 'assets/icons/copy.svg', height: 15),
+                      asset: 'assets/icons/copy.svg',
+                      height: 15,
+                    ),
                   ),
                 ),
         ),
@@ -644,7 +646,9 @@ class ChatInfoView extends StatelessWidget {
                 child: Transform.scale(
                   scale: 1.15,
                   child: const AssetWidget(
-                      asset: 'assets/icons/delete.svg', height: 14),
+                    asset: 'assets/icons/delete.svg',
+                    height: 14,
+                  ),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -671,7 +675,9 @@ class ChatInfoView extends StatelessWidget {
                   child: Transform.scale(
                     scale: 1.15,
                     child: const AssetWidget(
-                        asset: 'assets/icons/delete.svg', height: 14),
+                      asset: 'assets/icons/delete.svg',
+                      height: 14,
+                    ),
                   ),
                 ),
                 style:
@@ -723,7 +729,9 @@ class ChatInfoView extends StatelessWidget {
               child: Transform.scale(
                 scale: 1.15,
                 child: const AssetWidget(
-                    asset: 'assets/icons/delete.svg', height: 14),
+                  asset: 'assets/icons/delete.svg',
+                  height: 14,
+                ),
               ),
             ),
             style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -740,7 +748,9 @@ class ChatInfoView extends StatelessWidget {
               child: Transform.scale(
                 scale: 1.15,
                 child: const AssetWidget(
-                    asset: 'assets/icons/delete.svg', height: 14),
+                  asset: 'assets/icons/delete.svg',
+                  height: 14,
+                ),
               ),
             ),
             style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -757,7 +767,9 @@ class ChatInfoView extends StatelessWidget {
                 child: Transform.scale(
                   scale: 1.15,
                   child: const AssetWidget(
-                      asset: 'assets/icons/delete.svg', height: 14),
+                    asset: 'assets/icons/delete.svg',
+                    height: 14,
+                  ),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -773,7 +785,9 @@ class ChatInfoView extends StatelessWidget {
                 child: Transform.scale(
                   scale: 1.15,
                   child: const AssetWidget(
-                      asset: 'assets/icons/delete.svg', height: 14),
+                    asset: 'assets/icons/delete.svg',
+                    height: 14,
+                  ),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -789,7 +803,9 @@ class ChatInfoView extends StatelessWidget {
                 child: Transform.scale(
                   scale: 1.15,
                   child: const AssetWidget(
-                      asset: 'assets/icons/delete.svg', height: 14),
+                    asset: 'assets/icons/delete.svg',
+                    height: 14,
+                  ),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),

--- a/lib/ui/page/home/page/chat/info/view.dart
+++ b/lib/ui/page/home/page/chat/info/view.dart
@@ -728,10 +728,7 @@ class ChatInfoView extends StatelessWidget {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgImage.asset(
-                  'assets/icons/delete.svg',
-                  height: 14,
-                ),
+                child: SvgImage.asset('assets/icons/delete.svg', height: 14),
               ),
             ),
             style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -747,10 +744,7 @@ class ChatInfoView extends StatelessWidget {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgImage.asset(
-                  'assets/icons/delete.svg',
-                  height: 14,
-                ),
+                child: SvgImage.asset('assets/icons/delete.svg', height: 14),
               ),
             ),
             style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -766,10 +760,7 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgImage.asset(
-                    'assets/icons/delete.svg',
-                    height: 14,
-                  ),
+                  child: SvgImage.asset('assets/icons/delete.svg', height: 14),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -784,10 +775,7 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgImage.asset(
-                    'assets/icons/delete.svg',
-                    height: 14,
-                  ),
+                  child: SvgImage.asset('assets/icons/delete.svg', height: 14),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -802,10 +790,7 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgImage.asset(
-                    'assets/icons/delete.svg',
-                    height: 14,
-                  ),
+                  child: SvgImage.asset('assets/icons/delete.svg', height: 14),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),

--- a/lib/ui/page/home/page/chat/info/view.dart
+++ b/lib/ui/page/home/page/chat/info/view.dart
@@ -102,8 +102,8 @@ class ChatInfoView extends StatelessWidget {
                               ),
                               if (c.chat?.chat.value.muted != null) ...[
                                 const SizedBox(width: 5),
-                                const AssetWidget(
-                                  asset: 'assets/icons/muted.svg',
+                                SvgImage.asset(
+                                  'assets/icons/muted.svg',
                                   width: 19.99 * 0.6,
                                   height: 15 * 0.6,
                                 ),
@@ -125,8 +125,8 @@ class ChatInfoView extends StatelessWidget {
                   onPressed: () => router.chat(id, push: true),
                   child: Transform.translate(
                     offset: const Offset(0, 1),
-                    child: const AssetWidget(
-                      asset: 'assets/icons/chat.svg',
+                    child: SvgImage.asset(
+                      'assets/icons/chat.svg',
                       width: 20.12,
                       height: 21.62,
                     ),
@@ -137,8 +137,8 @@ class ChatInfoView extends StatelessWidget {
                     const SizedBox(width: 28),
                     WidgetButton(
                       onPressed: () => c.call(true),
-                      child: const AssetWidget(
-                        asset: 'assets/icons/chat_video_call.svg',
+                      child: SvgImage.asset(
+                        'assets/icons/chat_video_call.svg',
                         height: 17,
                       ),
                     ),
@@ -146,8 +146,8 @@ class ChatInfoView extends StatelessWidget {
                   const SizedBox(width: 28),
                   WidgetButton(
                     onPressed: () => c.call(false),
-                    child: const AssetWidget(
-                      asset: 'assets/icons/chat_audio_call.svg',
+                    child: SvgImage.asset(
+                      'assets/icons/chat_audio_call.svg',
                       height: 19,
                     ),
                   ),
@@ -167,9 +167,9 @@ class ChatInfoView extends StatelessWidget {
                                 color: Colors.red,
                                 shape: BoxShape.circle,
                               ),
-                              child: const Center(
-                                child: AssetWidget(
-                                  asset: 'assets/icons/call_end.svg',
+                              child: Center(
+                                child: SvgImage.asset(
+                                  'assets/icons/call_end.svg',
                                   width: 22,
                                   height: 22,
                                 ),
@@ -186,9 +186,9 @@ class ChatInfoView extends StatelessWidget {
                                 color: Theme.of(context).colorScheme.secondary,
                                 shape: BoxShape.circle,
                               ),
-                              child: const Center(
-                                child: AssetWidget(
-                                  asset: 'assets/icons/audio_call_start.svg',
+                              child: Center(
+                                child: SvgImage.asset(
+                                  'assets/icons/audio_call_start.svg',
                                   width: 10,
                                   height: 10,
                                 ),
@@ -373,8 +373,8 @@ class ChatInfoView extends StatelessWidget {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child: const AssetWidget(
-                      asset: 'assets/icons/copy.svg',
+                    child: SvgImage.asset(
+                      'assets/icons/copy.svg',
                       height: 15,
                     ),
                   ),
@@ -410,8 +410,8 @@ class ChatInfoView extends StatelessWidget {
                     offset: const Offset(0, -1),
                     child: Transform.scale(
                       scale: 1.15,
-                      child: const AssetWidget(
-                        asset: 'assets/icons/copy.svg',
+                      child: SvgImage.asset(
+                        'assets/icons/copy.svg',
                         height: 15,
                       ),
                     ),
@@ -567,9 +567,9 @@ class ChatInfoView extends StatelessWidget {
                           color: Colors.red,
                           shape: BoxShape.circle,
                         ),
-                        child: const Center(
-                          child: AssetWidget(
-                            asset: 'assets/icons/call_end.svg',
+                        child: Center(
+                          child: SvgImage.asset(
+                            'assets/icons/call_end.svg',
                             width: 22,
                             height: 22,
                           ),
@@ -583,12 +583,12 @@ class ChatInfoView extends StatelessWidget {
                       child: InkWell(
                         onTap: () => c.redialChatCallMember(e.id),
                         borderRadius: BorderRadius.circular(60),
-                        child: const SizedBox(
+                        child: SizedBox(
                           width: 22,
                           height: 22,
                           child: Center(
-                            child: AssetWidget(
-                              asset: 'assets/icons/audio_call_start.svg',
+                            child: SvgImage.asset(
+                              'assets/icons/audio_call_start.svg',
                               width: 10,
                               height: 10,
                             ),
@@ -613,8 +613,8 @@ class ChatInfoView extends StatelessWidget {
                   WidgetButton(
                     key: const Key('DeleteMemberButton'),
                     onPressed: () => _removeChatMember(c, context, e),
-                    child: const AssetWidget(
-                      asset: 'assets/icons/delete.svg',
+                    child: SvgImage.asset(
+                      'assets/icons/delete.svg',
                       height: 14 * 1.5,
                     ),
                   ),
@@ -645,8 +645,8 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: const AssetWidget(
-                    asset: 'assets/icons/delete.svg',
+                  child: SvgImage.asset(
+                    'assets/icons/delete.svg',
                     height: 14,
                   ),
                 ),
@@ -674,8 +674,8 @@ class ChatInfoView extends StatelessWidget {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child: const AssetWidget(
-                      asset: 'assets/icons/delete.svg',
+                    child: SvgImage.asset(
+                      'assets/icons/delete.svg',
                       height: 14,
                     ),
                   ),
@@ -700,13 +700,13 @@ class ChatInfoView extends StatelessWidget {
                   child: Transform.scale(
                     scale: 1.15,
                     child: muted
-                        ? const AssetWidget(
-                            asset: 'assets/icons/btn_mute.svg',
+                        ? SvgImage.asset(
+                            'assets/icons/btn_mute.svg',
                             width: 18.68,
                             height: 15,
                           )
-                        : const AssetWidget(
-                            asset: 'assets/icons/btn_unmute.svg',
+                        : SvgImage.asset(
+                            'assets/icons/btn_unmute.svg',
                             width: 17.86,
                             height: 15,
                           ),
@@ -728,8 +728,8 @@ class ChatInfoView extends StatelessWidget {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: const AssetWidget(
-                  asset: 'assets/icons/delete.svg',
+                child: SvgImage.asset(
+                  'assets/icons/delete.svg',
                   height: 14,
                 ),
               ),
@@ -747,8 +747,8 @@ class ChatInfoView extends StatelessWidget {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: const AssetWidget(
-                  asset: 'assets/icons/delete.svg',
+                child: SvgImage.asset(
+                  'assets/icons/delete.svg',
                   height: 14,
                 ),
               ),
@@ -766,8 +766,8 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: const AssetWidget(
-                    asset: 'assets/icons/delete.svg',
+                  child: SvgImage.asset(
+                    'assets/icons/delete.svg',
                     height: 14,
                   ),
                 ),
@@ -784,8 +784,8 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: const AssetWidget(
-                    asset: 'assets/icons/delete.svg',
+                  child: SvgImage.asset(
+                    'assets/icons/delete.svg',
                     height: 14,
                   ),
                 ),
@@ -802,8 +802,8 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: const AssetWidget(
-                    asset: 'assets/icons/delete.svg',
+                  child: SvgImage.asset(
+                    'assets/icons/delete.svg',
                     height: 14,
                   ),
                 ),

--- a/lib/ui/page/home/page/chat/info/view.dart
+++ b/lib/ui/page/home/page/chat/info/view.dart
@@ -102,8 +102,8 @@ class ChatInfoView extends StatelessWidget {
                               ),
                               if (c.chat?.chat.value.muted != null) ...[
                                 const SizedBox(width: 5),
-                                SvgLoader.asset(
-                                  'assets/icons/muted.svg',
+                                const AssetWidget(
+                                  asset: 'assets/icons/muted.svg',
                                   width: 19.99 * 0.6,
                                   height: 15 * 0.6,
                                 ),
@@ -125,8 +125,8 @@ class ChatInfoView extends StatelessWidget {
                   onPressed: () => router.chat(id, push: true),
                   child: Transform.translate(
                     offset: const Offset(0, 1),
-                    child: SvgLoader.asset(
-                      'assets/icons/chat.svg',
+                    child: const AssetWidget(
+                      asset: 'assets/icons/chat.svg',
                       width: 20.12,
                       height: 21.62,
                     ),
@@ -137,8 +137,8 @@ class ChatInfoView extends StatelessWidget {
                     const SizedBox(width: 28),
                     WidgetButton(
                       onPressed: () => c.call(true),
-                      child: SvgLoader.asset(
-                        'assets/icons/chat_video_call.svg',
+                      child: const AssetWidget(
+                        asset: 'assets/icons/chat_video_call.svg',
                         height: 17,
                       ),
                     ),
@@ -146,8 +146,8 @@ class ChatInfoView extends StatelessWidget {
                   const SizedBox(width: 28),
                   WidgetButton(
                     onPressed: () => c.call(false),
-                    child: SvgLoader.asset(
-                      'assets/icons/chat_audio_call.svg',
+                    child: const AssetWidget(
+                      asset: 'assets/icons/chat_audio_call.svg',
                       height: 19,
                     ),
                   ),
@@ -167,9 +167,9 @@ class ChatInfoView extends StatelessWidget {
                                 color: Colors.red,
                                 shape: BoxShape.circle,
                               ),
-                              child: Center(
-                                child: SvgLoader.asset(
-                                  'assets/icons/call_end.svg',
+                              child: const Center(
+                                child: AssetWidget(
+                                  asset: 'assets/icons/call_end.svg',
                                   width: 22,
                                   height: 22,
                                 ),
@@ -186,9 +186,9 @@ class ChatInfoView extends StatelessWidget {
                                 color: Theme.of(context).colorScheme.secondary,
                                 shape: BoxShape.circle,
                               ),
-                              child: Center(
-                                child: SvgLoader.asset(
-                                  'assets/icons/audio_call_start.svg',
+                              child: const Center(
+                                child: AssetWidget(
+                                  asset: 'assets/icons/audio_call_start.svg',
                                   width: 10,
                                   height: 10,
                                 ),
@@ -373,7 +373,8 @@ class ChatInfoView extends StatelessWidget {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child: SvgLoader.asset('assets/icons/copy.svg', height: 15),
+                    child: const AssetWidget(
+                        asset: 'assets/icons/copy.svg', height: 15),
                   ),
                 ),
         ),
@@ -407,8 +408,8 @@ class ChatInfoView extends StatelessWidget {
                     offset: const Offset(0, -1),
                     child: Transform.scale(
                       scale: 1.15,
-                      child: SvgLoader.asset(
-                        'assets/icons/copy.svg',
+                      child: const AssetWidget(
+                        asset: 'assets/icons/copy.svg',
                         height: 15,
                       ),
                     ),
@@ -564,9 +565,9 @@ class ChatInfoView extends StatelessWidget {
                           color: Colors.red,
                           shape: BoxShape.circle,
                         ),
-                        child: Center(
-                          child: SvgLoader.asset(
-                            'assets/icons/call_end.svg',
+                        child: const Center(
+                          child: AssetWidget(
+                            asset: 'assets/icons/call_end.svg',
                             width: 22,
                             height: 22,
                           ),
@@ -580,12 +581,12 @@ class ChatInfoView extends StatelessWidget {
                       child: InkWell(
                         onTap: () => c.redialChatCallMember(e.id),
                         borderRadius: BorderRadius.circular(60),
-                        child: SizedBox(
+                        child: const SizedBox(
                           width: 22,
                           height: 22,
                           child: Center(
-                            child: SvgLoader.asset(
-                              'assets/icons/audio_call_start.svg',
+                            child: AssetWidget(
+                              asset: 'assets/icons/audio_call_start.svg',
                               width: 10,
                               height: 10,
                             ),
@@ -610,8 +611,8 @@ class ChatInfoView extends StatelessWidget {
                   WidgetButton(
                     key: const Key('DeleteMemberButton'),
                     onPressed: () => _removeChatMember(c, context, e),
-                    child: SvgLoader.asset(
-                      'assets/icons/delete.svg',
+                    child: const AssetWidget(
+                      asset: 'assets/icons/delete.svg',
                       height: 14 * 1.5,
                     ),
                   ),
@@ -642,7 +643,8 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+                  child: const AssetWidget(
+                      asset: 'assets/icons/delete.svg', height: 14),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -668,8 +670,8 @@ class ChatInfoView extends StatelessWidget {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child:
-                        SvgLoader.asset('assets/icons/delete.svg', height: 14),
+                    child: const AssetWidget(
+                        asset: 'assets/icons/delete.svg', height: 14),
                   ),
                 ),
                 style:
@@ -692,13 +694,13 @@ class ChatInfoView extends StatelessWidget {
                   child: Transform.scale(
                     scale: 1.15,
                     child: muted
-                        ? SvgLoader.asset(
-                            'assets/icons/btn_mute.svg',
+                        ? const AssetWidget(
+                            asset: 'assets/icons/btn_mute.svg',
                             width: 18.68,
                             height: 15,
                           )
-                        : SvgLoader.asset(
-                            'assets/icons/btn_unmute.svg',
+                        : const AssetWidget(
+                            asset: 'assets/icons/btn_unmute.svg',
                             width: 17.86,
                             height: 15,
                           ),
@@ -720,7 +722,8 @@ class ChatInfoView extends StatelessWidget {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+                child: const AssetWidget(
+                    asset: 'assets/icons/delete.svg', height: 14),
               ),
             ),
             style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -736,7 +739,8 @@ class ChatInfoView extends StatelessWidget {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+                child: const AssetWidget(
+                    asset: 'assets/icons/delete.svg', height: 14),
               ),
             ),
             style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -752,7 +756,8 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+                  child: const AssetWidget(
+                      asset: 'assets/icons/delete.svg', height: 14),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -767,7 +772,8 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+                  child: const AssetWidget(
+                      asset: 'assets/icons/delete.svg', height: 14),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),
@@ -782,7 +788,8 @@ class ChatInfoView extends StatelessWidget {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+                  child: const AssetWidget(
+                      asset: 'assets/icons/delete.svg', height: 14),
                 ),
               ),
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),

--- a/lib/ui/page/home/page/chat/message_field/view.dart
+++ b/lib/ui/page/home/page/chat/message_field/view.dart
@@ -444,12 +444,12 @@ class MessageFieldView extends StatelessWidget {
                         );
                       }
                 : null,
-            child: const SizedBox(
+            child: SizedBox(
               width: 56,
               height: 56,
               child: Center(
-                child: AssetWidget(
-                  asset: 'assets/icons/attach.svg',
+                child: SvgImage.asset(
+                  'assets/icons/attach.svg',
                   height: 22,
                   width: 22,
                 ),
@@ -493,14 +493,14 @@ class MessageFieldView extends StatelessWidget {
                     child: AnimatedSwitcher(
                       duration: 300.milliseconds,
                       child: c.forwarding.value
-                          ? const AssetWidget(
-                              asset: 'assets/icons/forward.svg',
+                          ? SvgImage.asset(
+                              'assets/icons/forward.svg',
                               width: 26,
                               height: 22,
                             )
-                          : AssetWidget(
+                          : SvgImage.asset(
+                              'assets/icons/send.svg',
                               key: sendKey ?? const Key('Send'),
-                              asset: 'assets/icons/send.svg',
                               height: 22.85,
                               width: 25.18,
                             ),
@@ -734,8 +734,8 @@ class MessageFieldView extends StatelessWidget {
                                 color: style.cardColor,
                               ),
                               alignment: Alignment.center,
-                              child: const AssetWidget(
-                                asset: 'assets/icons/close_primary.svg',
+                              child: SvgImage.asset(
+                                'assets/icons/close_primary.svg',
                                 width: 7,
                                 height: 7,
                               ),
@@ -852,14 +852,12 @@ class MessageFieldView extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.fromLTRB(8, 0, 12, 0),
             child: item.withVideo
-                ? AssetWidget(
-                    asset:
-                        'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
+                ? SvgImage.asset(
+                    'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
                     height: 13,
                   )
-                : AssetWidget(
-                    asset:
-                        'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
+                : SvgImage.asset(
+                    'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
                     height: 15,
                   ),
           ),
@@ -898,8 +896,8 @@ class MessageFieldView extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           const SizedBox(width: 12),
-          const AssetWidget(
-            asset: 'assets/icons/edit.svg',
+          SvgImage.asset(
+            'assets/icons/edit.svg',
             width: 17,
             height: 17,
           ),
@@ -1021,8 +1019,8 @@ class MessageFieldView extends StatelessWidget {
                         color: style.cardColor,
                       ),
                       alignment: Alignment.center,
-                      child: const AssetWidget(
-                        asset: 'assets/icons/close_primary.svg',
+                      child: SvgImage.asset(
+                        'assets/icons/close_primary.svg',
                         width: 7,
                         height: 7,
                       ),

--- a/lib/ui/page/home/page/chat/message_field/view.dart
+++ b/lib/ui/page/home/page/chat/message_field/view.dart
@@ -444,12 +444,12 @@ class MessageFieldView extends StatelessWidget {
                         );
                       }
                 : null,
-            child: SizedBox(
+            child: const SizedBox(
               width: 56,
               height: 56,
               child: Center(
-                child: SvgLoader.asset(
-                  'assets/icons/attach.svg',
+                child: AssetWidget(
+                  asset: 'assets/icons/attach.svg',
                   height: 22,
                   width: 22,
                 ),
@@ -493,14 +493,14 @@ class MessageFieldView extends StatelessWidget {
                     child: AnimatedSwitcher(
                       duration: 300.milliseconds,
                       child: c.forwarding.value
-                          ? SvgLoader.asset(
-                              'assets/icons/forward.svg',
+                          ? const AssetWidget(
+                              asset: 'assets/icons/forward.svg',
                               width: 26,
                               height: 22,
                             )
-                          : SvgLoader.asset(
+                          : AssetWidget(
                               key: sendKey ?? const Key('Send'),
-                              'assets/icons/send.svg',
+                              asset: 'assets/icons/send.svg',
                               height: 22.85,
                               width: 25.18,
                             ),
@@ -734,8 +734,8 @@ class MessageFieldView extends StatelessWidget {
                                 color: style.cardColor,
                               ),
                               alignment: Alignment.center,
-                              child: SvgLoader.asset(
-                                'assets/icons/close_primary.svg',
+                              child: const AssetWidget(
+                                asset: 'assets/icons/close_primary.svg',
                                 width: 7,
                                 height: 7,
                               ),
@@ -852,12 +852,14 @@ class MessageFieldView extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.fromLTRB(8, 0, 12, 0),
             child: item.withVideo
-                ? SvgLoader.asset(
-                    'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
+                ? AssetWidget(
+                    asset:
+                        'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
                     height: 13,
                   )
-                : SvgLoader.asset(
-                    'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
+                : AssetWidget(
+                    asset:
+                        'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
                     height: 15,
                   ),
           ),
@@ -896,7 +898,8 @@ class MessageFieldView extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           const SizedBox(width: 12),
-          SvgLoader.asset('assets/icons/edit.svg', width: 17, height: 17),
+          const AssetWidget(
+              asset: 'assets/icons/edit.svg', width: 17, height: 17),
           Expanded(
             child: Container(
               decoration: BoxDecoration(
@@ -1015,8 +1018,8 @@ class MessageFieldView extends StatelessWidget {
                         color: style.cardColor,
                       ),
                       alignment: Alignment.center,
-                      child: SvgLoader.asset(
-                        'assets/icons/close_primary.svg',
+                      child: const AssetWidget(
+                        asset: 'assets/icons/close_primary.svg',
                         width: 7,
                         height: 7,
                       ),

--- a/lib/ui/page/home/page/chat/message_field/view.dart
+++ b/lib/ui/page/home/page/chat/message_field/view.dart
@@ -899,7 +899,10 @@ class MessageFieldView extends StatelessWidget {
         children: [
           const SizedBox(width: 12),
           const AssetWidget(
-              asset: 'assets/icons/edit.svg', width: 17, height: 17),
+            asset: 'assets/icons/edit.svg',
+            width: 17,
+            height: 17,
+          ),
           Expanded(
             child: Container(
               decoration: BoxDecoration(

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -212,8 +212,8 @@ class _ChatViewState extends State<ChatView>
                             children = [
                               WidgetButton(
                                 onPressed: () => c.call(true),
-                                child: const AssetWidget(
-                                  asset: 'assets/icons/chat_video_call.svg',
+                                child: SvgImage.asset(
+                                  'assets/icons/chat_video_call.svg',
                                   height: 17,
                                 ),
                               ),
@@ -221,8 +221,8 @@ class _ChatViewState extends State<ChatView>
                               WidgetButton(
                                 key: const Key('AudioCall'),
                                 onPressed: () => c.call(false),
-                                child: const AssetWidget(
-                                  asset: 'assets/icons/chat_audio_call.svg',
+                                child: SvgImage.asset(
+                                  'assets/icons/chat_audio_call.svg',
                                   height: 19,
                                 ),
                               ),
@@ -243,10 +243,9 @@ class _ChatViewState extends State<ChatView>
                                             color: Colors.red,
                                             shape: BoxShape.circle,
                                           ),
-                                          child: const Center(
-                                            child: AssetWidget(
-                                              asset:
-                                                  'assets/icons/call_end.svg',
+                                          child: Center(
+                                            child: SvgImage.asset(
+                                              'assets/icons/call_end.svg',
                                               width: 32,
                                               height: 32,
                                             ),
@@ -265,10 +264,9 @@ class _ChatViewState extends State<ChatView>
                                                 .secondary,
                                             shape: BoxShape.circle,
                                           ),
-                                          child: const Center(
-                                            child: AssetWidget(
-                                              asset:
-                                                  'assets/icons/audio_call_start.svg',
+                                          child: Center(
+                                            child: SvgImage.asset(
+                                              'assets/icons/audio_call_start.svg',
                                               width: 15,
                                               height: 15,
                                             ),
@@ -886,8 +884,8 @@ class _ChatViewState extends State<ChatView>
           return Row(
             children: [
               if (c.chat?.chat.value.muted != null) ...[
-                const AssetWidget(
-                  asset: 'assets/icons/muted_dark.svg',
+                SvgImage.asset(
+                  'assets/icons/muted_dark.svg',
                   width: 19.99 * 0.6,
                   height: 15 * 0.6,
                 ),

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -212,8 +212,8 @@ class _ChatViewState extends State<ChatView>
                             children = [
                               WidgetButton(
                                 onPressed: () => c.call(true),
-                                child: SvgLoader.asset(
-                                  'assets/icons/chat_video_call.svg',
+                                child: const AssetWidget(
+                                  asset: 'assets/icons/chat_video_call.svg',
                                   height: 17,
                                 ),
                               ),
@@ -221,8 +221,8 @@ class _ChatViewState extends State<ChatView>
                               WidgetButton(
                                 key: const Key('AudioCall'),
                                 onPressed: () => c.call(false),
-                                child: SvgLoader.asset(
-                                  'assets/icons/chat_audio_call.svg',
+                                child: const AssetWidget(
+                                  asset: 'assets/icons/chat_audio_call.svg',
                                   height: 19,
                                 ),
                               ),
@@ -243,9 +243,10 @@ class _ChatViewState extends State<ChatView>
                                             color: Colors.red,
                                             shape: BoxShape.circle,
                                           ),
-                                          child: Center(
-                                            child: SvgLoader.asset(
-                                              'assets/icons/call_end.svg',
+                                          child: const Center(
+                                            child: AssetWidget(
+                                              asset:
+                                                  'assets/icons/call_end.svg',
                                               width: 32,
                                               height: 32,
                                             ),
@@ -264,9 +265,10 @@ class _ChatViewState extends State<ChatView>
                                                 .secondary,
                                             shape: BoxShape.circle,
                                           ),
-                                          child: Center(
-                                            child: SvgLoader.asset(
-                                              'assets/icons/audio_call_start.svg',
+                                          child: const Center(
+                                            child: AssetWidget(
+                                              asset:
+                                                  'assets/icons/audio_call_start.svg',
                                               width: 15,
                                               height: 15,
                                             ),
@@ -884,8 +886,8 @@ class _ChatViewState extends State<ChatView>
           return Row(
             children: [
               if (c.chat?.chat.value.muted != null) ...[
-                SvgLoader.asset(
-                  'assets/icons/muted_dark.svg',
+                const AssetWidget(
+                  asset: 'assets/icons/muted_dark.svg',
                   width: 19.99 * 0.6,
                   height: 15 * 0.6,
                 ),

--- a/lib/ui/page/home/page/chat/widget/attachment_selector.dart
+++ b/lib/ui/page/home/page/chat/widget/attachment_selector.dart
@@ -103,8 +103,8 @@ class AttachmentSourceSelector extends StatelessWidget {
         text:
             PlatformUtils.isAndroid ? 'label_photo'.l10n : 'label_camera'.l10n,
         onPressed: onTakePhoto,
-        child: const AssetWidget(
-          asset: 'assets/icons/make_photo.svg',
+        child: SvgImage.asset(
+          'assets/icons/make_photo.svg',
           width: 60,
           height: 60,
         ),
@@ -113,8 +113,8 @@ class AttachmentSourceSelector extends StatelessWidget {
         button(
           text: 'label_video'.l10n,
           onPressed: onTakeVideo,
-          child: const AssetWidget(
-            asset: 'assets/icons/video_on.svg',
+          child: SvgImage.asset(
+            'assets/icons/video_on.svg',
             width: 60,
             height: 60,
           ),
@@ -122,8 +122,8 @@ class AttachmentSourceSelector extends StatelessWidget {
       button(
         text: 'label_gallery'.l10n,
         onPressed: onPickMedia,
-        child: const AssetWidget(
-          asset: 'assets/icons/gallery.svg',
+        child: SvgImage.asset(
+          'assets/icons/gallery.svg',
           width: 60,
           height: 60,
         ),
@@ -131,8 +131,8 @@ class AttachmentSourceSelector extends StatelessWidget {
       button(
         text: 'label_file'.l10n,
         onPressed: onPickFile,
-        child: const AssetWidget(
-          asset: 'assets/icons/file.svg',
+        child: SvgImage.asset(
+          'assets/icons/file.svg',
           width: 60,
           height: 60,
         ),

--- a/lib/ui/page/home/page/chat/widget/attachment_selector.dart
+++ b/lib/ui/page/home/page/chat/widget/attachment_selector.dart
@@ -103,8 +103,8 @@ class AttachmentSourceSelector extends StatelessWidget {
         text:
             PlatformUtils.isAndroid ? 'label_photo'.l10n : 'label_camera'.l10n,
         onPressed: onTakePhoto,
-        child: SvgLoader.asset(
-          'assets/icons/make_photo.svg',
+        child: const AssetWidget(
+          asset: 'assets/icons/make_photo.svg',
           width: 60,
           height: 60,
         ),
@@ -113,8 +113,8 @@ class AttachmentSourceSelector extends StatelessWidget {
         button(
           text: 'label_video'.l10n,
           onPressed: onTakeVideo,
-          child: SvgLoader.asset(
-            'assets/icons/video_on.svg',
+          child: const AssetWidget(
+            asset: 'assets/icons/video_on.svg',
             width: 60,
             height: 60,
           ),
@@ -122,8 +122,8 @@ class AttachmentSourceSelector extends StatelessWidget {
       button(
         text: 'label_gallery'.l10n,
         onPressed: onPickMedia,
-        child: SvgLoader.asset(
-          'assets/icons/gallery.svg',
+        child: const AssetWidget(
+          asset: 'assets/icons/gallery.svg',
           width: 60,
           height: 60,
         ),
@@ -131,8 +131,8 @@ class AttachmentSourceSelector extends StatelessWidget {
       button(
         text: 'label_file'.l10n,
         onPressed: onPickFile,
-        child: SvgLoader.asset(
-          'assets/icons/file.svg',
+        child: const AssetWidget(
+          asset: 'assets/icons/file.svg',
           width: 60,
           height: 60,
         ),

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -459,12 +459,14 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
             Padding(
               padding: const EdgeInsets.fromLTRB(8, 0, 12, 0),
               child: call?.withVideo == true
-                  ? SvgLoader.asset(
-                      'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
+                  ? AssetWidget(
+                      asset:
+                          'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
                       height: 13,
                     )
-                  : SvgLoader.asset(
-                      'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
+                  : AssetWidget(
+                      asset:
+                          'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
                       height: 15,
                     ),
             ),
@@ -920,8 +922,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                                 label: PlatformUtils.isMobile
                                     ? 'btn_copy'.l10n
                                     : 'btn_copy_text'.l10n,
-                                trailing: SvgLoader.asset(
-                                  'assets/icons/copy_small.svg',
+                                trailing: const AssetWidget(
+                                  asset: 'assets/icons/copy_small.svg',
                                   height: 18,
                                 ),
                                 onPressed: () => widget.onCopy
@@ -932,8 +934,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_reply'.l10n
                                   : 'btn_reply_message'.l10n,
-                              trailing: SvgLoader.asset(
-                                'assets/icons/reply.svg',
+                              trailing: const AssetWidget(
+                                asset: 'assets/icons/reply.svg',
                                 height: 18,
                               ),
                               onPressed: widget.onReply,
@@ -943,8 +945,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_forward'.l10n
                                   : 'btn_forward_message'.l10n,
-                              trailing: SvgLoader.asset(
-                                'assets/icons/forward.svg',
+                              trailing: const AssetWidget(
+                                asset: 'assets/icons/forward.svg',
                                 height: 18,
                               ),
                               onPressed: () async {
@@ -980,8 +982,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                               ContextMenuButton(
                                 key: const Key('EditButton'),
                                 label: 'btn_edit'.l10n,
-                                trailing: SvgLoader.asset(
-                                  'assets/icons/edit.svg',
+                                trailing: const AssetWidget(
+                                  asset: 'assets/icons/edit.svg',
                                   height: 18,
                                 ),
                                 onPressed: widget.onEdit,
@@ -990,8 +992,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_delete'.l10n
                                   : 'btn_delete_message'.l10n,
-                              trailing: SvgLoader.asset(
-                                'assets/icons/delete_small.svg',
+                              trailing: const AssetWidget(
+                                asset: 'assets/icons/delete_small.svg',
                                 height: 18,
                               ),
                               onPressed: () async {

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -459,14 +459,12 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
             Padding(
               padding: const EdgeInsets.fromLTRB(8, 0, 12, 0),
               child: call?.withVideo == true
-                  ? AssetWidget(
-                      asset:
-                          'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
+                  ? SvgImage.asset(
+                      'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
                       height: 13,
                     )
-                  : AssetWidget(
-                      asset:
-                          'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
+                  : SvgImage.asset(
+                      'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
                       height: 15,
                     ),
             ),
@@ -922,8 +920,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                                 label: PlatformUtils.isMobile
                                     ? 'btn_copy'.l10n
                                     : 'btn_copy_text'.l10n,
-                                trailing: const AssetWidget(
-                                  asset: 'assets/icons/copy_small.svg',
+                                trailing: SvgImage.asset(
+                                  'assets/icons/copy_small.svg',
                                   height: 18,
                                 ),
                                 onPressed: () => widget.onCopy
@@ -934,8 +932,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_reply'.l10n
                                   : 'btn_reply_message'.l10n,
-                              trailing: const AssetWidget(
-                                asset: 'assets/icons/reply.svg',
+                              trailing: SvgImage.asset(
+                                'assets/icons/reply.svg',
                                 height: 18,
                               ),
                               onPressed: widget.onReply,
@@ -945,8 +943,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_forward'.l10n
                                   : 'btn_forward_message'.l10n,
-                              trailing: const AssetWidget(
-                                asset: 'assets/icons/forward.svg',
+                              trailing: SvgImage.asset(
+                                'assets/icons/forward.svg',
                                 height: 18,
                               ),
                               onPressed: () async {
@@ -982,8 +980,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                               ContextMenuButton(
                                 key: const Key('EditButton'),
                                 label: 'btn_edit'.l10n,
-                                trailing: const AssetWidget(
-                                  asset: 'assets/icons/edit.svg',
+                                trailing: SvgImage.asset(
+                                  'assets/icons/edit.svg',
                                   height: 18,
                                 ),
                                 onPressed: widget.onEdit,
@@ -992,8 +990,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_delete'.l10n
                                   : 'btn_delete_message'.l10n,
-                              trailing: const AssetWidget(
-                                asset: 'assets/icons/delete_small.svg',
+                              trailing: SvgImage.asset(
+                                'assets/icons/delete_small.svg',
                                 height: 18,
                               ),
                               onPressed: () async {

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1130,12 +1130,14 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                   Padding(
                     padding: const EdgeInsets.fromLTRB(8, 0, 12, 0),
                     child: message.withVideo
-                        ? SvgLoader.asset(
-                            'assets/icons/call_video${isMissed && !_fromMe ? '_red' : ''}.svg',
+                        ? AssetWidget(
+                            asset:
+                                'assets/icons/call_video${isMissed && !_fromMe ? '_red' : ''}.svg',
                             height: 13 * 1.4,
                           )
-                        : SvgLoader.asset(
-                            'assets/icons/call_audio${isMissed && !_fromMe ? '_red' : ''}.svg',
+                        : AssetWidget(
+                            asset:
+                                'assets/icons/call_audio${isMissed && !_fromMe ? '_red' : ''}.svg',
                             height: 15 * 1.4,
                           ),
                   ),
@@ -1325,12 +1327,14 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
           Padding(
             padding: const EdgeInsets.fromLTRB(8, 0, 12, 0),
             child: call?.withVideo == true
-                ? SvgLoader.asset(
-                    'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
+                ? AssetWidget(
+                    asset:
+                        'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
                     height: 13,
                   )
-                : SvgLoader.asset(
-                    'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
+                : AssetWidget(
+                    asset:
+                        'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
                     height: 15,
                   ),
           ),
@@ -1627,8 +1631,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_copy'.l10n
                                   : 'btn_copy_text'.l10n,
-                              trailing: SvgLoader.asset(
-                                'assets/icons/copy_small.svg',
+                              trailing: const AssetWidget(
+                                asset: 'assets/icons/copy_small.svg',
                                 height: 18,
                               ),
                               onPressed: () => widget.onCopy
@@ -1640,8 +1644,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_reply'.l10n
                                   : 'btn_reply_message'.l10n,
-                              trailing: SvgLoader.asset(
-                                'assets/icons/reply.svg',
+                              trailing: const AssetWidget(
+                                asset: 'assets/icons/reply.svg',
                                 height: 18,
                               ),
                               onPressed: widget.onReply,
@@ -1652,8 +1656,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                                 label: PlatformUtils.isMobile
                                     ? 'btn_forward'.l10n
                                     : 'btn_forward_message'.l10n,
-                                trailing: SvgLoader.asset(
-                                  'assets/icons/forward.svg',
+                                trailing: const AssetWidget(
+                                  asset: 'assets/icons/forward.svg',
                                   height: 18,
                                 ),
                                 onPressed: () async {
@@ -1673,8 +1677,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               ContextMenuButton(
                                 key: const Key('EditButton'),
                                 label: 'btn_edit'.l10n,
-                                trailing: SvgLoader.asset(
-                                  'assets/icons/edit.svg',
+                                trailing: const AssetWidget(
+                                  asset: 'assets/icons/edit.svg',
                                   height: 18,
                                 ),
                                 onPressed: widget.onEdit,
@@ -1684,8 +1688,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_delete'.l10n
                                   : 'btn_delete_message'.l10n,
-                              trailing: SvgLoader.asset(
-                                'assets/icons/delete_small.svg',
+                              trailing: const AssetWidget(
+                                asset: 'assets/icons/delete_small.svg',
                                 height: 18,
                               ),
                               onPressed: () async {
@@ -1730,8 +1734,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_resend'.l10n
                                   : 'btn_resend_message'.l10n,
-                              trailing: SvgLoader.asset(
-                                'assets/icons/send_small.svg',
+                              trailing: const AssetWidget(
+                                asset: 'assets/icons/send_small.svg',
                                 width: 18.37,
                                 height: 16,
                               ),
@@ -1742,8 +1746,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_delete'.l10n
                                   : 'btn_delete_message'.l10n,
-                              trailing: SvgLoader.asset(
-                                'assets/icons/delete_small.svg',
+                              trailing: const AssetWidget(
+                                asset: 'assets/icons/delete_small.svg',
                                 width: 17.75,
                                 height: 17,
                               ),

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1130,14 +1130,12 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                   Padding(
                     padding: const EdgeInsets.fromLTRB(8, 0, 12, 0),
                     child: message.withVideo
-                        ? AssetWidget(
-                            asset:
-                                'assets/icons/call_video${isMissed && !_fromMe ? '_red' : ''}.svg',
+                        ? SvgImage.asset(
+                            'assets/icons/call_video${isMissed && !_fromMe ? '_red' : ''}.svg',
                             height: 13 * 1.4,
                           )
-                        : AssetWidget(
-                            asset:
-                                'assets/icons/call_audio${isMissed && !_fromMe ? '_red' : ''}.svg',
+                        : SvgImage.asset(
+                            'assets/icons/call_audio${isMissed && !_fromMe ? '_red' : ''}.svg',
                             height: 15 * 1.4,
                           ),
                   ),
@@ -1327,14 +1325,12 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
           Padding(
             padding: const EdgeInsets.fromLTRB(8, 0, 12, 0),
             child: call?.withVideo == true
-                ? AssetWidget(
-                    asset:
-                        'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
+                ? SvgImage.asset(
+                    'assets/icons/call_video${isMissed && !fromMe ? '_red' : ''}.svg',
                     height: 13,
                   )
-                : AssetWidget(
-                    asset:
-                        'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
+                : SvgImage.asset(
+                    'assets/icons/call_audio${isMissed && !fromMe ? '_red' : ''}.svg',
                     height: 15,
                   ),
           ),
@@ -1631,8 +1627,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_copy'.l10n
                                   : 'btn_copy_text'.l10n,
-                              trailing: const AssetWidget(
-                                asset: 'assets/icons/copy_small.svg',
+                              trailing: SvgImage.asset(
+                                'assets/icons/copy_small.svg',
                                 height: 18,
                               ),
                               onPressed: () => widget.onCopy
@@ -1644,8 +1640,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_reply'.l10n
                                   : 'btn_reply_message'.l10n,
-                              trailing: const AssetWidget(
-                                asset: 'assets/icons/reply.svg',
+                              trailing: SvgImage.asset(
+                                'assets/icons/reply.svg',
                                 height: 18,
                               ),
                               onPressed: widget.onReply,
@@ -1656,8 +1652,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                                 label: PlatformUtils.isMobile
                                     ? 'btn_forward'.l10n
                                     : 'btn_forward_message'.l10n,
-                                trailing: const AssetWidget(
-                                  asset: 'assets/icons/forward.svg',
+                                trailing: SvgImage.asset(
+                                  'assets/icons/forward.svg',
                                   height: 18,
                                 ),
                                 onPressed: () async {
@@ -1677,8 +1673,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               ContextMenuButton(
                                 key: const Key('EditButton'),
                                 label: 'btn_edit'.l10n,
-                                trailing: const AssetWidget(
-                                  asset: 'assets/icons/edit.svg',
+                                trailing: SvgImage.asset(
+                                  'assets/icons/edit.svg',
                                   height: 18,
                                 ),
                                 onPressed: widget.onEdit,
@@ -1688,8 +1684,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_delete'.l10n
                                   : 'btn_delete_message'.l10n,
-                              trailing: const AssetWidget(
-                                asset: 'assets/icons/delete_small.svg',
+                              trailing: SvgImage.asset(
+                                'assets/icons/delete_small.svg',
                                 height: 18,
                               ),
                               onPressed: () async {
@@ -1734,8 +1730,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_resend'.l10n
                                   : 'btn_resend_message'.l10n,
-                              trailing: const AssetWidget(
-                                asset: 'assets/icons/send_small.svg',
+                              trailing: SvgImage.asset(
+                                'assets/icons/send_small.svg',
                                 width: 18.37,
                                 height: 16,
                               ),
@@ -1746,8 +1742,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                               label: PlatformUtils.isMobile
                                   ? 'btn_delete'.l10n
                                   : 'btn_delete_message'.l10n,
-                              trailing: const AssetWidget(
-                                asset: 'assets/icons/delete_small.svg',
+                              trailing: SvgImage.asset(
+                                'assets/icons/delete_small.svg',
                                 width: 17.75,
                                 height: 17,
                               ),

--- a/lib/ui/page/home/page/chat/widget/data_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/data_attachment.dart
@@ -83,9 +83,9 @@ class _DataAttachmentState extends State<DataAttachment> {
                     ],
                   ),
                 ),
-                child: const Center(
-                  child: AssetWidget(
-                    asset: 'assets/icons/cancel.svg',
+                child: Center(
+                  child: SvgImage.asset(
+                    'assets/icons/cancel.svg',
                     width: 11,
                     height: 11,
                   ),
@@ -129,9 +129,9 @@ class _DataAttachmentState extends State<DataAttachment> {
                   color: Theme.of(context).colorScheme.secondary,
                 ),
               ),
-              child: const Center(
-                child: AssetWidget(
-                  asset: 'assets/icons/arrow_down.svg',
+              child: Center(
+                child: SvgImage.asset(
+                  'assets/icons/arrow_down.svg',
                   width: 10.55,
                   height: 14,
                 ),

--- a/lib/ui/page/home/page/chat/widget/data_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/data_attachment.dart
@@ -83,9 +83,9 @@ class _DataAttachmentState extends State<DataAttachment> {
                     ],
                   ),
                 ),
-                child: Center(
-                  child: SvgLoader.asset(
-                    'assets/icons/cancel.svg',
+                child: const Center(
+                  child: AssetWidget(
+                    asset: 'assets/icons/cancel.svg',
                     width: 11,
                     height: 11,
                   ),
@@ -129,9 +129,9 @@ class _DataAttachmentState extends State<DataAttachment> {
                   color: Theme.of(context).colorScheme.secondary,
                 ),
               ),
-              child: Center(
-                child: SvgLoader.asset(
-                  'assets/icons/arrow_down.svg',
+              child: const Center(
+                child: AssetWidget(
+                  asset: 'assets/icons/arrow_down.svg',
                   width: 10.55,
                   height: 14,
                 ),

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -99,8 +99,8 @@ class _MediaAttachmentState extends State<MediaAttachment> {
             );
           } else {
             if (attachment.file.isSvg) {
-              return BytesWidget(
-                bytes: attachment.file.bytes.value!,
+              return SvgImage.bytes(
+                attachment.file.bytes.value!,
                 width: widget.width,
                 height: widget.height,
               );

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -99,8 +99,8 @@ class _MediaAttachmentState extends State<MediaAttachment> {
             );
           } else {
             if (attachment.file.isSvg) {
-              return SvgLoader.bytes(
-                attachment.file.bytes.value!,
+              return BytesWidget(
+                bytes: attachment.file.bytes.value!,
                 width: widget.width,
                 height: widget.height,
               );

--- a/lib/ui/page/home/page/chat/widget/message_info/view.dart
+++ b/lib/ui/page/home/page/chat/widget/message_info/view.dart
@@ -98,7 +98,9 @@ class MessageInfo extends StatelessWidget {
                       ),
                       const SizedBox(width: 8),
                       const AssetWidget(
-                          asset: 'assets/icons/copy.svg', height: 12),
+                        asset: 'assets/icons/copy.svg',
+                        height: 12,
+                      ),
                     ],
                   ),
                 ),

--- a/lib/ui/page/home/page/chat/widget/message_info/view.dart
+++ b/lib/ui/page/home/page/chat/widget/message_info/view.dart
@@ -97,8 +97,8 @@ class MessageInfo extends StatelessWidget {
                         style: thin?.copyWith(fontSize: 13),
                       ),
                       const SizedBox(width: 8),
-                      const AssetWidget(
-                        asset: 'assets/icons/copy.svg',
+                      SvgImage.asset(
+                        'assets/icons/copy.svg',
                         height: 12,
                       ),
                     ],
@@ -140,11 +140,11 @@ class MessageInfo extends StatelessWidget {
                         ),
                       ),
                     ),
-                    leading: const [
+                    leading: [
                       Padding(
-                        padding: EdgeInsets.only(left: 20, right: 12),
-                        child: AssetWidget(
-                          asset: 'assets/icons/search.svg',
+                        padding: const EdgeInsets.only(left: 20, right: 12),
+                        child: SvgImage.asset(
+                          'assets/icons/search.svg',
                           width: 17.77,
                         ),
                       )
@@ -157,10 +157,10 @@ class MessageInfo extends StatelessWidget {
                             c.search.unsubmit();
                             c.query.value = '';
                           },
-                          child: const Padding(
-                            padding: EdgeInsets.only(left: 12, right: 18),
-                            child: AssetWidget(
-                              asset: 'assets/icons/close_primary.svg',
+                          child: Padding(
+                            padding: const EdgeInsets.only(left: 12, right: 18),
+                            child: SvgImage.asset(
+                              'assets/icons/close_primary.svg',
                               height: 15,
                             ),
                           ),

--- a/lib/ui/page/home/page/chat/widget/message_info/view.dart
+++ b/lib/ui/page/home/page/chat/widget/message_info/view.dart
@@ -97,7 +97,8 @@ class MessageInfo extends StatelessWidget {
                         style: thin?.copyWith(fontSize: 13),
                       ),
                       const SizedBox(width: 8),
-                      SvgLoader.asset('assets/icons/copy.svg', height: 12),
+                      const AssetWidget(
+                          asset: 'assets/icons/copy.svg', height: 12),
                     ],
                   ),
                 ),
@@ -137,11 +138,11 @@ class MessageInfo extends StatelessWidget {
                         ),
                       ),
                     ),
-                    leading: [
+                    leading: const [
                       Padding(
-                        padding: const EdgeInsets.only(left: 20, right: 12),
-                        child: SvgLoader.asset(
-                          'assets/icons/search.svg',
+                        padding: EdgeInsets.only(left: 20, right: 12),
+                        child: AssetWidget(
+                          asset: 'assets/icons/search.svg',
                           width: 17.77,
                         ),
                       )
@@ -154,10 +155,10 @@ class MessageInfo extends StatelessWidget {
                             c.search.unsubmit();
                             c.query.value = '';
                           },
-                          child: Padding(
-                            padding: const EdgeInsets.only(left: 12, right: 18),
-                            child: SvgLoader.asset(
-                              'assets/icons/close_primary.svg',
+                          child: const Padding(
+                            padding: EdgeInsets.only(left: 12, right: 18),
+                            child: AssetWidget(
+                              asset: 'assets/icons/close_primary.svg',
                               height: 15,
                             ),
                           ),

--- a/lib/ui/page/home/page/chat/widget/message_info/view.dart
+++ b/lib/ui/page/home/page/chat/widget/message_info/view.dart
@@ -97,10 +97,7 @@ class MessageInfo extends StatelessWidget {
                         style: thin?.copyWith(fontSize: 13),
                       ),
                       const SizedBox(width: 8),
-                      SvgImage.asset(
-                        'assets/icons/copy.svg',
-                        height: 12,
-                      ),
+                      SvgImage.asset('assets/icons/copy.svg', height: 12),
                     ],
                   ),
                 ),

--- a/lib/ui/page/home/page/my_profile/camera_switch/view.dart
+++ b/lib/ui/page/home/page/my_profile/camera_switch/view.dart
@@ -96,9 +96,9 @@ class CameraSwitchView extends StatelessWidget {
                                 borderRadius: BorderRadius.circular(10),
                               ),
                               child: local == null
-                                  ? Center(
-                                      child: SvgLoader.asset(
-                                        'assets/icons/no_video.svg',
+                                  ? const Center(
+                                      child: AssetWidget(
+                                        asset: 'assets/icons/no_video.svg',
                                         width: 48.54,
                                         height: 42,
                                       ),

--- a/lib/ui/page/home/page/my_profile/camera_switch/view.dart
+++ b/lib/ui/page/home/page/my_profile/camera_switch/view.dart
@@ -96,9 +96,9 @@ class CameraSwitchView extends StatelessWidget {
                                 borderRadius: BorderRadius.circular(10),
                               ),
                               child: local == null
-                                  ? const Center(
-                                      child: AssetWidget(
-                                        asset: 'assets/icons/no_video.svg',
+                                  ? Center(
+                                      child: SvgImage.asset(
+                                        'assets/icons/no_video.svg',
                                         width: 48.54,
                                         height: 42,
                                       ),

--- a/lib/ui/page/home/page/my_profile/password/view.dart
+++ b/lib/ui/page/home/page/my_profile/password/view.dart
@@ -114,8 +114,9 @@ class ChangePasswordView extends StatelessWidget {
                           obscure: c.obscurePassword.value,
                           onSuffixPressed: c.obscurePassword.toggle,
                           treatErrorAsStatus: false,
-                          trailing: SvgLoader.asset(
-                            'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
+                          trailing: AssetWidget(
+                            asset:
+                                'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
                             width: 17.07,
                           ),
                         ),
@@ -127,8 +128,9 @@ class ChangePasswordView extends StatelessWidget {
                       obscure: c.obscureNewPassword.value,
                       onSuffixPressed: c.obscureNewPassword.toggle,
                       treatErrorAsStatus: false,
-                      trailing: SvgLoader.asset(
-                        'assets/icons/visible_${c.obscureNewPassword.value ? 'off' : 'on'}.svg',
+                      trailing: AssetWidget(
+                        asset:
+                            'assets/icons/visible_${c.obscureNewPassword.value ? 'off' : 'on'}.svg',
                         width: 17.07,
                       ),
                     ),
@@ -140,8 +142,9 @@ class ChangePasswordView extends StatelessWidget {
                       obscure: c.obscureRepeatPassword.value,
                       onSuffixPressed: c.obscureRepeatPassword.toggle,
                       treatErrorAsStatus: false,
-                      trailing: SvgLoader.asset(
-                        'assets/icons/visible_${c.obscureRepeatPassword.value ? 'off' : 'on'}.svg',
+                      trailing: AssetWidget(
+                        asset:
+                            'assets/icons/visible_${c.obscureRepeatPassword.value ? 'off' : 'on'}.svg',
                         width: 17.07,
                       ),
                     ),

--- a/lib/ui/page/home/page/my_profile/password/view.dart
+++ b/lib/ui/page/home/page/my_profile/password/view.dart
@@ -114,9 +114,8 @@ class ChangePasswordView extends StatelessWidget {
                           obscure: c.obscurePassword.value,
                           onSuffixPressed: c.obscurePassword.toggle,
                           treatErrorAsStatus: false,
-                          trailing: AssetWidget(
-                            asset:
-                                'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
+                          trailing: SvgImage.asset(
+                            'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
                             width: 17.07,
                           ),
                         ),
@@ -128,9 +127,8 @@ class ChangePasswordView extends StatelessWidget {
                       obscure: c.obscureNewPassword.value,
                       onSuffixPressed: c.obscureNewPassword.toggle,
                       treatErrorAsStatus: false,
-                      trailing: AssetWidget(
-                        asset:
-                            'assets/icons/visible_${c.obscureNewPassword.value ? 'off' : 'on'}.svg',
+                      trailing: SvgImage.asset(
+                        'assets/icons/visible_${c.obscureNewPassword.value ? 'off' : 'on'}.svg',
                         width: 17.07,
                       ),
                     ),
@@ -142,9 +140,8 @@ class ChangePasswordView extends StatelessWidget {
                       obscure: c.obscureRepeatPassword.value,
                       onSuffixPressed: c.obscureRepeatPassword.toggle,
                       treatErrorAsStatus: false,
-                      trailing: AssetWidget(
-                        asset:
-                            'assets/icons/visible_${c.obscureRepeatPassword.value ? 'off' : 'on'}.svg',
+                      trailing: SvgImage.asset(
+                        'assets/icons/visible_${c.obscureRepeatPassword.value ? 'off' : 'on'}.svg',
                         width: 17.07,
                       ),
                     ),

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -325,8 +325,8 @@ Widget _name(MyProfileController c) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: const AssetWidget(
-                  asset: 'assets/icons/copy.svg',
+                child: SvgImage.asset(
+                  'assets/icons/copy.svg',
                   height: 15,
                 ),
               ),
@@ -356,8 +356,8 @@ Widget _status(MyProfileController c) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: const AssetWidget(
-                  asset: 'assets/icons/copy.svg',
+                child: SvgImage.asset(
+                  'assets/icons/copy.svg',
                   height: 15,
                 ),
               ),
@@ -426,8 +426,8 @@ Widget _link(BuildContext context, MyProfileController c) {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child: const AssetWidget(
-                      asset: 'assets/icons/copy.svg',
+                    child: SvgImage.asset(
+                      'assets/icons/copy.svg',
                       height: 15,
                     ),
                   ),
@@ -498,8 +498,8 @@ Widget _login(MyProfileController c, BuildContext context) {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child: const AssetWidget(
-                      asset: 'assets/icons/copy.svg',
+                    child: SvgImage.asset(
+                      'assets/icons/copy.svg',
                       height: 15,
                     ),
                   ),
@@ -606,8 +606,8 @@ Widget _emails(MyProfileController c, BuildContext context) {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: const AssetWidget(
-                    asset: 'assets/icons/delete.svg',
+                  child: SvgImage.asset(
+                    'assets/icons/delete.svg',
                     height: 14,
                   ),
                 ),
@@ -698,8 +698,8 @@ Widget _emails(MyProfileController c, BuildContext context) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: const AssetWidget(
-                  asset: 'assets/icons/delete.svg',
+                child: SvgImage.asset(
+                  'assets/icons/delete.svg',
                   height: 14,
                 ),
               ),
@@ -764,8 +764,8 @@ Widget _phones(MyProfileController c, BuildContext context) {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: const AssetWidget(
-                    asset: 'assets/icons/delete.svg',
+                  child: SvgImage.asset(
+                    'assets/icons/delete.svg',
                     height: 14,
                   ),
                 ),
@@ -861,8 +861,8 @@ Widget _phones(MyProfileController c, BuildContext context) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: const AssetWidget(
-                  asset: 'assets/icons/delete.svg',
+                child: SvgImage.asset(
+                  'assets/icons/delete.svg',
                   height: 14,
                 ),
               ),
@@ -946,8 +946,8 @@ Widget _danger(BuildContext context, MyProfileController c) {
             offset: const Offset(0, -1),
             child: Transform.scale(
               scale: 1.15,
-              child: const AssetWidget(
-                asset: 'assets/icons/delete.svg',
+              child: SvgImage.asset(
+                'assets/icons/delete.svg',
                 height: 14,
               ),
             ),
@@ -1022,8 +1022,8 @@ Widget _background(BuildContext context, MyProfileController c) {
                     children: [
                       Positioned.fill(
                         child: c.background.value == null
-                            ? const AssetWidget(
-                                asset: 'assets/images/background_light.svg',
+                            ? SvgImage.asset(
+                                'assets/images/background_light.svg',
                                 width: double.infinity,
                                 height: double.infinity,
                                 fit: BoxFit.cover,

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -326,7 +326,9 @@ Widget _name(MyProfileController c) {
               child: Transform.scale(
                 scale: 1.15,
                 child: const AssetWidget(
-                    asset: 'assets/icons/copy.svg', height: 15),
+                  asset: 'assets/icons/copy.svg',
+                  height: 15,
+                ),
               ),
             ),
     ),
@@ -425,7 +427,9 @@ Widget _link(BuildContext context, MyProfileController c) {
                   child: Transform.scale(
                     scale: 1.15,
                     child: const AssetWidget(
-                        asset: 'assets/icons/copy.svg', height: 15),
+                      asset: 'assets/icons/copy.svg',
+                      height: 15,
+                    ),
                   ),
                 ),
           label: '${Config.origin}/',
@@ -858,7 +862,9 @@ Widget _phones(MyProfileController c, BuildContext context) {
               child: Transform.scale(
                 scale: 1.15,
                 child: const AssetWidget(
-                    asset: 'assets/icons/delete.svg', height: 14),
+                  asset: 'assets/icons/delete.svg',
+                  height: 14,
+                ),
               ),
             ),
             onPressed: () => AddPhoneView.show(
@@ -941,7 +947,9 @@ Widget _danger(BuildContext context, MyProfileController c) {
             child: Transform.scale(
               scale: 1.15,
               child: const AssetWidget(
-                  asset: 'assets/icons/delete.svg', height: 14),
+                asset: 'assets/icons/delete.svg',
+                height: 14,
+              ),
             ),
           ),
           onPressed: () => _deleteAccount(c, context),

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -325,10 +325,7 @@ Widget _name(MyProfileController c) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgImage.asset(
-                  'assets/icons/copy.svg',
-                  height: 15,
-                ),
+                child: SvgImage.asset('assets/icons/copy.svg', height: 15),
               ),
             ),
     ),
@@ -356,10 +353,7 @@ Widget _status(MyProfileController c) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgImage.asset(
-                  'assets/icons/copy.svg',
-                  height: 15,
-                ),
+                child: SvgImage.asset('assets/icons/copy.svg', height: 15),
               ),
             ),
     ),
@@ -426,10 +420,7 @@ Widget _link(BuildContext context, MyProfileController c) {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child: SvgImage.asset(
-                      'assets/icons/copy.svg',
-                      height: 15,
-                    ),
+                    child: SvgImage.asset('assets/icons/copy.svg', height: 15),
                   ),
                 ),
           label: '${Config.origin}/',
@@ -498,10 +489,7 @@ Widget _login(MyProfileController c, BuildContext context) {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child: SvgImage.asset(
-                      'assets/icons/copy.svg',
-                      height: 15,
-                    ),
+                    child: SvgImage.asset('assets/icons/copy.svg', height: 15),
                   ),
                 ),
           label: 'label_login'.l10n,
@@ -606,10 +594,7 @@ Widget _emails(MyProfileController c, BuildContext context) {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgImage.asset(
-                    'assets/icons/delete.svg',
-                    height: 14,
-                  ),
+                  child: SvgImage.asset('assets/icons/delete.svg', height: 14),
                 ),
               ),
             ),
@@ -698,10 +683,7 @@ Widget _emails(MyProfileController c, BuildContext context) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgImage.asset(
-                  'assets/icons/delete.svg',
-                  height: 14,
-                ),
+                child: SvgImage.asset('assets/icons/delete.svg', height: 14),
               ),
             ),
             onPressed: () => AddEmailView.show(
@@ -764,10 +746,7 @@ Widget _phones(MyProfileController c, BuildContext context) {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgImage.asset(
-                    'assets/icons/delete.svg',
-                    height: 14,
-                  ),
+                  child: SvgImage.asset('assets/icons/delete.svg', height: 14),
                 ),
               ),
               onPressed: () {
@@ -861,10 +840,7 @@ Widget _phones(MyProfileController c, BuildContext context) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgImage.asset(
-                  'assets/icons/delete.svg',
-                  height: 14,
-                ),
+                child: SvgImage.asset('assets/icons/delete.svg', height: 14),
               ),
             ),
             onPressed: () => AddPhoneView.show(
@@ -946,10 +922,7 @@ Widget _danger(BuildContext context, MyProfileController c) {
             offset: const Offset(0, -1),
             child: Transform.scale(
               scale: 1.15,
-              child: SvgImage.asset(
-                'assets/icons/delete.svg',
-                height: 14,
-              ),
+              child: SvgImage.asset('assets/icons/delete.svg', height: 14),
             ),
           ),
           onPressed: () => _deleteAccount(c, context),

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -325,7 +325,8 @@ Widget _name(MyProfileController c) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgLoader.asset('assets/icons/copy.svg', height: 15),
+                child: const AssetWidget(
+                    asset: 'assets/icons/copy.svg', height: 15),
               ),
             ),
     ),
@@ -353,8 +354,8 @@ Widget _status(MyProfileController c) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgLoader.asset(
-                  'assets/icons/copy.svg',
+                child: const AssetWidget(
+                  asset: 'assets/icons/copy.svg',
                   height: 15,
                 ),
               ),
@@ -423,7 +424,8 @@ Widget _link(BuildContext context, MyProfileController c) {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child: SvgLoader.asset('assets/icons/copy.svg', height: 15),
+                    child: const AssetWidget(
+                        asset: 'assets/icons/copy.svg', height: 15),
                   ),
                 ),
           label: '${Config.origin}/',
@@ -492,8 +494,8 @@ Widget _login(MyProfileController c, BuildContext context) {
                   offset: const Offset(0, -1),
                   child: Transform.scale(
                     scale: 1.15,
-                    child: SvgLoader.asset(
-                      'assets/icons/copy.svg',
+                    child: const AssetWidget(
+                      asset: 'assets/icons/copy.svg',
                       height: 15,
                     ),
                   ),
@@ -600,8 +602,8 @@ Widget _emails(MyProfileController c, BuildContext context) {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgLoader.asset(
-                    'assets/icons/delete.svg',
+                  child: const AssetWidget(
+                    asset: 'assets/icons/delete.svg',
                     height: 14,
                   ),
                 ),
@@ -692,8 +694,8 @@ Widget _emails(MyProfileController c, BuildContext context) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgLoader.asset(
-                  'assets/icons/delete.svg',
+                child: const AssetWidget(
+                  asset: 'assets/icons/delete.svg',
                   height: 14,
                 ),
               ),
@@ -758,8 +760,8 @@ Widget _phones(MyProfileController c, BuildContext context) {
                 offset: const Offset(0, -1),
                 child: Transform.scale(
                   scale: 1.15,
-                  child: SvgLoader.asset(
-                    'assets/icons/delete.svg',
+                  child: const AssetWidget(
+                    asset: 'assets/icons/delete.svg',
                     height: 14,
                   ),
                 ),
@@ -855,7 +857,8 @@ Widget _phones(MyProfileController c, BuildContext context) {
               offset: const Offset(0, -1),
               child: Transform.scale(
                 scale: 1.15,
-                child: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+                child: const AssetWidget(
+                    asset: 'assets/icons/delete.svg', height: 14),
               ),
             ),
             onPressed: () => AddPhoneView.show(
@@ -937,7 +940,8 @@ Widget _danger(BuildContext context, MyProfileController c) {
             offset: const Offset(0, -1),
             child: Transform.scale(
               scale: 1.15,
-              child: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+              child: const AssetWidget(
+                  asset: 'assets/icons/delete.svg', height: 14),
             ),
           ),
           onPressed: () => _deleteAccount(c, context),
@@ -1010,13 +1014,11 @@ Widget _background(BuildContext context, MyProfileController c) {
                     children: [
                       Positioned.fill(
                         child: c.background.value == null
-                            ? Container(
-                                child: SvgLoader.asset(
-                                  'assets/images/background_light.svg',
-                                  width: double.infinity,
-                                  height: double.infinity,
-                                  fit: BoxFit.cover,
-                                ),
+                            ? const AssetWidget(
+                                asset: 'assets/images/background_light.svg',
+                                width: double.infinity,
+                                height: double.infinity,
+                                fit: BoxFit.cover,
                               )
                             : Image.memory(
                                 c.background.value!,

--- a/lib/ui/page/home/page/my_profile/widget/copyable.dart
+++ b/lib/ui/page/home/page/my_profile/widget/copyable.dart
@@ -90,8 +90,8 @@ class CopyableTextField extends StatelessWidget {
                     offset: const Offset(0, -1),
                     child: Transform.scale(
                       scale: 1.15,
-                      child: SvgLoader.asset(
-                        'assets/icons/copy.svg',
+                      child: const AssetWidget(
+                        asset: 'assets/icons/copy.svg',
                         height: 15,
                       ),
                     ),

--- a/lib/ui/page/home/page/my_profile/widget/copyable.dart
+++ b/lib/ui/page/home/page/my_profile/widget/copyable.dart
@@ -90,8 +90,8 @@ class CopyableTextField extends StatelessWidget {
                     offset: const Offset(0, -1),
                     child: Transform.scale(
                       scale: 1.15,
-                      child: const AssetWidget(
-                        asset: 'assets/icons/copy.svg',
+                      child: SvgImage.asset(
+                        'assets/icons/copy.svg',
                         height: 15,
                       ),
                     ),

--- a/lib/ui/page/home/page/my_profile/widget/download_button.dart
+++ b/lib/ui/page/home/page/my_profile/widget/download_button.dart
@@ -72,8 +72,8 @@ class DownloadButton extends StatelessWidget {
               padding: const EdgeInsets.only(left: 16),
               child: Transform.scale(
                 scale: 2,
-                child: SvgLoader.asset(
-                  'assets/icons/$asset.svg',
+                child: AssetWidget(
+                  asset: 'assets/icons/$asset.svg',
                   width: width == null ? null : width! / 2,
                   height: height == null ? null : height! / 2,
                 ),
@@ -83,7 +83,7 @@ class DownloadButton extends StatelessWidget {
         offset: const Offset(0, -1),
         child: Transform.scale(
           scale: 1.15,
-          child: SvgLoader.asset('assets/icons/copy.svg', height: 15),
+          child: const AssetWidget(asset: 'assets/icons/copy.svg', height: 15),
         ),
       ),
       style: TextStyle(color: Theme.of(context).colorScheme.secondary),

--- a/lib/ui/page/home/page/my_profile/widget/download_button.dart
+++ b/lib/ui/page/home/page/my_profile/widget/download_button.dart
@@ -83,7 +83,10 @@ class DownloadButton extends StatelessWidget {
         offset: const Offset(0, -1),
         child: Transform.scale(
           scale: 1.15,
-          child: SvgImage.asset('assets/icons/copy.svg', height: 15),
+          child: SvgImage.asset(
+            'assets/icons/copy.svg',
+            height: 15,
+          ),
         ),
       ),
       style: TextStyle(color: Theme.of(context).colorScheme.secondary),

--- a/lib/ui/page/home/page/my_profile/widget/download_button.dart
+++ b/lib/ui/page/home/page/my_profile/widget/download_button.dart
@@ -72,8 +72,8 @@ class DownloadButton extends StatelessWidget {
               padding: const EdgeInsets.only(left: 16),
               child: Transform.scale(
                 scale: 2,
-                child: AssetWidget(
-                  asset: 'assets/icons/$asset.svg',
+                child: SvgImage.asset(
+                  'assets/icons/$asset.svg',
                   width: width == null ? null : width! / 2,
                   height: height == null ? null : height! / 2,
                 ),
@@ -83,7 +83,7 @@ class DownloadButton extends StatelessWidget {
         offset: const Offset(0, -1),
         child: Transform.scale(
           scale: 1.15,
-          child: const AssetWidget(asset: 'assets/icons/copy.svg', height: 15),
+          child: SvgImage.asset('assets/icons/copy.svg', height: 15),
         ),
       ),
       style: TextStyle(color: Theme.of(context).colorScheme.secondary),

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -332,15 +332,19 @@ class UserView extends StatelessWidget {
           }),
           action(
             text: 'btn_hide_chat'.l10n,
-            trailing:
-                const AssetWidget(asset: 'assets/icons/delete.svg', height: 14),
+            trailing: const AssetWidget(
+              asset: 'assets/icons/delete.svg',
+              height: 14,
+            ),
             onPressed: () => _hideChat(c, context),
           ),
           action(
             key: const Key('ClearHistoryButton'),
             text: 'btn_clear_history'.l10n,
-            trailing:
-                const AssetWidget(asset: 'assets/icons/delete.svg', height: 14),
+            trailing: const AssetWidget(
+              asset: 'assets/icons/delete.svg',
+              height: 14,
+            ),
             onPressed: () => _clearChat(c, context),
           ),
         ],

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -141,8 +141,8 @@ class UserView extends StatelessWidget {
                     onPressed: c.openChat,
                     child: Transform.translate(
                       offset: const Offset(0, 1),
-                      child: const AssetWidget(
-                        asset: 'assets/icons/chat.svg',
+                      child: SvgImage.asset(
+                        'assets/icons/chat.svg',
                         width: 20.12,
                         height: 21.62,
                       ),
@@ -152,8 +152,8 @@ class UserView extends StatelessWidget {
                     const SizedBox(width: 28),
                     WidgetButton(
                       onPressed: () => c.call(true),
-                      child: const AssetWidget(
-                        asset: 'assets/icons/chat_video_call.svg',
+                      child: SvgImage.asset(
+                        'assets/icons/chat_video_call.svg',
                         height: 17,
                       ),
                     ),
@@ -161,8 +161,8 @@ class UserView extends StatelessWidget {
                   const SizedBox(width: 28),
                   WidgetButton(
                     onPressed: () => c.call(false),
-                    child: const AssetWidget(
-                      asset: 'assets/icons/chat_audio_call.svg',
+                    child: SvgImage.asset(
+                      'assets/icons/chat_audio_call.svg',
                       height: 19,
                     ),
                   ),
@@ -317,13 +317,13 @@ class UserView extends StatelessWidget {
             return action(
               text: isMuted ? 'btn_unmute_chat'.l10n : 'btn_mute_chat'.l10n,
               trailing: isMuted
-                  ? const AssetWidget(
-                      asset: 'assets/icons/btn_mute.svg',
+                  ? SvgImage.asset(
+                      'assets/icons/btn_mute.svg',
                       width: 18.68,
                       height: 15,
                     )
-                  : const AssetWidget(
-                      asset: 'assets/icons/btn_unmute.svg',
+                  : SvgImage.asset(
+                      'assets/icons/btn_unmute.svg',
                       width: 17.86,
                       height: 15,
                     ),
@@ -332,8 +332,8 @@ class UserView extends StatelessWidget {
           }),
           action(
             text: 'btn_hide_chat'.l10n,
-            trailing: const AssetWidget(
-              asset: 'assets/icons/delete.svg',
+            trailing: SvgImage.asset(
+              'assets/icons/delete.svg',
               height: 14,
             ),
             onPressed: () => _hideChat(c, context),
@@ -341,8 +341,8 @@ class UserView extends StatelessWidget {
           action(
             key: const Key('ClearHistoryButton'),
             text: 'btn_clear_history'.l10n,
-            trailing: const AssetWidget(
-              asset: 'assets/icons/delete.svg',
+            trailing: SvgImage.asset(
+              'assets/icons/delete.svg',
               height: 14,
             ),
             onPressed: () => _clearChat(c, context),

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -332,19 +332,13 @@ class UserView extends StatelessWidget {
           }),
           action(
             text: 'btn_hide_chat'.l10n,
-            trailing: SvgImage.asset(
-              'assets/icons/delete.svg',
-              height: 14,
-            ),
+            trailing: SvgImage.asset('assets/icons/delete.svg', height: 14),
             onPressed: () => _hideChat(c, context),
           ),
           action(
             key: const Key('ClearHistoryButton'),
             text: 'btn_clear_history'.l10n,
-            trailing: SvgImage.asset(
-              'assets/icons/delete.svg',
-              height: 14,
-            ),
+            trailing: SvgImage.asset('assets/icons/delete.svg', height: 14),
             onPressed: () => _clearChat(c, context),
           ),
         ],

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -141,8 +141,8 @@ class UserView extends StatelessWidget {
                     onPressed: c.openChat,
                     child: Transform.translate(
                       offset: const Offset(0, 1),
-                      child: SvgLoader.asset(
-                        'assets/icons/chat.svg',
+                      child: const AssetWidget(
+                        asset: 'assets/icons/chat.svg',
                         width: 20.12,
                         height: 21.62,
                       ),
@@ -152,8 +152,8 @@ class UserView extends StatelessWidget {
                     const SizedBox(width: 28),
                     WidgetButton(
                       onPressed: () => c.call(true),
-                      child: SvgLoader.asset(
-                        'assets/icons/chat_video_call.svg',
+                      child: const AssetWidget(
+                        asset: 'assets/icons/chat_video_call.svg',
                         height: 17,
                       ),
                     ),
@@ -161,8 +161,8 @@ class UserView extends StatelessWidget {
                   const SizedBox(width: 28),
                   WidgetButton(
                     onPressed: () => c.call(false),
-                    child: SvgLoader.asset(
-                      'assets/icons/chat_audio_call.svg',
+                    child: const AssetWidget(
+                      asset: 'assets/icons/chat_audio_call.svg',
                       height: 19,
                     ),
                   ),
@@ -317,13 +317,13 @@ class UserView extends StatelessWidget {
             return action(
               text: isMuted ? 'btn_unmute_chat'.l10n : 'btn_mute_chat'.l10n,
               trailing: isMuted
-                  ? SvgLoader.asset(
-                      'assets/icons/btn_mute.svg',
+                  ? const AssetWidget(
+                      asset: 'assets/icons/btn_mute.svg',
                       width: 18.68,
                       height: 15,
                     )
-                  : SvgLoader.asset(
-                      'assets/icons/btn_unmute.svg',
+                  : const AssetWidget(
+                      asset: 'assets/icons/btn_unmute.svg',
                       width: 17.86,
                       height: 15,
                     ),
@@ -332,13 +332,15 @@ class UserView extends StatelessWidget {
           }),
           action(
             text: 'btn_hide_chat'.l10n,
-            trailing: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+            trailing:
+                const AssetWidget(asset: 'assets/icons/delete.svg', height: 14),
             onPressed: () => _hideChat(c, context),
           ),
           action(
             key: const Key('ClearHistoryButton'),
             text: 'btn_clear_history'.l10n,
-            trailing: SvgLoader.asset('assets/icons/delete.svg', height: 14),
+            trailing:
+                const AssetWidget(asset: 'assets/icons/delete.svg', height: 14),
             onPressed: () => _clearChat(c, context),
           ),
         ],

--- a/lib/ui/page/home/tab/chats/more/view.dart
+++ b/lib/ui/page/home/tab/chats/more/view.dart
@@ -172,8 +172,8 @@ class ChatsMoreView extends StatelessWidget {
                     offset: const Offset(0, -1),
                     child: Transform.scale(
                       scale: 1.15,
-                      child: SvgLoader.asset(
-                        'assets/icons/copy.svg',
+                      child: const AssetWidget(
+                        asset: 'assets/icons/copy.svg',
                         height: 15,
                       ),
                     ),

--- a/lib/ui/page/home/tab/chats/more/view.dart
+++ b/lib/ui/page/home/tab/chats/more/view.dart
@@ -172,8 +172,8 @@ class ChatsMoreView extends StatelessWidget {
                     offset: const Offset(0, -1),
                     child: Transform.scale(
                       scale: 1.15,
-                      child: const AssetWidget(
-                        asset: 'assets/icons/copy.svg',
+                      child: SvgImage.asset(
+                        'assets/icons/copy.svg',
                         height: 15,
                       ),
                     ),

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -153,8 +153,8 @@ class ChatsTabView extends StatelessWidget {
                           child: Container(
                             padding: const EdgeInsets.only(left: 20, right: 12),
                             height: double.infinity,
-                            child: SvgLoader.asset(
-                              'assets/icons/search.svg',
+                            child: const AssetWidget(
+                              asset: 'assets/icons/search.svg',
                               width: 17.77,
                             ),
                           ),
@@ -167,21 +167,21 @@ class ChatsTabView extends StatelessWidget {
                       final Widget child;
 
                       if (c.searching.value) {
-                        child = SvgLoader.asset(
-                          'assets/icons/close_primary.svg',
-                          key: const Key('CloseSearch'),
+                        child = const AssetWidget(
+                          asset: 'assets/icons/close_primary.svg',
+                          key: Key('CloseSearch'),
                           height: 15,
                         );
                       } else {
                         child = c.groupCreating.value || c.selecting.value
-                            ? SvgLoader.asset(
-                                'assets/icons/close_primary.svg',
-                                key: const Key('CloseGroupSearching'),
+                            ? const AssetWidget(
+                                asset: 'assets/icons/close_primary.svg',
+                                key: Key('CloseGroupSearching'),
                                 height: 15,
                               )
-                            : SvgLoader.asset(
-                                'assets/icons/group.svg',
-                                key: const Key('CreateGroup'),
+                            : const AssetWidget(
+                                asset: 'assets/icons/group.svg',
+                                key: Key('CreateGroup'),
                                 width: 21.77,
                                 height: 18.44,
                               );

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -153,8 +153,8 @@ class ChatsTabView extends StatelessWidget {
                           child: Container(
                             padding: const EdgeInsets.only(left: 20, right: 12),
                             height: double.infinity,
-                            child: const AssetWidget(
-                              asset: 'assets/icons/search.svg',
+                            child: SvgImage.asset(
+                              'assets/icons/search.svg',
                               width: 17.77,
                             ),
                           ),
@@ -167,21 +167,21 @@ class ChatsTabView extends StatelessWidget {
                       final Widget child;
 
                       if (c.searching.value) {
-                        child = const AssetWidget(
-                          asset: 'assets/icons/close_primary.svg',
-                          key: Key('CloseSearch'),
+                        child = SvgImage.asset(
+                          'assets/icons/close_primary.svg',
+                          key: const Key('CloseSearch'),
                           height: 15,
                         );
                       } else {
                         child = c.groupCreating.value || c.selecting.value
-                            ? const AssetWidget(
-                                asset: 'assets/icons/close_primary.svg',
-                                key: Key('CloseGroupSearching'),
+                            ? SvgImage.asset(
+                                'assets/icons/close_primary.svg',
+                                key: const Key('CloseGroupSearching'),
                                 height: 15,
                               )
-                            : const AssetWidget(
-                                asset: 'assets/icons/group.svg',
-                                key: Key('CreateGroup'),
+                            : SvgImage.asset(
+                                'assets/icons/group.svg',
+                                key: const Key('CreateGroup'),
                                 width: 21.77,
                                 height: 18.44,
                               );

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -171,8 +171,8 @@ class RecentChatTile extends StatelessWidget {
                   ],
                   if (chat.muted != null) ...[
                     const SizedBox(width: 5),
-                    SvgLoader.asset(
-                      'assets/icons/muted.svg',
+                    AssetWidget(
+                      asset: 'assets/icons/muted.svg',
                       key: Key('MuteIndicator_${chat.id}'),
                       width: 19.99,
                       height: 15,
@@ -706,8 +706,8 @@ class RecentChatTile extends StatelessWidget {
       } else {
         content = Container(
           color: Colors.grey,
-          child: SvgLoader.asset(
-            'assets/icons/file.svg',
+          child: const AssetWidget(
+            asset: 'assets/icons/file.svg',
             width: 30,
             height: 30,
           ),
@@ -753,8 +753,8 @@ class RecentChatTile extends StatelessWidget {
       } else {
         content = Container(
           color: Colors.grey,
-          child: SvgLoader.asset(
-            'assets/icons/file.svg',
+          child: const AssetWidget(
+            asset: 'assets/icons/file.svg',
             width: 30,
             height: 30,
           ),

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -706,11 +706,7 @@ class RecentChatTile extends StatelessWidget {
       } else {
         content = Container(
           color: Colors.grey,
-          child: SvgImage.asset(
-            'assets/icons/file.svg',
-            width: 30,
-            height: 30,
-          ),
+          child: SvgImage.asset('assets/icons/file.svg', width: 30, height: 30),
         );
       }
     }
@@ -753,11 +749,7 @@ class RecentChatTile extends StatelessWidget {
       } else {
         content = Container(
           color: Colors.grey,
-          child: SvgImage.asset(
-            'assets/icons/file.svg',
-            width: 30,
-            height: 30,
-          ),
+          child: SvgImage.asset('assets/icons/file.svg', width: 30, height: 30),
         );
       }
     }

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -171,8 +171,8 @@ class RecentChatTile extends StatelessWidget {
                   ],
                   if (chat.muted != null) ...[
                     const SizedBox(width: 5),
-                    AssetWidget(
-                      asset: 'assets/icons/muted.svg',
+                    SvgImage.asset(
+                      'assets/icons/muted.svg',
                       key: Key('MuteIndicator_${chat.id}'),
                       width: 19.99,
                       height: 15,
@@ -706,8 +706,8 @@ class RecentChatTile extends StatelessWidget {
       } else {
         content = Container(
           color: Colors.grey,
-          child: const AssetWidget(
-            asset: 'assets/icons/file.svg',
+          child: SvgImage.asset(
+            'assets/icons/file.svg',
             width: 30,
             height: 30,
           ),
@@ -753,8 +753,8 @@ class RecentChatTile extends StatelessWidget {
       } else {
         content = Container(
           color: Colors.grey,
-          child: const AssetWidget(
-            asset: 'assets/icons/file.svg',
+          child: SvgImage.asset(
+            'assets/icons/file.svg',
             width: 30,
             height: 30,
           ),

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -110,16 +110,15 @@ class ContactsTabView extends StatelessWidget {
                 final Widget child;
 
                 if (c.search.value != null || c.selecting.value) {
-                  child = const AssetWidget(
-                    key: Key('CloseSearch'),
-                    asset: 'assets/icons/close_primary.svg',
+                  child = SvgImage.asset(
+                    'assets/icons/close_primary.svg',
+                    key: const Key('CloseSearch'),
                     height: 15,
                     width: 15,
                   );
                 } else {
-                  child = AssetWidget(
-                    asset:
-                        'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
+                  child = SvgImage.asset(
+                    'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
                     key: Key('SortBy${c.sortByName ? 'Abc' : 'Time'}'),
                     width: 29.69,
                     height: 21,
@@ -162,8 +161,8 @@ class ContactsTabView extends StatelessWidget {
                   child: Container(
                     padding: const EdgeInsets.only(left: 20, right: 12),
                     height: double.infinity,
-                    child: const AssetWidget(
-                      asset: 'assets/icons/search.svg',
+                    child: SvgImage.asset(
+                      'assets/icons/search.svg',
                       width: 17.77,
                     ),
                   ),
@@ -537,8 +536,8 @@ class ContactsTabView extends StatelessWidget {
 
             return Padding(
               padding: const EdgeInsets.symmetric(horizontal: 5),
-              child: AssetWidget(
-                asset: 'assets/icons/muted.svg',
+              child: SvgImage.asset(
+                'assets/icons/muted.svg',
                 key: Key('MuteIndicator_${contact.id}'),
                 width: 19.99,
                 height: 15,

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -110,15 +110,16 @@ class ContactsTabView extends StatelessWidget {
                 final Widget child;
 
                 if (c.search.value != null || c.selecting.value) {
-                  child = SvgLoader.asset(
-                    key: const Key('CloseSearch'),
-                    'assets/icons/close_primary.svg',
+                  child = const AssetWidget(
+                    key: Key('CloseSearch'),
+                    asset: 'assets/icons/close_primary.svg',
                     height: 15,
                     width: 15,
                   );
                 } else {
-                  child = SvgLoader.asset(
-                    'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
+                  child = AssetWidget(
+                    asset:
+                        'assets/icons/sort_${c.sortByName ? 'abc' : 'time'}.svg',
                     key: Key('SortBy${c.sortByName ? 'Abc' : 'Time'}'),
                     width: 29.69,
                     height: 21,
@@ -161,8 +162,8 @@ class ContactsTabView extends StatelessWidget {
                   child: Container(
                     padding: const EdgeInsets.only(left: 20, right: 12),
                     height: double.infinity,
-                    child: SvgLoader.asset(
-                      'assets/icons/search.svg',
+                    child: const AssetWidget(
+                      asset: 'assets/icons/search.svg',
                       width: 17.77,
                     ),
                   ),
@@ -536,8 +537,8 @@ class ContactsTabView extends StatelessWidget {
 
             return Padding(
               padding: const EdgeInsets.symmetric(horizontal: 5),
-              child: SvgLoader.asset(
-                'assets/icons/muted.svg',
+              child: AssetWidget(
+                asset: 'assets/icons/muted.svg',
                 key: Key('MuteIndicator_${contact.id}'),
                 width: 19.99,
                 height: 15,

--- a/lib/ui/page/home/tab/menu/confirm/view.dart
+++ b/lib/ui/page/home/tab/menu/confirm/view.dart
@@ -72,8 +72,9 @@ class ConfirmLogoutView extends StatelessWidget {
                   style: thin,
                   onSuffixPressed: c.obscurePassword.toggle,
                   treatErrorAsStatus: false,
-                  trailing: SvgLoader.asset(
-                    'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
+                  trailing: AssetWidget(
+                    asset:
+                        'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -86,8 +87,9 @@ class ConfirmLogoutView extends StatelessWidget {
                   style: thin,
                   onSuffixPressed: c.obscureRepeat.toggle,
                   treatErrorAsStatus: false,
-                  trailing: SvgLoader.asset(
-                    'assets/icons/visible_${c.obscureRepeat.value ? 'off' : 'on'}.svg',
+                  trailing: AssetWidget(
+                    asset:
+                        'assets/icons/visible_${c.obscureRepeat.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),

--- a/lib/ui/page/home/tab/menu/confirm/view.dart
+++ b/lib/ui/page/home/tab/menu/confirm/view.dart
@@ -72,9 +72,8 @@ class ConfirmLogoutView extends StatelessWidget {
                   style: thin,
                   onSuffixPressed: c.obscurePassword.toggle,
                   treatErrorAsStatus: false,
-                  trailing: AssetWidget(
-                    asset:
-                        'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
+                  trailing: SvgImage.asset(
+                    'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -87,9 +86,8 @@ class ConfirmLogoutView extends StatelessWidget {
                   style: thin,
                   onSuffixPressed: c.obscureRepeat.toggle,
                   treatErrorAsStatus: false,
-                  trailing: AssetWidget(
-                    asset:
-                        'assets/icons/visible_${c.obscureRepeat.value ? 'off' : 'on'}.svg',
+                  trailing: SvgImage.asset(
+                    'assets/icons/visible_${c.obscureRepeat.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),

--- a/lib/ui/page/home/tab/menu/status/view.dart
+++ b/lib/ui/page/home/tab/menu/status/view.dart
@@ -96,8 +96,8 @@ class StatusView extends StatelessWidget {
                                   offset: const Offset(0, -1),
                                   child: Transform.scale(
                                     scale: 1.15,
-                                    child: const AssetWidget(
-                                      asset: 'assets/icons/copy.svg',
+                                    child: SvgImage.asset(
+                                      'assets/icons/copy.svg',
                                       height: 15,
                                     ),
                                   ),

--- a/lib/ui/page/home/tab/menu/status/view.dart
+++ b/lib/ui/page/home/tab/menu/status/view.dart
@@ -96,8 +96,8 @@ class StatusView extends StatelessWidget {
                                   offset: const Offset(0, -1),
                                   child: Transform.scale(
                                     scale: 1.15,
-                                    child: SvgLoader.asset(
-                                      'assets/icons/copy.svg',
+                                    child: const AssetWidget(
+                                      asset: 'assets/icons/copy.svg',
                                       height: 15,
                                     ),
                                   ),

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -199,8 +199,8 @@ class _HomeViewState extends State<HomeView> {
                                 key: const Key('ContactsButton'),
                                 child: tab(
                                   tab: HomeTab.contacts,
-                                  child: const AssetWidget(
-                                    asset: 'assets/icons/contacts.svg',
+                                  child: SvgImage.asset(
+                                    'assets/icons/contacts.svg',
                                     width: 30,
                                     height: 30,
                                   ),
@@ -225,16 +225,16 @@ class _HomeViewState extends State<HomeView> {
                                       final Widget child;
 
                                       if (c.myUser.value?.muted != null) {
-                                        child = const AssetWidget(
-                                          asset: 'assets/icons/chats_muted.svg',
-                                          key: Key('Muted'),
+                                        child = SvgImage.asset(
+                                          'assets/icons/chats_muted.svg',
+                                          key: const Key('Muted'),
                                           width: 36.06,
                                           height: 30,
                                         );
                                       } else {
-                                        child = const AssetWidget(
-                                          asset: 'assets/icons/chats.svg',
-                                          key: Key('Unmuted'),
+                                        child = SvgImage.asset(
+                                          'assets/icons/chats.svg',
+                                          key: const Key('Unmuted'),
                                           width: 36.06,
                                           height: 30,
                                         );
@@ -372,10 +372,10 @@ class _HomeViewState extends State<HomeView> {
 
           return Stack(
             children: [
-              const Positioned.fill(
-                child: AssetWidget(
-                  asset: 'assets/images/background_light.svg',
-                  key: Key('DefaultBackground'),
+              Positioned.fill(
+                child: SvgImage.asset(
+                  'assets/images/background_light.svg',
+                  key: const Key('DefaultBackground'),
                   width: double.infinity,
                   height: double.infinity,
                   fit: BoxFit.cover,

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -199,8 +199,8 @@ class _HomeViewState extends State<HomeView> {
                                 key: const Key('ContactsButton'),
                                 child: tab(
                                   tab: HomeTab.contacts,
-                                  child: SvgLoader.asset(
-                                    'assets/icons/contacts.svg',
+                                  child: const AssetWidget(
+                                    asset: 'assets/icons/contacts.svg',
                                     width: 30,
                                     height: 30,
                                   ),
@@ -225,16 +225,16 @@ class _HomeViewState extends State<HomeView> {
                                       final Widget child;
 
                                       if (c.myUser.value?.muted != null) {
-                                        child = SvgLoader.asset(
-                                          'assets/icons/chats_muted.svg',
-                                          key: const Key('Muted'),
+                                        child = const AssetWidget(
+                                          asset: 'assets/icons/chats_muted.svg',
+                                          key: Key('Muted'),
                                           width: 36.06,
                                           height: 30,
                                         );
                                       } else {
-                                        child = SvgLoader.asset(
-                                          'assets/icons/chats.svg',
-                                          key: const Key('Unmuted'),
+                                        child = const AssetWidget(
+                                          asset: 'assets/icons/chats.svg',
+                                          key: Key('Unmuted'),
                                           width: 36.06,
                                           height: 30,
                                         );
@@ -372,10 +372,10 @@ class _HomeViewState extends State<HomeView> {
 
           return Stack(
             children: [
-              Positioned.fill(
-                child: SvgLoader.asset(
-                  'assets/images/background_light.svg',
-                  key: const Key('DefaultBackground'),
+              const Positioned.fill(
+                child: AssetWidget(
+                  asset: 'assets/images/background_light.svg',
+                  key: Key('DefaultBackground'),
                   width: double.infinity,
                   height: double.infinity,
                   fit: BoxFit.cover,

--- a/lib/ui/page/home/widget/gallery.dart
+++ b/lib/ui/page/home/widget/gallery.dart
@@ -139,10 +139,10 @@ class _CarouselGalleryState extends State<CarouselGallery> {
               ),
               items: widget.items?.isNotEmpty != true
                   ? [
-                      const Padding(
-                        padding: EdgeInsets.symmetric(vertical: 50),
-                        child: AssetWidget(
-                          asset: 'assets/images/logo/logo0000.svg',
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 50),
+                        child: SvgImage.asset(
+                          'assets/images/logo/logo0000.svg',
                         ),
                       ),
                     ]

--- a/lib/ui/page/home/widget/gallery.dart
+++ b/lib/ui/page/home/widget/gallery.dart
@@ -139,10 +139,10 @@ class _CarouselGalleryState extends State<CarouselGallery> {
               ),
               items: widget.items?.isNotEmpty != true
                   ? [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 50),
-                        child:
-                            SvgLoader.asset('assets/images/logo/logo0000.svg'),
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 50),
+                        child: AssetWidget(
+                            asset: 'assets/images/logo/logo0000.svg'),
                       ),
                     ]
                   : widget.items!

--- a/lib/ui/page/home/widget/gallery.dart
+++ b/lib/ui/page/home/widget/gallery.dart
@@ -142,7 +142,8 @@ class _CarouselGalleryState extends State<CarouselGallery> {
                       const Padding(
                         padding: EdgeInsets.symmetric(vertical: 50),
                         child: AssetWidget(
-                            asset: 'assets/images/logo/logo0000.svg'),
+                          asset: 'assets/images/logo/logo0000.svg',
+                        ),
                       ),
                     ]
                   : widget.items!

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -209,8 +209,8 @@ class _RetryImageState extends State<RetryImage> {
       Widget image;
 
       if (_isSvg) {
-        return BytesWidget(
-          bytes: _image!,
+        return SvgImage.bytes(
+          _image!,
           width: widget.width,
           height: widget.height,
           fit: widget.fit ?? BoxFit.contain,
@@ -288,13 +288,13 @@ class _RetryImageState extends State<RetryImage> {
                                 ),
                               ],
                             ),
-                            child: const AssetWidget(
-                              asset: 'assets/icons/download.svg',
+                            child: SvgImage.asset(
+                              'assets/icons/download.svg',
                               height: 40,
                             ),
                           )
-                        : const AssetWidget(
-                            asset: 'assets/icons/close_primary.svg',
+                        : SvgImage.asset(
+                            'assets/icons/close_primary.svg',
                             height: 13,
                           ),
                   ),

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -209,8 +209,8 @@ class _RetryImageState extends State<RetryImage> {
       Widget image;
 
       if (_isSvg) {
-        return SvgLoader.bytes(
-          _image!,
+        return BytesWidget(
+          bytes: _image!,
           width: widget.width,
           height: widget.height,
           fit: widget.fit ?? BoxFit.contain,
@@ -288,13 +288,13 @@ class _RetryImageState extends State<RetryImage> {
                                 ),
                               ],
                             ),
-                            child: SvgLoader.asset(
-                              'assets/icons/download.svg',
+                            child: const AssetWidget(
+                              asset: 'assets/icons/download.svg',
                               height: 40,
                             ),
                           )
-                        : SvgLoader.asset(
-                            'assets/icons/close_primary.svg',
+                        : const AssetWidget(
+                            asset: 'assets/icons/close_primary.svg',
                             height: 13,
                           ),
                   ),

--- a/lib/ui/page/login/view.dart
+++ b/lib/ui/page/login/view.dart
@@ -173,8 +173,9 @@ class LoginView extends StatelessWidget {
                   obscure: c.obscureNewPassword.value,
                   onSuffixPressed: c.obscureNewPassword.toggle,
                   treatErrorAsStatus: false,
-                  trailing: SvgLoader.asset(
-                    'assets/icons/visible_${c.obscureNewPassword.value ? 'off' : 'on'}.svg',
+                  trailing: AssetWidget(
+                    asset:
+                        'assets/icons/visible_${c.obscureNewPassword.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -186,8 +187,9 @@ class LoginView extends StatelessWidget {
                   obscure: c.obscureRepeatPassword.value,
                   onSuffixPressed: c.obscureRepeatPassword.toggle,
                   treatErrorAsStatus: false,
-                  trailing: SvgLoader.asset(
-                    'assets/icons/visible_${c.obscureRepeatPassword.value ? 'off' : 'on'}.svg',
+                  trailing: AssetWidget(
+                    asset:
+                        'assets/icons/visible_${c.obscureRepeatPassword.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -244,8 +246,9 @@ class LoginView extends StatelessWidget {
                       obscure: c.obscurePassword.value,
                       onSuffixPressed: c.obscurePassword.toggle,
                       treatErrorAsStatus: false,
-                      trailing: SvgLoader.asset(
-                        'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
+                      trailing: AssetWidget(
+                        asset:
+                            'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
                         width: 17.07,
                       ),
                     ),

--- a/lib/ui/page/login/view.dart
+++ b/lib/ui/page/login/view.dart
@@ -173,9 +173,8 @@ class LoginView extends StatelessWidget {
                   obscure: c.obscureNewPassword.value,
                   onSuffixPressed: c.obscureNewPassword.toggle,
                   treatErrorAsStatus: false,
-                  trailing: AssetWidget(
-                    asset:
-                        'assets/icons/visible_${c.obscureNewPassword.value ? 'off' : 'on'}.svg',
+                  trailing: SvgImage.asset(
+                    'assets/icons/visible_${c.obscureNewPassword.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -187,9 +186,8 @@ class LoginView extends StatelessWidget {
                   obscure: c.obscureRepeatPassword.value,
                   onSuffixPressed: c.obscureRepeatPassword.toggle,
                   treatErrorAsStatus: false,
-                  trailing: AssetWidget(
-                    asset:
-                        'assets/icons/visible_${c.obscureRepeatPassword.value ? 'off' : 'on'}.svg',
+                  trailing: SvgImage.asset(
+                    'assets/icons/visible_${c.obscureRepeatPassword.value ? 'off' : 'on'}.svg',
                     width: 17.07,
                   ),
                 ),
@@ -246,9 +244,8 @@ class LoginView extends StatelessWidget {
                       obscure: c.obscurePassword.value,
                       onSuffixPressed: c.obscurePassword.toggle,
                       treatErrorAsStatus: false,
-                      trailing: AssetWidget(
-                        asset:
-                            'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
+                      trailing: SvgImage.asset(
+                        'assets/icons/visible_${c.obscurePassword.value ? 'off' : 'on'}.svg',
                         width: 17.07,
                       ),
                     ),

--- a/lib/ui/page/style/tab/element.dart
+++ b/lib/ui/page/style/tab/element.dart
@@ -73,16 +73,16 @@ class ElementStyleTabView extends StatelessWidget {
               element(
                 title: 'Logo в полный рост.',
                 asset: 'assets/images/logo/logo0000.svg',
-                child: const AssetWidget(
-                  asset: 'assets/images/logo/logo0000.svg',
+                child: SvgImage.asset(
+                  'assets/images/logo/logo0000.svg',
                   height: 350,
                 ),
               ),
               element(
                 title: 'Logo голова.',
                 asset: 'assets/images/logo/head0000.svg',
-                child: const AssetWidget(
-                  asset: 'assets/images/logo/head0000.svg',
+                child: SvgImage.asset(
+                  'assets/images/logo/head0000.svg',
                   height: 160,
                 ),
               ),
@@ -99,8 +99,8 @@ class ElementStyleTabView extends StatelessWidget {
                     'no registration'.l10n,
                     style: const TextStyle(color: Colors.white),
                   ),
-                  leading: const AssetWidget(
-                    asset: 'assets/icons/start.svg',
+                  leading: SvgImage.asset(
+                    'assets/icons/start.svg',
                     width: 25,
                   ),
                   onPressed: () {},
@@ -116,8 +116,8 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Sign in'),
                   subtitle: const Text('or register'),
-                  leading: const AssetWidget(
-                    asset: 'assets/icons/sign_in.svg',
+                  leading: SvgImage.asset(
+                    'assets/icons/sign_in.svg',
                     width: 20,
                   ),
                   onPressed: () {},
@@ -130,10 +130,10 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Download'),
                   subtitle: const Text('App Store'),
-                  leading: const Padding(
-                    padding: EdgeInsets.only(bottom: 3),
-                    child: AssetWidget(
-                      asset: 'assets/icons/apple.svg',
+                  leading: Padding(
+                    padding: const EdgeInsets.only(bottom: 3),
+                    child: SvgImage.asset(
+                      'assets/icons/apple.svg',
                       width: 22,
                     ),
                   ),
@@ -147,10 +147,10 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Download'),
                   subtitle: const Text('Google Play'),
-                  leading: const Padding(
-                    padding: EdgeInsets.only(left: 2),
-                    child: AssetWidget(
-                      asset: 'assets/icons/google.svg',
+                  leading: Padding(
+                    padding: const EdgeInsets.only(left: 2),
+                    child: SvgImage.asset(
+                      'assets/icons/google.svg',
                       width: 22,
                     ),
                   ),
@@ -164,8 +164,8 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Download'),
                   subtitle: const Text('application'),
-                  leading: const AssetWidget(
-                    asset: 'assets/icons/linux.svg',
+                  leading: SvgImage.asset(
+                    'assets/icons/linux.svg',
                     width: 22,
                   ),
                   onPressed: () {},
@@ -178,8 +178,8 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Download'),
                   subtitle: const Text('application'),
-                  leading: const AssetWidget(
-                    asset: 'assets/icons/windows.svg',
+                  leading: SvgImage.asset(
+                    'assets/icons/windows.svg',
                     width: 22,
                   ),
                   onPressed: () {},
@@ -285,10 +285,10 @@ class ElementStyleTabView extends StatelessWidget {
                                     'add_user.svg',
                                   ),
                                   hint: 'btn_add_participant'.l10n,
-                                  child: const Padding(
-                                    padding: EdgeInsets.only(top: 2),
-                                    child: AssetWidget(
-                                      asset: 'assets/icons/add_user.svg',
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(top: 2),
+                                    child: SvgImage.asset(
+                                      'assets/icons/add_user.svg',
                                       width: 19,
                                     ),
                                   ),
@@ -300,8 +300,8 @@ class ElementStyleTabView extends StatelessWidget {
                                     'settings.svg',
                                   ),
                                   hint: 'btn_call_settings'.l10n,
-                                  child: const AssetWidget(
-                                    asset: 'assets/icons/settings.svg',
+                                  child: SvgImage.asset(
+                                    'assets/icons/settings.svg',
                                     width: 16,
                                   ),
                                 ),
@@ -312,8 +312,8 @@ class ElementStyleTabView extends StatelessWidget {
                                     'fullscreen_enter.svg',
                                   ),
                                   hint: 'Fullscreen mode',
-                                  child: const AssetWidget(
-                                    asset: 'assets/icons/fullscreen_enter.svg',
+                                  child: SvgImage.asset(
+                                    'assets/icons/fullscreen_enter.svg',
                                     width: 14,
                                   ),
                                 ),
@@ -510,8 +510,8 @@ class ElementStyleTabView extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      const AssetWidget(
-                        asset: 'assets/icons/drag_n_drop.svg',
+                      SvgImage.asset(
+                        'assets/icons/drag_n_drop.svg',
                         width: 44,
                       ),
                       const SizedBox(height: 5),

--- a/lib/ui/page/style/tab/element.dart
+++ b/lib/ui/page/style/tab/element.dart
@@ -73,14 +73,14 @@ class ElementStyleTabView extends StatelessWidget {
               element(
                 title: 'Logo в полный рост.',
                 asset: 'assets/images/logo/logo0000.svg',
-                child: SvgLoader.asset('assets/images/logo/logo0000.svg',
-                    height: 350),
+                child: const AssetWidget(
+                    asset: 'assets/images/logo/logo0000.svg', height: 350),
               ),
               element(
                 title: 'Logo голова.',
                 asset: 'assets/images/logo/head0000.svg',
-                child: SvgLoader.asset('assets/images/logo/head0000.svg',
-                    height: 160),
+                child: const AssetWidget(
+                    asset: 'assets/images/logo/head0000.svg', height: 160),
               ),
               element(
                 background: true,
@@ -95,7 +95,8 @@ class ElementStyleTabView extends StatelessWidget {
                     'no registration'.l10n,
                     style: const TextStyle(color: Colors.white),
                   ),
-                  leading: SvgLoader.asset('assets/icons/start.svg', width: 25),
+                  leading: const AssetWidget(
+                      asset: 'assets/icons/start.svg', width: 25),
                   onPressed: () {},
                   gradient: const LinearGradient(
                     colors: [Color(0xFF03A803), Color(0xFF20CD66)],
@@ -109,8 +110,8 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Sign in'),
                   subtitle: const Text('or register'),
-                  leading:
-                      SvgLoader.asset('assets/icons/sign_in.svg', width: 20),
+                  leading: const AssetWidget(
+                      asset: 'assets/icons/sign_in.svg', width: 20),
                   onPressed: () {},
                 ),
               ),
@@ -121,9 +122,10 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Download'),
                   subtitle: const Text('App Store'),
-                  leading: Padding(
-                    padding: const EdgeInsets.only(bottom: 3),
-                    child: SvgLoader.asset('assets/icons/apple.svg', width: 22),
+                  leading: const Padding(
+                    padding: EdgeInsets.only(bottom: 3),
+                    child:
+                        AssetWidget(asset: 'assets/icons/apple.svg', width: 22),
                   ),
                   onPressed: () {},
                 ),
@@ -135,10 +137,10 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Download'),
                   subtitle: const Text('Google Play'),
-                  leading: Padding(
-                    padding: const EdgeInsets.only(left: 2),
-                    child:
-                        SvgLoader.asset('assets/icons/google.svg', width: 22),
+                  leading: const Padding(
+                    padding: EdgeInsets.only(left: 2),
+                    child: AssetWidget(
+                        asset: 'assets/icons/google.svg', width: 22),
                   ),
                   onPressed: () {},
                 ),
@@ -150,7 +152,8 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Download'),
                   subtitle: const Text('application'),
-                  leading: SvgLoader.asset('assets/icons/linux.svg', width: 22),
+                  leading: const AssetWidget(
+                      asset: 'assets/icons/linux.svg', width: 22),
                   onPressed: () {},
                 ),
               ),
@@ -161,8 +164,8 @@ class ElementStyleTabView extends StatelessWidget {
                 child: OutlinedRoundedButton(
                   title: const Text('Download'),
                   subtitle: const Text('application'),
-                  leading:
-                      SvgLoader.asset('assets/icons/windows.svg', width: 22),
+                  leading: const AssetWidget(
+                      asset: 'assets/icons/windows.svg', width: 22),
                   onPressed: () {},
                 ),
               ),
@@ -266,10 +269,10 @@ class ElementStyleTabView extends StatelessWidget {
                                     'add_user.svg',
                                   ),
                                   hint: 'btn_add_participant'.l10n,
-                                  child: Padding(
-                                    padding: const EdgeInsets.only(top: 2),
-                                    child: SvgLoader.asset(
-                                      'assets/icons/add_user.svg',
+                                  child: const Padding(
+                                    padding: EdgeInsets.only(top: 2),
+                                    child: AssetWidget(
+                                      asset: 'assets/icons/add_user.svg',
                                       width: 19,
                                     ),
                                   ),
@@ -281,8 +284,8 @@ class ElementStyleTabView extends StatelessWidget {
                                     'settings.svg',
                                   ),
                                   hint: 'btn_call_settings'.l10n,
-                                  child: SvgLoader.asset(
-                                    'assets/icons/settings.svg',
+                                  child: const AssetWidget(
+                                    asset: 'assets/icons/settings.svg',
                                     width: 16,
                                   ),
                                 ),
@@ -293,8 +296,8 @@ class ElementStyleTabView extends StatelessWidget {
                                     'fullscreen_enter.svg',
                                   ),
                                   hint: 'Fullscreen mode',
-                                  child: SvgLoader.asset(
-                                    'assets/icons/fullscreen_enter.svg',
+                                  child: const AssetWidget(
+                                    asset: 'assets/icons/fullscreen_enter.svg',
                                     width: 14,
                                   ),
                                 ),
@@ -491,8 +494,8 @@ class ElementStyleTabView extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      SvgLoader.asset('assets/icons/drag_n_drop.svg',
-                          width: 44),
+                      const AssetWidget(
+                          asset: 'assets/icons/drag_n_drop.svg', width: 44),
                       const SizedBox(height: 5),
                       Text(
                         'Drop any\nvideo here',

--- a/lib/ui/page/style/tab/element.dart
+++ b/lib/ui/page/style/tab/element.dart
@@ -74,13 +74,17 @@ class ElementStyleTabView extends StatelessWidget {
                 title: 'Logo в полный рост.',
                 asset: 'assets/images/logo/logo0000.svg',
                 child: const AssetWidget(
-                    asset: 'assets/images/logo/logo0000.svg', height: 350),
+                  asset: 'assets/images/logo/logo0000.svg',
+                  height: 350,
+                ),
               ),
               element(
                 title: 'Logo голова.',
                 asset: 'assets/images/logo/head0000.svg',
                 child: const AssetWidget(
-                    asset: 'assets/images/logo/head0000.svg', height: 160),
+                  asset: 'assets/images/logo/head0000.svg',
+                  height: 160,
+                ),
               ),
               element(
                 background: true,
@@ -96,7 +100,9 @@ class ElementStyleTabView extends StatelessWidget {
                     style: const TextStyle(color: Colors.white),
                   ),
                   leading: const AssetWidget(
-                      asset: 'assets/icons/start.svg', width: 25),
+                    asset: 'assets/icons/start.svg',
+                    width: 25,
+                  ),
                   onPressed: () {},
                   gradient: const LinearGradient(
                     colors: [Color(0xFF03A803), Color(0xFF20CD66)],
@@ -111,7 +117,9 @@ class ElementStyleTabView extends StatelessWidget {
                   title: const Text('Sign in'),
                   subtitle: const Text('or register'),
                   leading: const AssetWidget(
-                      asset: 'assets/icons/sign_in.svg', width: 20),
+                    asset: 'assets/icons/sign_in.svg',
+                    width: 20,
+                  ),
                   onPressed: () {},
                 ),
               ),
@@ -124,8 +132,10 @@ class ElementStyleTabView extends StatelessWidget {
                   subtitle: const Text('App Store'),
                   leading: const Padding(
                     padding: EdgeInsets.only(bottom: 3),
-                    child:
-                        AssetWidget(asset: 'assets/icons/apple.svg', width: 22),
+                    child: AssetWidget(
+                      asset: 'assets/icons/apple.svg',
+                      width: 22,
+                    ),
                   ),
                   onPressed: () {},
                 ),
@@ -140,7 +150,9 @@ class ElementStyleTabView extends StatelessWidget {
                   leading: const Padding(
                     padding: EdgeInsets.only(left: 2),
                     child: AssetWidget(
-                        asset: 'assets/icons/google.svg', width: 22),
+                      asset: 'assets/icons/google.svg',
+                      width: 22,
+                    ),
                   ),
                   onPressed: () {},
                 ),
@@ -153,7 +165,9 @@ class ElementStyleTabView extends StatelessWidget {
                   title: const Text('Download'),
                   subtitle: const Text('application'),
                   leading: const AssetWidget(
-                      asset: 'assets/icons/linux.svg', width: 22),
+                    asset: 'assets/icons/linux.svg',
+                    width: 22,
+                  ),
                   onPressed: () {},
                 ),
               ),
@@ -165,7 +179,9 @@ class ElementStyleTabView extends StatelessWidget {
                   title: const Text('Download'),
                   subtitle: const Text('application'),
                   leading: const AssetWidget(
-                      asset: 'assets/icons/windows.svg', width: 22),
+                    asset: 'assets/icons/windows.svg',
+                    width: 22,
+                  ),
                   onPressed: () {},
                 ),
               ),
@@ -495,7 +511,9 @@ class ElementStyleTabView extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       const AssetWidget(
-                          asset: 'assets/icons/drag_n_drop.svg', width: 44),
+                        asset: 'assets/icons/drag_n_drop.svg',
+                        width: 44,
+                      ),
                       const SizedBox(height: 5),
                       Text(
                         'Drop any\nvideo here',

--- a/lib/ui/page/style/tab/element.dart
+++ b/lib/ui/page/style/tab/element.dart
@@ -132,10 +132,7 @@ class ElementStyleTabView extends StatelessWidget {
                   subtitle: const Text('App Store'),
                   leading: Padding(
                     padding: const EdgeInsets.only(bottom: 3),
-                    child: SvgImage.asset(
-                      'assets/icons/apple.svg',
-                      width: 22,
-                    ),
+                    child: SvgImage.asset('assets/icons/apple.svg', width: 22),
                   ),
                   onPressed: () {},
                 ),
@@ -149,10 +146,7 @@ class ElementStyleTabView extends StatelessWidget {
                   subtitle: const Text('Google Play'),
                   leading: Padding(
                     padding: const EdgeInsets.only(left: 2),
-                    child: SvgImage.asset(
-                      'assets/icons/google.svg',
-                      width: 22,
-                    ),
+                    child: SvgImage.asset('assets/icons/google.svg', width: 22),
                   ),
                   onPressed: () {},
                 ),

--- a/lib/ui/widget/svg/svg.dart
+++ b/lib/ui/widget/svg/svg.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
 // Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
 //                       <https://github.com/team113>
 //
@@ -24,101 +25,135 @@ import 'src/interface.dart'
     if (dart.library.io) 'src/io.dart'
     if (dart.library.html) 'src/web.dart';
 
-/// SVG images renderer.
+/// Instantiates a widget rendering an SVG picture from an [AssetBundle].
 ///
-/// Actual renderer is determined based on the current platform:
-/// - [SvgPicture] is used on all non-web platforms and on web with `CanvasKit`
-///   renderer;
-/// - [Image.network] is used on web with html-renderer.
-class SvgLoader {
-  /// Instantiates a widget rendering an SVG picture from an [AssetBundle].
-  ///
-  /// The key will be derived from the `assetName`, `package`, and `bundle`
-  /// arguments. The `package` argument must be non-`null` when displaying an
-  /// SVG from a package and `null` otherwise.
-  ///
-  /// Either the [width] and [height] arguments should be specified, or the
-  /// widget should be placed in a context that sets tight layout constraints.
-  /// Otherwise, the image dimensions will change as the image is loaded, which
-  /// will result in ugly layout changes.
-  static Widget asset(
-    String asset, {
+/// The key will be derived from the `assetName`, `package`, and `bundle`
+/// arguments. The `package` argument must be non-`null` when displaying an
+/// SVG from a package and `null` otherwise.
+///
+/// Either the [width] and [height] arguments should be specified, or the
+/// widget should be placed in a context that sets tight layout constraints.
+/// Otherwise, the image dimensions will change as the image is loaded, which
+/// will result in ugly layout changes.
+class AssetWidget extends StatelessWidget {
+  final String asset;
+  final Alignment alignment;
+  final BoxFit fit;
+  final double? height;
+  final String? package;
+  final WidgetBuilder? placeholderBuilder;
+  final String? semanticsLabel;
+  final double? width;
+  final bool excludeFromSemantics;
+  const AssetWidget({
     Key? key,
-    Alignment alignment = Alignment.center,
-    BoxFit fit = BoxFit.contain,
-    double? height,
-    String? package,
-    WidgetBuilder? placeholderBuilder,
-    String? semanticsLabel,
-    double? width,
-    bool excludeFromSemantics = false,
-  }) =>
-      svgFromAsset(
-        asset,
-        key: key,
-        alignment: alignment,
-        fit: fit,
-        height: height,
-        package: package,
-        placeholderBuilder: placeholderBuilder,
-        semanticsLabel: semanticsLabel,
-        width: width,
-        excludeFromSemantics: excludeFromSemantics,
-      );
+    required this.asset,
+    this.alignment = Alignment.center,
+    this.fit = BoxFit.contain,
+    this.height,
+    this.package,
+    this.placeholderBuilder,
+    this.semanticsLabel,
+    this.width,
+    this.excludeFromSemantics = false,
+  }) : super(key: key);
 
-  /// Instantiates a widget rendering an SVG picture from an [Uint8List].
-  ///
-  /// Either the [width] and [height] arguments should be specified, or the
-  /// widget should be placed in a context setting layout constraints tightly.
-  /// Otherwise, the image dimensions will change as the image is loaded, which
-  /// will result in ugly layout changes.
-  static Widget bytes(
-    Uint8List bytes, {
-    Key? key,
-    Alignment alignment = Alignment.center,
-    BoxFit fit = BoxFit.cover,
-    double? width,
-    double? height,
-    WidgetBuilder? placeholderBuilder,
-    String? semanticsLabel,
-    bool excludeFromSemantics = false,
-  }) =>
-      svgFromBytes(
-        bytes,
-        key: key,
-        alignment: Alignment.center,
-        fit: fit,
-        width: width,
-        height: height,
-        semanticsLabel: semanticsLabel,
-        excludeFromSemantics: excludeFromSemantics,
-      );
+  @override
+  Widget build(BuildContext context) {
+    return svgFromAsset(
+      asset,
+      alignment: alignment,
+      fit: fit,
+      height: height,
+      package: package,
+      placeholderBuilder: placeholderBuilder,
+      semanticsLabel: semanticsLabel,
+      width: width,
+      excludeFromSemantics: excludeFromSemantics,
+    );
+  }
+}
 
-  /// Instantiates a widget rendering an SVG picture from a [File].
-  ///
-  /// Either the [width] and [height] arguments should be specified, or the
-  /// widget should be placed in a context setting layout constraints tightly.
-  /// Otherwise, the image dimensions will change as the image is loaded, which
-  /// will result in ugly layout changes.
-  static Widget file(
-    File file, {
+/// Instantiates a widget rendering an SVG picture from an [Uint8List].
+///
+/// Either the [width] and [height] arguments should be specified, or the
+/// widget should be placed in a context setting layout constraints tightly.
+/// Otherwise, the image dimensions will change as the image is loaded, which
+/// will result in ugly layout changes.
+class BytesWidget extends StatelessWidget {
+  final Uint8List bytes;
+  final Alignment alignment;
+  final BoxFit fit;
+  final double? width;
+  final double? height;
+  final WidgetBuilder? placeholderBuilder;
+  final String? semanticsLabel;
+  final bool excludeFromSemantics;
+  const BytesWidget({
     Key? key,
-    Alignment alignment = Alignment.center,
-    BoxFit fit = BoxFit.cover,
-    double? width,
-    double? height,
-    WidgetBuilder? placeholderBuilder,
-    String? semanticsLabel,
-    bool excludeFromSemantics = false,
-  }) =>
-      svgFromFile(
-        file,
-        key: key,
-        alignment: Alignment.center,
-        excludeFromSemantics: excludeFromSemantics,
-        fit: fit,
-        height: height,
-        semanticsLabel: semanticsLabel,
-        width: width,
-      );
+    required this.bytes,
+    this.alignment = Alignment.center,
+    this.fit = BoxFit.cover,
+    this.width,
+    this.height,
+    this.placeholderBuilder,
+    this.semanticsLabel,
+    this.excludeFromSemantics = false,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return svgFromBytes(
+      bytes,
+      key: key,
+      alignment: Alignment.center,
+      fit: fit,
+      width: width,
+      height: height,
+      semanticsLabel: semanticsLabel,
+      excludeFromSemantics: excludeFromSemantics,
+    );
+  }
+}
+
+/// Instantiates a widget rendering an SVG picture from a [File].
+///
+/// Either the [width] and [height] arguments should be specified, or the
+/// widget should be placed in a context setting layout constraints tightly.
+/// Otherwise, the image dimensions will change as the image is loaded, which
+/// will result in ugly layout changes.
+class FileWidget extends StatelessWidget {
+  final File file;
+  final Alignment alignment;
+  final BoxFit fit;
+  final double? width;
+  final double? height;
+  final WidgetBuilder? placeholderBuilder;
+  final String? semanticsLabel;
+  final bool excludeFromSemantics;
+  const FileWidget({
+    Key? key,
+    required this.file,
+    this.alignment = Alignment.center,
+    this.fit = BoxFit.cover,
+    this.width,
+    this.height,
+    this.placeholderBuilder,
+    this.semanticsLabel,
+    this.excludeFromSemantics = false,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return svgFromFile(
+      file,
+      key: key,
+      alignment: Alignment.center,
+      excludeFromSemantics: excludeFromSemantics,
+      fit: fit,
+      height: height,
+      semanticsLabel: semanticsLabel,
+      width: width,
+    );
+  }
 }

--- a/lib/ui/widget/svg/svg.dart
+++ b/lib/ui/widget/svg/svg.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
 // Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
 //                       <https://github.com/team113>
 //
@@ -25,135 +24,188 @@ import 'src/interface.dart'
     if (dart.library.io) 'src/io.dart'
     if (dart.library.html) 'src/web.dart';
 
-/// Instantiates a widget rendering an SVG picture from an [AssetBundle].
+/// SVG images renderer.
 ///
-/// The key will be derived from the `assetName`, `package`, and `bundle`
-/// arguments. The `package` argument must be non-`null` when displaying an
-/// SVG from a package and `null` otherwise.
-///
-/// Either the [width] and [height] arguments should be specified, or the
-/// widget should be placed in a context that sets tight layout constraints.
-/// Otherwise, the image dimensions will change as the image is loaded, which
-/// will result in ugly layout changes.
-class AssetWidget extends StatelessWidget {
-  final String asset;
-  final Alignment alignment;
-  final BoxFit fit;
-  final double? height;
-  final String? package;
-  final WidgetBuilder? placeholderBuilder;
-  final String? semanticsLabel;
-  final double? width;
-  final bool excludeFromSemantics;
-  const AssetWidget({
-    Key? key,
-    required this.asset,
-    this.alignment = Alignment.center,
-    this.fit = BoxFit.contain,
+/// Actual renderer is determined based on the current platform:
+/// - [SvgPicture] is used on all non-web platforms and on web with `CanvasKit`
+///   renderer;
+/// - [Image.network] is used on web with html-renderer.
+class SvgImage extends StatelessWidget {
+  const SvgImage._({
+    super.key,
+    this.asset,
+    this.file,
+    this.bytes,
+    required this.alignment,
+    required this.fit,
+    this.width,
     this.height,
-    this.package,
     this.placeholderBuilder,
     this.semanticsLabel,
-    this.width,
     this.excludeFromSemantics = false,
-  }) : super(key: key);
+  });
 
-  @override
-  Widget build(BuildContext context) {
-    return svgFromAsset(
-      asset,
-      alignment: alignment,
-      fit: fit,
+  /// Relative path to the file of the resource containing the image.
+  final String? asset;
+
+  /// Reference to a file on the file system.
+  final File? file;
+
+  /// Array of bytes containing image data.
+  final Uint8List? bytes;
+
+  /// Image alignment.
+  final Alignment alignment;
+
+  /// Image scaling.
+  final BoxFit fit;
+
+  /// Image width.
+  final double? width;
+
+  /// Image height.
+  final double? height;
+
+  /// Сreates a temporary image when loading.
+  final WidgetBuilder? placeholderBuilder;
+
+  /// A text description of the image.
+  final String? semanticsLabel;
+
+  /// Indicating whether to exclude the image from the screen reader.
+  final bool excludeFromSemantics;
+
+  /// Instantiates a widget rendering an SVG picture from an [AssetBundle].
+  ///
+  /// The key will be derived from the `assetName`, `package`, and `bundle`
+  /// arguments. The `package` argument must be non-`null` when displaying an
+  /// SVG from a package and `null` otherwise.
+  ///
+  /// Either the [width] and [height] arguments should be specified, or the
+  /// widget should be placed in a context that sets tight layout constraints.
+  /// Otherwise, the image dimensions will change as the image is loaded, which
+  /// will result in ugly layout changes.
+  factory SvgImage.asset(
+    String asset, {
+    Key? key,
+    Alignment alignment = Alignment.center,
+    BoxFit fit = BoxFit.contain,
+    double? width,
+    double? height,
+    WidgetBuilder? placeholderBuilder,
+    String? semanticsLabel,
+    bool excludeFromSemantics = false,
+  }) {
+    return SvgImage._(
+      asset: asset,
+      key: key,
+      alignment: Alignment.center,
+      fit: BoxFit.contain,
+      width: width,
       height: height,
-      package: package,
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
-      width: width,
-      excludeFromSemantics: excludeFromSemantics,
+      excludeFromSemantics: false,
     );
   }
-}
 
-/// Instantiates a widget rendering an SVG picture from an [Uint8List].
-///
-/// Either the [width] and [height] arguments should be specified, or the
-/// widget should be placed in a context setting layout constraints tightly.
-/// Otherwise, the image dimensions will change as the image is loaded, which
-/// will result in ugly layout changes.
-class BytesWidget extends StatelessWidget {
-  final Uint8List bytes;
-  final Alignment alignment;
-  final BoxFit fit;
-  final double? width;
-  final double? height;
-  final WidgetBuilder? placeholderBuilder;
-  final String? semanticsLabel;
-  final bool excludeFromSemantics;
-  const BytesWidget({
+  /// Instantiates a widget rendering an SVG picture from a [File].
+  ///
+  /// Either the [width] and [height] arguments should be specified, or the
+  /// widget should be placed in a context setting layout constraints tightly.
+  /// Otherwise, the image dimensions will change as the image is loaded, which
+  /// will result in ugly layout changes.
+  factory SvgImage.file(
+    File file, {
     Key? key,
-    required this.bytes,
-    this.alignment = Alignment.center,
-    this.fit = BoxFit.cover,
-    this.width,
-    this.height,
-    this.placeholderBuilder,
-    this.semanticsLabel,
-    this.excludeFromSemantics = false,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return svgFromBytes(
-      bytes,
+    Alignment alignment = Alignment.center,
+    BoxFit fit = BoxFit.contain,
+    double? width,
+    double? height,
+    WidgetBuilder? placeholderBuilder,
+    String? semanticsLabel,
+    bool excludeFromSemantics = false,
+  }) {
+    return SvgImage._(
+      file: file,
       key: key,
-      alignment: Alignment.center,
+      alignment: alignment,
       fit: fit,
       width: width,
       height: height,
+      placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
     );
   }
-}
 
-/// Instantiates a widget rendering an SVG picture from a [File].
-///
-/// Either the [width] and [height] arguments should be specified, or the
-/// widget should be placed in a context setting layout constraints tightly.
-/// Otherwise, the image dimensions will change as the image is loaded, which
-/// will result in ugly layout changes.
-class FileWidget extends StatelessWidget {
-  final File file;
-  final Alignment alignment;
-  final BoxFit fit;
-  final double? width;
-  final double? height;
-  final WidgetBuilder? placeholderBuilder;
-  final String? semanticsLabel;
-  final bool excludeFromSemantics;
-  const FileWidget({
+  /// Instantiates a widget rendering an SVG picture from an [Uint8List].
+  ///
+  /// Either the [width] and [height] arguments should be specified, or the
+  /// widget should be placed in a context setting layout constraints tightly.
+  /// Otherwise, the image dimensions will change as the image is loaded, which
+  /// will result in ugly layout changes.
+  factory SvgImage.bytes(
+    Uint8List bytes, {
     Key? key,
-    required this.file,
-    this.alignment = Alignment.center,
-    this.fit = BoxFit.cover,
-    this.width,
-    this.height,
-    this.placeholderBuilder,
-    this.semanticsLabel,
-    this.excludeFromSemantics = false,
-  }) : super(key: key);
+    Alignment alignment = Alignment.center,
+    BoxFit fit = BoxFit.contain,
+    double? width,
+    double? height,
+    WidgetBuilder? placeholderBuilder,
+    String? semanticsLabel,
+    bool excludeFromSemantics = false,
+  }) {
+    return SvgImage._(
+      bytes: bytes,
+      key: key,
+      alignment: alignment,
+      fit: fit,
+      width: width,
+      height: height,
+      placeholderBuilder: placeholderBuilder,
+      semanticsLabel: semanticsLabel,
+      excludeFromSemantics: excludeFromSemantics,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    return svgFromFile(
-      file,
-      key: key,
-      alignment: Alignment.center,
-      excludeFromSemantics: excludeFromSemantics,
-      fit: fit,
-      height: height,
-      semanticsLabel: semanticsLabel,
-      width: width,
-    );
+    if (asset != null) {
+      return svgFromAsset(
+        asset!,
+        alignment: alignment,
+        fit: fit,
+        width: width,
+        height: height,
+        placeholderBuilder: placeholderBuilder,
+        semanticsLabel: semanticsLabel,
+        excludeFromSemantics: excludeFromSemantics,
+      );
+    } else if (file != null) {
+      return svgFromFile(
+        file!,
+        alignment: alignment,
+        fit: fit,
+        width: width,
+        height: height,
+        placeholderBuilder: placeholderBuilder,
+        semanticsLabel: semanticsLabel,
+        excludeFromSemantics: excludeFromSemantics,
+      );
+    } else if (bytes != null) {
+      return svgFromBytes(
+        bytes!,
+        alignment: alignment,
+        fit: fit,
+        width: width,
+        height: height,
+        placeholderBuilder: placeholderBuilder,
+        semanticsLabel: semanticsLabel,
+        excludeFromSemantics: excludeFromSemantics,
+      );
+    } else {
+      return Container();
+    }
   }
 }

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -190,8 +190,8 @@ class ReactiveTextField extends StatelessWidget {
                       height: 24,
                       child: ElasticAnimatedSwitcher(
                         child: state.status.value.isLoading
-                            ? SvgLoader.asset(
-                                'assets/icons/timer.svg',
+                            ? const AssetWidget(
+                                asset: 'assets/icons/timer.svg',
                                 width: 17,
                                 height: 17,
                               )

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -190,8 +190,8 @@ class ReactiveTextField extends StatelessWidget {
                       height: 24,
                       child: ElasticAnimatedSwitcher(
                         child: state.status.value.isLoading
-                            ? const AssetWidget(
-                                asset: 'assets/icons/timer.svg',
+                            ? SvgImage.asset(
+                                'assets/icons/timer.svg',
                                 width: 17,
                                 height: 17,
                               )


### PR DESCRIPTION
Resolves 


## Synopsis

В текущей реализации класс `SvgLoader` содержит статические виджеты и не очень корректный нейминг ,что создает ряд проблем.




## Solution

- Переименовать класс `SvgLoader` в `SvgImage`.
- Реализовать фабричные конструкторы для создания и возврата виджетов.




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
