### PR TITLE
Fix `wakelock` invoking on Linux

### DIFF
--- a/lib/ui/worker/call.dart
+++ b/lib/ui/worker/call.dart
@@ -115,17 +115,21 @@ class CallWorker extends DisposableService {
     _initWebUtils();
 
     bool wakelock = _callService.calls.isNotEmpty;
-    if (wakelock) {
+    if (wakelock && !PlatformUtils.isLinux) {
       Wakelock.enable().onError((_, __) => false);
     }
 
     _subscription = _callService.calls.changes.listen((event) async {
-      if (!wakelock && _callService.calls.isNotEmpty) {
-        wakelock = true;
-        Wakelock.enable().onError((_, __) => false);
-      } else if (wakelock && _callService.calls.isEmpty) {
-        wakelock = false;
-        Wakelock.disable().onError((_, __) => false);
+      // TODO: Wait for Linux `wakelock` implementation to be done and merged:
+      //       https://github.com/creativecreatorormaybenot/wakelock/pull/186
+      if (!PlatformUtils.isLinux) {
+        if (!wakelock && _callService.calls.isNotEmpty) {
+          wakelock = true;
+          Wakelock.enable().onError((_, __) => false);
+        } else if (wakelock && _callService.calls.isEmpty) {
+          wakelock = false;
+          Wakelock.disable().onError((_, __) => false);
+        }
       }
 
       switch (event.op) {


### PR DESCRIPTION
## Synopsis

`wakelock` throws a uncatchable exception on Linux every time it's executed.




## Solution

Add `if (!linux) then wakelock`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
