### PR TITLE
Upgrade to 0.1.0-beta.9 backend version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # - `z` makes bind mount content shared among multiple containers.
 # - `Z` makes bind mount content private and unshared.
 
-version: "2"
+version: "2.4"
 
 services:
   frontend:
@@ -27,14 +27,18 @@ services:
       CONF.DB.COCKROACHDB.HOST: cockroachdb
       CONF.FCM.SA_KEY: ${COMPOSE_FCM_SA_KEY}
       CONF.MEDIA_SERVER.MEDEA.SERVER.CLIENT.HTTP.PUBLIC_URL: ws://localhost/api/medea/ws
+      CONF.MEDIA_SERVER.MEDEA.SERVER.CLIENT.WEBRTC.PUBLIC_IP: 127.0.0.1
       CONF.MEDIA_SERVER.MEDEA.ICE.EMBEDDED.PUBLIC_HOST: 127.0.0.1:3478
       CONF.STORAGE.FILE.S3.HOST: baza-storage
       CONF.SMTP.HOST: mailhog
     ports:
-      - 3478:3478                # backend medea stun
+      - 3478:3478                # backend medea stun tcp
+      - 3478:3478/udp            # backend medea stun udp
       - 8081:7777                # backend http
-      - 8090:8090                # backend medea ws
+      - 8090:8090                # backend medea http (ws)
       - 49066-49100:49166-49200  # backend medea turn
+      - 19305:19305              # backend medea webrtc tcp
+      - 19305:19305/udp          # backend medea webrtc udp
     expose:
       - 9372   # backend metrics
       - 10025  # backend healthz
@@ -52,11 +56,18 @@ services:
     volumes:
       - ./.cache/cockroachdb/data/:/cockroach/cockroach-data/:Z
       - ./dev/cockroachdb/logs.yaml:/logs.yaml:ro,Z
+    healthcheck:
+      # https://www.cockroachlabs.com/docs/monitoring-and-alerting.html#health-ready-1
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]
+      interval: 3s
+      timeout: 3s
+      retries: 5
   cockroachdb-pgweb:
     container_name: ${COMPOSE_PROJECT_NAME}-cockroachdb-pgweb
     image: sosedoff/pgweb:latest
-    depends_on: ["cockroachdb"]
-    restart: on-failure
+    depends_on:
+      cockroachdb:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgres://root@127.0.0.1:26257/defaultdb?sslmode=disable
     network_mode: service:cockroachdb

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,11 +36,11 @@ type AddChatMemberError {
 """Possible error codes of performing `Mutation.addChatMember`."""
 enum AddChatMemberErrorCode {
   """
-  Authenticated `MyUser` is blacklisted by the `User` he tries to add to the `Chat`.
+  Authenticated `MyUser` is blocked by the `User` he tries to add to the `Chat`.
 
   Status code: 403 Forbidden.
   """
-  BLACKLISTED
+  BLOCKED
 
   """
   `Chat` is not a group, so cannot accept new members.
@@ -162,25 +162,25 @@ interface Attachment {
 scalar AttachmentId
 
 """
-[Connection] with blacklisted `User`s.
+[Connection] with `BlocklistRecord`s.
 
 [Connection]: https://tinyurl.com/gql-relay#sec-Connection-Types
 """
-type BlacklistConnection {
+type BlocklistConnection {
   """
-  List of `User` [Edges] in this [Connection].
+  List of `BlocklistRecord` [Edges] in this [Connection].
 
   [Connection]: https://tinyurl.com/gql-relay#sec-Connection-Types
   [Edges]: https://tinyurl.com/gql-relay#sel-FAFFFBEAAAACBFpwI
   """
-  edges: [BlacklistEdge!]!
+  edges: [BlocklistEdge!]!
 
   """
-  List of `User`s in this [Connection].
+  List of `BlocklistRecord`s in this [Connection].
 
   [Connection]: https://tinyurl.com/gql-relay#sec-Connection-Types
   """
-  nodes: [User!]!
+  nodes: [BlocklistRecord!]!
 
   """
   [PageInfo] of this [Connection].
@@ -189,53 +189,93 @@ type BlacklistConnection {
   [PageInfo]: https://tinyurl.com/gql-relay#sec-undefined.PageInfo
   """
   pageInfo: PageInfo!
+
+  """Total count of `BlocklistRecord`s."""
+  totalCount: Int!
 }
 
-"""Cursor of blacklisted `User`s."""
-scalar BlacklistCursor
+"""Cursor of `BlocklistRecord`s."""
+scalar BlocklistCursor
 
 """
-[Edge] with a blacklisted `User`.
+[Edge] with a `BlocklistRecord`.
 
 [Edge]: https://tinyurl.com/gql-relay#sec-Edge-Types
 """
-type BlacklistEdge {
+type BlocklistEdge {
   """
   [Cursor] of this [Edge].
 
   [Cursor]: https://tinyurl.com/gql-relay#sec-Cursor
   [Edge]: https://tinyurl.com/gql-relay#sec-Edge-Types
   """
-  cursor: BlacklistCursor!
+  cursor: BlocklistCursor!
 
   """
-  `User` [Node] at the end of this [Edge].
+  `BlocklistRecord` [Node] at the end of this [Edge].
 
   [Edge]: https://tinyurl.com/gql-relay#sec-Edge-Types
   [Node]: https://tinyurl.com/gql-relay#sec-Node
   """
-  node: User!
+  node: BlocklistRecord!
 }
 
-"""Event of a `User` being added or removed to/from `MyUser.blacklist`."""
-interface BlacklistEvent {
-  """`DateTime` when this `BlacklistEvent` happened."""
+"""Event of a `User` being added or removed to/from `Query.blocklist`."""
+interface BlocklistEvent {
+  """`DateTime` when this `BlocklistEvent` happened."""
   at: DateTime!
 
-  """`User` this `BlacklistEvent` is about."""
+  """`User` this `BlocklistEvent` is about."""
   user: User!
-
-  """ID of the `User` this `BlacklistEvent` is about."""
-  userId: UserId!
 }
 
-"""`BlacklistEvent`s along with the corresponding `MyUserVersion`."""
-type BlacklistEventsVersioned {
-  """`BlacklistEvent`s themselves."""
-  events: [BlacklistEvent!]!
+"""`BlocklistEvent`s along with the corresponding `MyUserVersion`."""
+type BlocklistEventsVersioned {
+  """
+  Actual state of the `MyUser.blocklist` after this `BlocklistEvent`
+  has been emitted. Alias of `MyUser.blocklist`.
+
+  ## Sorting
+
+  Returned `User`s are sorted primarily by their blocking `DateTime`, and
+  secondary by their IDs (if the blocking `DateTime` is the same), in
+  descending order.
+
+  ## Pagination
+
+  It's allowed to specify both `first` and `last` counts at the same time,
+  provided that `after` and `before` cursors are equal. In such case the
+  returned page will include the `BlocklistRecord` pointed by the cursor
+  and the requested count of `BlocklistRecord`s preceding and following
+  it.
+
+  If it's desired to receive the `BlocklistRecord`, pointed by the cursor,
+  without querying in both directions, one can specify `first` or `last`
+  count as `0`.
+  """
+  blocklist(
+    """
+    Cursor indicating the `BlocklistEdge` position to return next `BlocklistRecord`s after.
+    """
+    after: BlocklistCursor
+
+    """
+    Cursor indicating the `BlocklistEdge` position to return prior `BlocklistRecord`s before.
+    """
+    before: BlocklistCursor
+
+    """Number of next `BlocklistRecord`s to return."""
+    first: Int
+
+    """Number of prior `BlocklistRecord`s to return."""
+    last: Int
+  ): BlocklistConnection!
+
+  """`BlocklistEvent`s themselves."""
+  events: [BlocklistEvent!]!
 
   """
-  Version of the `MyUser`'s state updated by these `BlacklistEvent`s.
+  Version of the `MyUser`'s state updated by these `BlocklistEvent`s.
 
   It increases monotonically, so may be used (and is intended to) for
   tracking state's actuality.
@@ -243,26 +283,29 @@ type BlacklistEventsVersioned {
   ver: MyUserVersion!
 }
 
-"""Reason of blacklisting a `User` by the authenticated `MyUser`."""
-scalar BlacklistReason
+"""Reason of blocking a `User` by the authenticated `MyUser`."""
+scalar BlocklistReason
 
-"""`User`'s record in the blacklist of the authenticated `MyUser`."""
-type BlacklistRecord {
-  """`DateTime` when the `User` was blacklisted."""
+"""`User`'s record in a `Query.blocklist` of the authenticated `MyUser`."""
+type BlocklistRecord {
+  """`DateTime` when the `User` was blocked."""
   at: DateTime!
 
-  """Reason of why the `User` was blacklisted."""
-  reason: BlacklistReason
+  """Reason of why the `User` was blocked."""
+  reason: BlocklistReason
+
+  """Blocked `User`."""
+  user: User!
 }
 
-"""Error of performing `Mutation.blacklistUser`."""
-type BlacklistUserError {
+"""Error of performing `Mutation.blockUser`."""
+type BlockUserError {
   """Code indicating why this error has happened."""
-  code: BlacklistUserErrorCode!
+  code: BlockUserErrorCode!
 }
 
-"""Possible error codes of performing `Mutation.blacklistUser`."""
-enum BlacklistUserErrorCode {
+"""Possible error codes of performing `Mutation.blockUser`."""
+enum BlockUserErrorCode {
   """
   `User` with the provided ID doesn't exist.
 
@@ -271,8 +314,8 @@ enum BlacklistUserErrorCode {
   UNKNOWN_USER
 }
 
-"""Result of performing `Mutation.blacklistUser`."""
-union BlacklistUserResult = BlacklistEventsVersioned | BlacklistUserError
+"""Result of performing `Mutation.blockUser`."""
+union BlockUserResult = BlockUserError | BlocklistEventsVersioned
 
 """`Chat` is a conversation between `User`s."""
 type Chat {
@@ -322,6 +365,11 @@ type Chat {
   """
   items(
     """
+    Indicator whether to filter out all the `ChatItem`s without attachments.
+    """
+    onlyAttachments: Boolean = false
+
+    """
     Cursor indicating the `ChatItemsEdge` position to return next `ChatItem`s after.
     """
     after: ChatItemsCursor
@@ -336,11 +384,6 @@ type Chat {
 
     """Number of prior `ChatItem`s to return."""
     last: Int
-
-    """
-    Indicator whether to filter out all the `ChatItem`s without attachments.
-    """
-    onlyAttachments: Boolean = false
   ): ChatItemsConnection!
 
   """Kind of this `Chat`."""
@@ -406,6 +449,12 @@ type Chat {
     Cursor indicating the `ChatMembersEdge` position to return prior `ChatMember`s before.
     """
     before: ChatMembersCursor
+
+    """
+    ID of the `ChatItem` that should be read by returned `ChatMember`s.
+    `null` means omitting filtering by this criteria.
+    """
+    readItem: ChatItemId
 
     """Number of next `ChatMember`s to return."""
     first: Int
@@ -476,31 +525,36 @@ type Chat {
 """Avatar of a `Chat`."""
 type ChatAvatar {
   """
-  `big` `ChatAvatar`'s view image `File`, square-cropped to its minimum
-  dimension (either width or height), and scaled to `70px`x`70px`.
+  `big` view `ImageFile` of this `ChatAvatar`, square-cropped to its
+  minimum dimension (either width or height), and scaled to
+  `250px`x`250px`.
   """
-  big: File!
+  big: ImageFile!
 
   """`CropArea` applied to the original image to create this `ChatAvatar`."""
   crop: CropArea
 
-  """Full `ChatAvatar`'s image `File`, keeping the `original` dimensions."""
-  full: File!
+  """
+  Full-sized `ImageFile` representing this `ChatAvatar`, keeping the
+  `original` dimensions.
+  """
+  full: ImageFile!
 
   """
-  `medium` `ChatAvatar`'s view image `File`, square-cropped to its minimum
-  dimension (either width or height), and scaled to `46px`x`46px`.
+  `medium` view `ImageFile` of this `ChatAvatar`, square-cropped to its
+  minimum dimension (either width or height), and scaled to
+  `100px`x`100px`.
   """
-  medium: File!
+  medium: ImageFile!
 
-  """Original image `File` representing this `ChatAvatar`."""
-  original: File!
+  """Original `ImageFile` representing this `ChatAvatar`."""
+  original: ImageFile!
 
   """
-  `small` `ChatAvatar`'s view image `File`, square-cropped to its minimum
-  dimension (either width or height), and scaled to `25px`x`25px`.
+  `small` view `ImageFile` of this `ChatAvatar`, square-cropped to its
+  minimum dimension (either width or height), and scaled to `46px`x`46px`.
   """
-  small: File!
+  small: ImageFile!
 }
 
 """Call in a `Chat`."""
@@ -508,16 +562,13 @@ type ChatCall implements ChatItem {
   """`DateTime` when this `ChatCall` was started."""
   at: DateTime!
 
-  """ID of the `User` who started this `ChatCall`."""
-  authorId: UserId!
-
   """
   `User` who started this `ChatCall`.
 
   Note, that this `User` may not be a member of this `ChatCall` at the
   moment.
   """
-  caller: User
+  author: User!
 
   """ID of the `Chat` where this `ChatCall` is organized."""
   chatId: ChatId!
@@ -946,6 +997,11 @@ type ChatContactsList {
   """
   chatContacts(
     """
+    Indicator whether favorite `ChatContact`s should be excluded from the result.
+    """
+    noFavorite: Boolean = false
+
+    """
     Cursor indicating the `ChatContactsEdge` position to return next `ChatContact`s after.
     """
     after: ChatContactsCursor
@@ -960,11 +1016,6 @@ type ChatContactsList {
 
     """Number of prior `ChatContact`s to return."""
     last: Int
-
-    """
-    Indicator whether favorite `ChatContact`s should be excluded from the result.
-    """
-    noFavorite: Boolean = false
   ): ChatContactsConnection!
 
   """
@@ -1061,8 +1112,8 @@ type ChatForward implements ChatItem {
   """`DateTime` when this `ChatForward` was posted."""
   at: DateTime!
 
-  """ID of the `User` who posted this `ChatForward`."""
-  authorId: UserId!
+  """`User` who posted this `ChatForward`."""
+  author: User!
 
   """ID of the `Chat` this `ChatForward` is posted in."""
   chatId: ChatId!
@@ -1100,9 +1151,6 @@ type ChatInfo implements ChatItem {
 
   """`User` who triggered this `ChatInfo`."""
   author: User!
-
-  """ID of the `User` who triggered this `ChatInfo`."""
-  authorId: UserId!
 
   """ID of the `Chat` this `ChatInfo` was posted in."""
   chatId: ChatId!
@@ -1201,8 +1249,8 @@ interface ChatItem {
   """`DateTime` when this `ChatItem` was posted."""
   at: DateTime!
 
-  """ID of the `User` who posted this `ChatItem`."""
-  authorId: UserId!
+  """`User` who posted this `ChatItem`."""
+  author: User!
 
   """ID of the `Chat` this `ChatItem` is posted in."""
   chatId: ChatId!
@@ -1444,8 +1492,8 @@ type ChatMessage implements ChatItem {
   """
   attachments: [Attachment!]!
 
-  """ID of the `User` who posted this `ChatMessage`."""
-  authorId: UserId!
+  """`User` who posted this `ChatMessage`."""
+  author: User!
 
   """ID of the `Chat` this `ChatMessage` is posted in."""
   chatId: ChatId!
@@ -1804,11 +1852,11 @@ type CreateDialogChatError {
 """Possible error codes of performing `Mutation.createDialogChat`."""
 enum CreateDialogChatErrorCode {
   """
-  Authenticated `MyUser` is blacklisted by the responder.
+  Authenticated `MyUser` is blocked by the responder.
 
   Status code: 403 Forbidden.
   """
-  BLACKLISTED
+  BLOCKED
 
   """
   Creating a `Chat`-dialog with the authenticated `MyUser` is not possible, consider creating a `Chat`-monolog instead.
@@ -1837,11 +1885,11 @@ type CreateGroupChatError {
 """Possible error codes of performing `Mutation.createGroupChat`."""
 enum CreateGroupChatErrorCode {
   """
-  Authenticated `MyUser` is blacklisted by one of the members.
+  Authenticated `MyUser` is blocked by one of the members.
 
   Status code: 403 Forbidden.
   """
-  BLACKLISTED
+  BLOCKED
 
   """
   `Chat` cannot be created with more than 100 initial members.
@@ -2179,31 +2227,31 @@ enum EditChatMessageTextErrorCode {
 """Result of performing `Mutation.editChatMessageText`."""
 union EditChatMessageTextResult = ChatEventsVersioned | EditChatMessageTextError
 
-"""Event of a blacklist record being added."""
-type EventBlacklistRecordAdded implements BlacklistEvent {
-  """`DateTime` when the `User` was blacklisted."""
+"""
+Event of a `BlocklistRecord` being added to `Query.blocklist` of the
+authenticated `MyUser`.
+"""
+type EventBlocklistRecordAdded implements BlocklistEvent {
+  """`DateTime` when the `User` was blocked."""
   at: DateTime!
 
-  """Reason of blacklisting the `User`."""
-  reason: BlacklistReason
+  """Reason of why the `User` was blocked."""
+  reason: BlocklistReason
 
-  """Blacklisted `User`."""
+  """Blocked `User`."""
   user: User!
-
-  """ID of the blacklisted `User`."""
-  userId: UserId!
 }
 
-"""Event of a blacklist record being removed."""
-type EventBlacklistRecordRemoved implements BlacklistEvent {
-  """`DateTime` when the `User` was removed from the blacklist."""
+"""
+Event of a `BlocklistRecord` being removed from `Query.blocklist` of the
+authenticated `MyUser`.
+"""
+type EventBlocklistRecordRemoved implements BlocklistEvent {
+  """`DateTime` when the `User` was unblocked."""
   at: DateTime!
 
-  """`User` removed from the blacklist."""
+  """Unblocked `User`."""
   user: User!
-
-  """ID of the `User` removed from the blacklist."""
-  userId: UserId!
 }
 
 """Event of an answer timeout being reached in a `ChatCall`."""
@@ -2238,6 +2286,27 @@ type EventChatCallAnswerTimeoutPassed implements ChatCallEvent & ChatEvent {
   `ChatMember`s.
   """
   userId: UserId
+}
+
+"""
+Event of an audio/video conversation being started in a `ChatCall`, meaning
+that enough `ChatCallMember`s joined the [Medea] room after ringing had been
+finished.
+
+[Medea]: https://github.com/instrumetisto/medea
+"""
+type EventChatCallConversationStarted implements ChatCallEvent & ChatEvent {
+  """`DateTime` when the conversation started."""
+  at: DateTime!
+
+  """`ChatCall` the conversation started in."""
+  call: ChatCall!
+
+  """ID of the `ChatCall` the conversation started in."""
+  callId: ChatItemId!
+
+  """ID of the `Chat` the conversation's `ChatCall` belongs to."""
+  chatId: ChatId!
 }
 
 """Event of a `ChatCall` being declined by a `ChatMember`."""
@@ -2396,6 +2465,35 @@ type EventChatCallMemberRedialed implements ChatCallEvent & ChatEvent {
 
   """
   `User` representing the `ChatMember` who was redialed in the `ChatCall`.
+  """
+  user: User!
+}
+
+"""Event of a dialed `User` being undialed in a `ChatCall`."""
+type EventChatCallMemberUndialed implements ChatCallEvent & ChatEvent {
+  """
+  `DateTime` when the dialed `ChatMember` was undialed in the `ChatCall`.
+  """
+  at: DateTime!
+
+  """
+  `User` representing the `ChatMember` who undialed the dialed `User` in
+  the `ChatCall`.
+  """
+  by: User!
+
+  """`ChatCall` the dialed `User` was undialed in."""
+  call: ChatCall!
+
+  """ID of the `ChatCall` the dialed `User` was undialed in."""
+  callId: ChatItemId!
+
+  """ID of the `Chat` the `ChatCall` belongs to."""
+  chatId: ChatId!
+
+  """
+  `User` representing the dialed `ChatMember` being undialed in the
+  `ChatCall`.
   """
   user: User!
 }
@@ -3465,7 +3563,7 @@ See [Firebase Cloud Messaging][0] documentation for how to generate
 scalar FcmRegistrationToken
 
 """File on a file storage."""
-type File {
+interface File {
   """
   [SHA-256] checksum of this `File`.
 
@@ -3514,14 +3612,14 @@ type File {
 
 """Plain file `Attachment`."""
 type FileAttachment implements Attachment {
-  """Uploaded `File`'s name."""
+  """Uploaded `PlainFile`'s name."""
   filename: String!
 
   """Unique ID of this `FileAttachment`."""
   id: AttachmentId!
 
-  """Original `File` representing this `FileAttachment`."""
-  original: File!
+  """Original `PlainFile` representing this `FileAttachment`."""
+  original: PlainFile!
 }
 
 """Error of performing `Mutation.forwardChatItems`."""
@@ -3533,13 +3631,13 @@ type ForwardChatItemsError {
 """Possible error codes of performing `Mutation.forwardChatItems`."""
 enum ForwardChatItemsErrorCode {
   """
-  Authenticated `MyUser` is blacklisted by the `User`, who receives the `ChatForward`.
+  Authenticated `MyUser` is blocked by the `User`, who receives the `ChatForward`.
 
   This error can happen only if `Chat` represents a dialog (consists only of two `User`s).
 
   Status code: 403 Forbidden.
   """
-  BLACKLISTED
+  BLOCKED
 
   """
   Either `withText` field or at least one ID in `attachments` field should be specified in all of the `ChatItemQuoteInput`s.
@@ -3594,16 +3692,22 @@ enum ForwardChatItemsErrorCode {
 """Result of performing `Mutation.forwardChatItems`."""
 union ForwardChatItemsResult = ChatEventsVersioned | ForwardChatItemsError
 
-"""Item in a `User`'s or `Chat`'s gallery."""
-interface GalleryItem {
+"""Item in a `User`'s gallery."""
+type GalleryItem {
   """`DateTime` when this `GalleryItem` was added."""
   addedAt: DateTime!
 
   """Unique ID of this `GalleryItem`."""
   id: GalleryItemId!
 
-  """Original `File` representing this `GalleryItem`."""
-  original: File!
+  """Original `ImageFile` representing this `GalleryItem`."""
+  original: ImageFile!
+
+  """
+  `square` view `ImageFile` of this `GalleryItem`, square-cropped to its
+  minimum dimension (either width or height), and scaled to `85px`x`85px`.
+  """
+  square: ImageFile!
 }
 
 """Type of a `GalleryItem`'s ID."""
@@ -3650,49 +3754,87 @@ union HideChatResult = ChatEventsVersioned | HideChatError
 """Image `Attachment`."""
 type ImageAttachment implements Attachment {
   """
-  `big` `ImageAttachment`'s view image `File`, scaled proportionally to
-  `400px` of its maximum dimension (either width or height).
+  `big` view `ImageFile` of this `ImageAttachment`, scaled proportionally
+  to `800px` of its maximum dimension (either width or height).
   """
-  big: File!
+  big: ImageFile!
 
-  """Uploaded `File`'s name."""
+  """Uploaded `ImageFile`'s name."""
   filename: String!
 
   """Unique ID of this `ImageAttachment`."""
   id: AttachmentId!
 
   """
-  `medium` `ImageAttachment`'s view image `File`, scaled proportionally to
-  `200px` of its maximum dimension (either width or height).
+  `medium` view `ImageFile` of this `ImageAttachment`, scaled
+  proportionally to `200px` of its maximum dimension (either width or
+  height).
   """
-  medium: File!
+  medium: ImageFile!
 
-  """Original `File` representing this `ImageAttachment`."""
-  original: File!
+  """Original `ImageFile` representing this `ImageAttachment`."""
+  original: ImageFile!
 
   """
-  `small` `ImageAttachment`'s view image `File`, scaled proportionally to
-  `30px` of its maximum dimension (either width or height).
+  `small` view `ImageFile` of this `ImageAttachment`, scaled
+  proportionally to `30px` of its maximum dimension (either width or
+  height).
   """
-  small: File!
+  small: ImageFile!
 }
 
-"""Image `GalleryItem`."""
-type ImageGalleryItem implements GalleryItem {
-  """`DateTime` when this `ImageGalleryItem` was added."""
-  addedAt: DateTime!
+"""Image-`File` on a file storage."""
+type ImageFile implements File {
+  """
+  [SHA-256] checksum of this `ImageFile`.
 
-  """Unique ID of this `ImageGalleryItem`."""
-  id: GalleryItemId!
+  May be `null` in case this `ImageFile` is not ready on a file storage
+  yet. May be also computed on a client side, once this `ImageFile`
+  is ready and successfully downloaded from a file storage.
 
-  """Original `File` representing this `ImageGalleryItem`."""
-  original: File!
+  This checksum is especially useful if a client side requires to verify
+  the integrity and authenticity of this `ImageFile`, downloaded from
+  a file storage.
+
+  Also, this checksum may be useful as a key in a client side cache,
+  allowing to store `ImageFile`s in deduplicated manner.
+
+  [SHA-256]: https://en.wikipedia.org/wiki/SHA-2
+  """
+  checksum: String
+
+  """Height of this `ImageFile` in pixels."""
+  height: Int
 
   """
-  `square` `ImageGalleryItem`'s view `File`, square-cropped to its minimum
-  dimension (either width or height), and scaled to `85px`x`85px`.
+  [Relative reference][1] to this `ImageFile` on a file storage.
+
+  Prepend it with a file storage URL to obtain the full link to this
+  `ImageFile`.
+
+  If `404` HTTP status code is returned while trying to download this
+  `ImageFile` from a file storage, then the `ImageFile` is not ready yet.
+  Back off, and retry again later.
+
+  `403` HTTP status code, on the other hand, means that the link has been
+  expired and this [relative reference][1] should be re-fetched to rebuild
+  the link.
+
+  [1]: https://www.rfc-editor.org/rfc/rfc3986#section-4.2
   """
-  square: File!
+  relativeRef: String!
+
+  """
+  Size of this `ImageFile` (in bytes).
+
+  May be `null` in case this `ImageFile` is not ready on a file storage
+  yet. May be also computed on a client side, once this `ImageFile`
+  is ready and successfully downloaded from a file storage.
+  """
+  size: Int
+
+  """Width of this `ImageFile` in pixels."""
+  width: Int
 }
 
 """
@@ -3772,16 +3914,16 @@ type IncomingChatCallsTop {
 union IncomingChatCallsTopEvents = EventIncomingChatCallsTopChatCallAdded | EventIncomingChatCallsTopChatCallRemoved | IncomingChatCallsTop | SubscriptionInitialized
 
 """
-Information about some `User` being present in `MyUser.blacklist` of the
+Information about some `User` being present in a `Query.blocklist` of the
 authenticated `MyUser`.
 """
-type IsBlacklisted {
+type IsBlocked {
   """
-  `BlacklistRecord` of the `User` in `Query.blacklist`.
+  `BlocklistRecord` of the `User` in the `Query.blocklist`.
 
-  `null` if the `User` is not blacklisted by the authenticated `MyUser`.
+  `null` if the `User` is not blocked by the authenticated `MyUser`.
   """
-  record: BlacklistRecord
+  record: BlocklistRecord
 
   """Version of the authenticated `MyUser`'s state."""
   ver: MyUserVersion!
@@ -3970,12 +4112,12 @@ type Mutation {
   ): AddUserPhoneResult
 
   """
-  Blacklists the specified `User` for the authenticated `MyUser`.
+  Blocks the specified `User` for the authenticated `MyUser`.
 
-  Blacklisted `User`s are not able to communicate with the authenticated
-  `MyUser` directly (in `Chat`-dialogs).
+  Blocked `User`s are not able to communicate with the authenticated
+  `MyUser` directly (in `Chat`-dialogs) and add him to `Chat`-groups.
 
-  `MyUser`'s blacklist can be obtained via `Query.blacklist`.
+  `MyUser`'s blocklist can be obtained via `Query.blocklist`.
 
   ## Authentication
 
@@ -3983,22 +4125,22 @@ type Mutation {
 
   ## Result
 
-  Only the following `BlacklistEvent` may be produced on success:
-  - `EventBlacklistRecordAdded`.
+  Only the following `BlocklistEvent` may be produced on success:
+  - `EventBlocklistRecordAdded`.
 
   ## Idempotent
 
-  Succeeds as no-op (and returns no `BlacklistEvent`) if the specified
-  `User` is blacklisted by the authenticated `MyUser` already with the
-  same `BlacklistReason`.
+  Succeeds as no-op (and returns no `BlocklistEvent`) if the specified
+  `User` is blocked by the authenticated `MyUser` already with the same
+  `BlocklistReason`.
   """
-  blacklistUser(
-    """ID of the `User` to blacklist."""
+  blockUser(
+    """ID of the `User` to block."""
     id: UserId!
 
-    """Reason to blacklist the `User`."""
-    reason: BlacklistReason
-  ): BlacklistUserResult
+    """Reason to block the `User`."""
+    reason: BlocklistReason
+  ): BlockUserResult
 
   """
   Clears an existing `Chat` (hides all its `ChatItem`s) for the
@@ -4019,11 +4161,11 @@ type Mutation {
   is already cleared until the specified `ChatItem`.
   """
   clearChat(
-    """ID of the `Chat` to be cleared."""
-    id: ChatId!
-
     """ID of the `ChatItem` to clear the `Chat` until (inclusively)."""
     untilId: ChatItemId!
+
+    """ID of the `Chat` to be cleared."""
+    id: ChatId!
   ): ClearChatResult
 
   """
@@ -4100,13 +4242,13 @@ type Mutation {
   Each time creates a new unique `ChatContact`.
   """
   createChatContact(
-    """Name to create the `ChatContact` with."""
-    name: UserName!
-
     """
     Optional `ChatContactRecord`s to create and attach to the created `ChatContact`.
     """
     records: [ChatContactRecord!] = []
+
+    """Name to create the `ChatContact` with."""
+    name: UserName!
   ): CreateChatContactResult!
 
   """
@@ -4282,6 +4424,9 @@ type Mutation {
   Each time creates a new `Session`.
   """
   createSession(
+    """Generate `RememberedSession` along with `Session` or not."""
+    remember: Boolean = false
+
     """Email address of `MyUser` to create `Session` for."""
     email: UserEmail
 
@@ -4296,9 +4441,6 @@ type Mutation {
 
     """Phone number of `MyUser` to create `Session` for."""
     phone: UserPhone
-
-    """Generate `RememberedSession` along with `Session` or not."""
-    remember: Boolean = false
   ): CreateSessionResult!
 
   """
@@ -4738,24 +4880,24 @@ type Mutation {
   Each time posts a new `ChatForward`.
   """
   forwardChatItems(
+    """ID of the `Chat` to forward `ChatItem`s from."""
+    from: ChatId!
+
+    """ID of the `Chat` to forward `ChatItem`s into."""
+    to: ChatId!
+
     """
     Optional IDs of `Attachment`s to be attached to the `ChatMessage` posted along with the forwarded `ChatItem`s.
     """
     attachments: [AttachmentId!]
-
-    """ID of the `Chat` to forward `ChatItem`s from."""
-    from: ChatId!
-
-    """Quotes of the `ChatItem`s to be forwarded."""
-    items: [ChatItemQuoteInput!]!
 
     """
     Optional text to post a `ChatMessage` along with the forwarded `ChatItem`s.
     """
     text: ChatMessageText
 
-    """ID of the `Chat` to forward `ChatItem`s into."""
-    to: ChatId!
+    """Quotes of the `ChatItem`s to be forwarded."""
+    items: [ChatItemQuoteInput!]!
   ): ForwardChatItemsResult!
 
   """
@@ -4954,12 +5096,6 @@ type Mutation {
   `ChatEvent`.
   """
   postChatMessage(
-    """
-    Optional IDs of `Attachment`s to be attached to the posted `ChatMessage`. If
-    not specified or empty then `text` argument must be specified.
-    """
-    attachments: [AttachmentId!]
-
     """ID of the `Chat` to post a new `ChatMessage` in."""
     chatId: ChatId!
 
@@ -4968,6 +5104,12 @@ type Mutation {
     replied `ChatItem`s may belong to the current `Chat` only.
     """
     repliesTo: [ChatItemId!]!
+
+    """
+    Optional IDs of `Attachment`s to be attached to the posted `ChatMessage`. If
+    not specified or empty then `text` argument must be specified.
+    """
+    attachments: [AttachmentId!]
 
     """
     Optional text of the posted `ChatMessage`. If not specified then `attachments` argument must be specified and non-empty.
@@ -5007,11 +5149,11 @@ type Mutation {
   `ChatItem`.
   """
   readChat(
-    """ID of the `Chat` to be read."""
-    id: ChatId!
-
     """ID of the `ChatItem` to read the `Chat` until (inclusively)."""
     untilId: ChatItemId!
+
+    """ID of the `Chat` to be read."""
+    id: ChatId!
   ): ReadChatResult
 
   """
@@ -5034,7 +5176,7 @@ type Mutation {
 
   ## Result
 
-  Always returns `null` on success.
+  Always returns `true` on success.
 
   ## Non-idempotent
 
@@ -5052,7 +5194,7 @@ type Mutation {
 
     """Phone number of `MyUser`."""
     phone: UserPhone
-  ): RecoverUserPasswordErrorCode
+  ): Boolean!
 
   """
   Redials a `User` who left or declined the ongoing `ChatCall` in the
@@ -5146,7 +5288,9 @@ type Mutation {
 
   The following `ChatEvent`s may be produced on success:
   - `EventChatCallMemberLeft` (for each device of the `User`);
-  - `EventChatCallFinished`.
+  - `EventChatCallFinished`;
+  - `EventChatCallMemberUndialed` (for dialed `User`);
+  - `EventChatCallDeclined` (for dialed `MyUser`).
 
   ## Idempotent
 
@@ -5222,13 +5366,13 @@ type Mutation {
 
   """
   Renews a `Session` of the `MyUser` identified by the provided
-  `RememberToken`.
+  `RefreshToken`.
 
-  Invalidates the provided `RememberToken` and returns a new one, which
+  Invalidates the provided `RefreshToken` and returns a new one, which
   should be used instead.
 
   The renewed `Session` has its own expiration after renewal, so to renew
-  it again use this mutation with the new returned `RememberToken` (omit
+  it again use this mutation with the new returned `RefreshToken` (omit
   using old ones).
 
   The expiration of the renewed `RememberedSession` is not prolonged
@@ -5242,13 +5386,13 @@ type Mutation {
 
   ## Non-idempotent
 
-  Each time creates a new `Session` and generates a new `RememberToken`.
+  Each time creates a new `Session` and generates a new `RefreshToken`.
   """
   renewSession(
     """
-    `RememberToken` for mutation authentication and `MyUser` identification.
+    `RefreshToken` for mutation authentication and `MyUser` identification.
     """
-    token: RememberToken!
+    token: RefreshToken!
   ): RenewSessionResult!
 
   """
@@ -5327,25 +5471,25 @@ type Mutation {
   already.
   """
   resetUserPassword(
-    """
-    Recovery `ConfirmationCode` for `MyUser` identification and mutation authentication.
-    """
-    code: ConfirmationCode!
-
     """Email address of `MyUser`."""
     email: UserEmail
 
     """Login of `MyUser`."""
     login: UserLogin
 
-    """Password to update `MyUser` with."""
-    newPassword: UserPassword!
-
     """Number of `MyUser`."""
     num: UserNum
 
+    """Password to update `MyUser` with."""
+    newPassword: UserPassword!
+
     """Phone number of `MyUser`."""
     phone: UserPhone
+
+    """
+    Recovery `ConfirmationCode` for `MyUser` identification and mutation authentication.
+    """
+    code: ConfirmationCode!
   ): ResetUserPasswordResult!
 
   """
@@ -5398,6 +5542,9 @@ type Mutation {
   Joins it if the authenticated `MyUser` is not a member yet.
   """
   startChatCall(
+    """Indicates whether the `ChatCall` is intended to start with video."""
+    withVideo: Boolean = false
+
     """ID of the `Chat` to start a `ChatCall` in."""
     chatId: ChatId!
 
@@ -5413,9 +5560,6 @@ type Mutation {
     device. Generate new credentials in any other case.
     """
     creds: ChatCallCredentials!
-
-    """Indicates whether the `ChatCall` is intended to start with video."""
-    withVideo: Boolean = false
   ): StartChatCallResult!
 
   """
@@ -5573,23 +5717,23 @@ type Mutation {
   [Medea]: https://github.com/instrumetisto/medea
   """
   transformDialogCallIntoGroupCall(
+    """ID of the `Chat`-dialog to move the ongoing `ChatCall` from."""
+    chatId: ChatId!
+
     """
     IDs of `User`s to create the new `Chat`-group with (in addition to the existing `Chat`-dialog members).
     """
     additionalMemberIds: [UserId!]!
-
-    """ID of the `Chat`-dialog to move the ongoing `ChatCall` from."""
-    chatId: ChatId!
 
     """Optional name to assign to the new `Chat`-group."""
     groupName: ChatName
   ): TransformDialogCallIntoGroupCallResult
 
   """
-  Removes the specified `User` from the blacklist of the authenticated
+  Removes the specified `User` from the blocklist of the authenticated
   `MyUser`.
 
-  Reverses the action of `Mutation.blacklistUser`.
+  Reverses the action of `Mutation.blockUser`.
 
   ## Authentication
 
@@ -5597,18 +5741,18 @@ type Mutation {
 
   ## Result
 
-  Only the following `BlacklistEvent` may be produced on success:
-  - `EventBlacklistRecordRemoved`.
+  Only the following `BlocklistEvent` may be produced on success:
+  - `EventBlocklistRecordRemoved`.
 
   ## Idempotent
 
-  Succeeds as no-op (and returns no `BlacklistEvent`) if the specified
-  `User` is not blacklisted by the authenticated `MyUser` already.
+  Succeeds as no-op (and returns no `BlocklistEvent`) if the specified
+  `User` is not blocked by the authenticated `MyUser` already.
   """
-  unblacklistUser(
-    """ID of the `User` to remove from the blacklist."""
+  unblockUser(
+    """ID of the `User` to remove from the blocklist."""
     id: UserId!
-  ): UnblacklistUserResult
+  ): UnblockUserResult
 
   """
   Removes the specified `Chat` from the favorites list of the
@@ -5703,16 +5847,6 @@ type Mutation {
   area.
   """
   updateChatAvatar(
-    """ID of the `Chat` to update `avatar` of."""
-    chatId: ChatId!
-
-    """
-    Optional area to crop the provided `file`.
-
-    Only makes sense if the `file` argument is specified.
-    """
-    crop: CropAreaInput
-
     """
     File to use as a `ChatAvatar`.
 
@@ -5728,6 +5862,16 @@ type Mutation {
     [1]: https://github.com/jaydenseric/graphql-multipart-request-spec
     """
     file: Upload
+
+    """ID of the `Chat` to update `avatar` of."""
+    chatId: ChatId!
+
+    """
+    Optional area to crop the provided `file`.
+
+    Only makes sense if the `file` argument is specified.
+    """
+    crop: CropAreaInput
   ): UpdateChatAvatarResult
 
   """
@@ -5778,18 +5922,18 @@ type Mutation {
   """
   updateUserAvatar(
     """
-    Optional area to crop the provided `GalleryItem`.
-
-    Only makes sense if `id` argument is specified.
-    """
-    crop: CropAreaInput
-
-    """
     ID of the `GalleryItem` to be set as `avatar`.
 
     If absent or is `null` then the `MyUser.avatar` field will be reset.
     """
     id: GalleryItemId
+
+    """
+    Optional area to crop the provided `GalleryItem`.
+
+    Only makes sense if `id` argument is specified.
+    """
+    crop: CropAreaInput
   ): UpdateUserAvatarResult
 
   """
@@ -5841,18 +5985,18 @@ type Mutation {
   """
   updateUserCallCover(
     """
-    Optional area to crop the provided `GalleryItem`.
-
-    Only makes sense if `id` argument is specified.
-    """
-    crop: CropAreaInput
-
-    """
     ID of the `GalleryItem` to be set as `callCover`.
 
     If absent or is `null` then the `MyUser.callCover` field will be reset.
     """
     id: GalleryItemId
+
+    """
+    Optional area to crop the provided `GalleryItem`.
+
+    Only makes sense if `id` argument is specified.
+    """
+    crop: CropAreaInput
   ): UpdateUserCallCoverResult
 
   """
@@ -5926,11 +6070,11 @@ type Mutation {
   one.
   """
   updateUserPassword(
-    """Password to update `MyUser` with."""
-    new: UserPassword!
-
     """Current password of `MyUser` for mutation authentication (if exists)."""
     old: UserPassword
+
+    """Password to update `MyUser` with."""
+    new: UserPassword!
   ): UpdateUserPasswordResult!
 
   """
@@ -6109,9 +6253,6 @@ type Mutation {
   `ConfirmationCode` can be validated unlimited number of times (for now).
   """
   validateUserPasswordRecoveryCode(
-    """Recovery `ConfirmationCode` to validate."""
-    code: ConfirmationCode!
-
     """Email address of `MyUser`."""
     email: UserEmail
 
@@ -6123,6 +6264,9 @@ type Mutation {
 
     """Phone number of `MyUser`."""
     phone: UserPhone
+
+    """Recovery `ConfirmationCode` to validate."""
+    code: ConfirmationCode!
   ): ValidateUserPasswordRecoveryErrorCode
 }
 
@@ -6176,6 +6320,45 @@ type MyUser {
 
   """Arbitrary descriptive information about this `MyUser`."""
   bio: UserBio
+
+  """
+  Returns `User`s blocked by this `MyUser` as `BlocklistRecord`s.
+
+  ## Sorting
+
+  Returned `User`s are sorted primarily by their blocking `DateTime`, and
+  secondary by their IDs (if the blocking `DateTime` is the same), in
+  descending order.
+
+  ## Pagination
+
+  It's allowed to specify both `first` and `last` counts at the same time,
+  provided that `after` and `before` cursors are equal. In such case the
+  returned page will include the `BlocklistRecord` pointed by the cursor
+  and the requested count of `BlocklistRecord`s preceding and following
+  it.
+
+  If it's desired to receive the `BlocklistRecord`, pointed by the cursor,
+  without querying in both directions, one can specify `first` or `last`
+  count as `0`.
+  """
+  blocklist(
+    """
+    Cursor indicating the `BlocklistEdge` position to return next `BlocklistRecord`s after.
+    """
+    after: BlocklistCursor
+
+    """
+    Cursor indicating the `BlocklistEdge` position to return prior `BlocklistRecord`s before.
+    """
+    before: BlocklistCursor
+
+    """Number of next `BlocklistRecord`s to return."""
+    first: Int
+
+    """Number of prior `BlocklistRecord`s to return."""
+    last: Int
+  ): BlocklistConnection!
 
   """
   Call cover of this `MyUser`.
@@ -6321,7 +6504,7 @@ type MyUser {
 }
 
 """Events happening with `MyUser`."""
-union MyUserEvent = EventBlacklistRecordAdded | EventBlacklistRecordRemoved | EventUserAvatarDeleted | EventUserAvatarUpdated | EventUserBioDeleted | EventUserBioUpdated | EventUserCallCoverDeleted | EventUserCallCoverUpdated | EventUserCameOffline | EventUserCameOnline | EventUserDeleted | EventUserDirectLinkDeleted | EventUserDirectLinkUpdated | EventUserEmailAdded | EventUserEmailConfirmed | EventUserEmailDeleted | EventUserGalleryItemAdded | EventUserGalleryItemDeleted | EventUserLoginUpdated | EventUserMuted | EventUserNameDeleted | EventUserNameUpdated | EventUserPasswordUpdated | EventUserPhoneAdded | EventUserPhoneConfirmed | EventUserPhoneDeleted | EventUserPresenceUpdated | EventUserStatusDeleted | EventUserStatusUpdated | EventUserUnmuted | EventUserUnreadChatsCountUpdated
+union MyUserEvent = EventBlocklistRecordAdded | EventBlocklistRecordRemoved | EventUserAvatarDeleted | EventUserAvatarUpdated | EventUserBioDeleted | EventUserBioUpdated | EventUserCallCoverDeleted | EventUserCallCoverUpdated | EventUserCameOffline | EventUserCameOnline | EventUserDeleted | EventUserDirectLinkDeleted | EventUserDirectLinkUpdated | EventUserEmailAdded | EventUserEmailConfirmed | EventUserEmailDeleted | EventUserGalleryItemAdded | EventUserGalleryItemDeleted | EventUserLoginUpdated | EventUserMuted | EventUserNameDeleted | EventUserNameUpdated | EventUserPasswordUpdated | EventUserPhoneAdded | EventUserPhoneConfirmed | EventUserPhoneDeleted | EventUserPresenceUpdated | EventUserStatusDeleted | EventUserStatusUpdated | EventUserUnmuted | EventUserUnreadChatsCountUpdated
 
 """Events emitted by `Subscription.myUserEvents`."""
 union MyUserEvents = MyUser | MyUserEventsVersioned | SubscriptionInitialized
@@ -6419,6 +6602,54 @@ type PageInfo {
   startCursor: String
 }
 
+"""Plain-`File` on a file storage."""
+type PlainFile implements File {
+  """
+  [SHA-256] checksum of this `PlainFile`.
+
+  May be `null` in case this `PlainFile` is not ready on a file storage
+  yet. May be also computed on a client side, once this `PlainFile`
+  is ready and successfully downloaded from a file storage.
+
+  This checksum is especially useful if a client side requires to verify
+  the integrity and authenticity of this `PlainFile`, downloaded from
+  a file storage.
+
+  Also, this checksum may be useful as a key in a client side cache,
+  allowing to store `PlainFile`s in deduplicated manner.
+
+  [SHA-256]: https://en.wikipedia.org/wiki/SHA-2
+  """
+  checksum: String
+
+  """
+  [Relative reference][1] to this `PlainFile` on a file storage.
+
+  Prepend it with a file storage URL to obtain the full link to this
+  `PlainFile`.
+
+  If `404` HTTP status code is returned while trying to download this
+  `PlainFile` from a file storage, then the `PlainFile` is not ready yet.
+  Back off, and retry again later.
+
+  `403` HTTP status code, on the other hand, means that the link has been
+  expired and this [relative reference][1] should be re-fetched to rebuild
+  the link.
+
+  [1]: https://www.rfc-editor.org/rfc/rfc3986#section-4.2
+  """
+  relativeRef: String!
+
+  """
+  Size of this `PlainFile` (in bytes).
+
+  May be `null` in case this `PlainFile` is not ready on a file storage
+  yet. May be also computed on a client side, once this `PlainFile`
+  is ready and successfully downloaded from a file storage.
+  """
+  size: Int
+}
+
 """2D point on an image."""
 type Point {
   """X coordinate of this `Point` in `px` (pixels)."""
@@ -6450,13 +6681,13 @@ type PostChatMessageError {
 """Possible error codes of performing `Mutation.postChatMessage`."""
 enum PostChatMessageErrorCode {
   """
-  Authenticated `MyUser` is blacklisted by the `User` who receives the `ChatMessage`.
+  Authenticated `MyUser` is blocked by the `User` who receives the `ChatMessage`.
 
   This error can happen only if `Chat` represents a dialog (consists only of two `User`s).
 
   Status code: 403 Forbidden.
   """
-  BLACKLISTED
+  BLOCKED
 
   """
   Either `text` argument or at least one ID in `attachments` should be specified.
@@ -6516,7 +6747,8 @@ enum Presence {
 
 type Query {
   """
-  Returns `User`s blacklisted by the authenticated `MyUser`.
+  Returns `User`s blocked by the authenticated `MyUser` as
+  `BlocklistRecord`s.
 
   ## Authentication
 
@@ -6524,38 +6756,39 @@ type Query {
 
   ## Sorting
 
-  Returned `User`s are sorted primarily by their blacklisting `DateTime`,
-  and secondary by their IDs (if the blacklisting `DateTime` is the same),
-  in descending order.
+  Returned `User`s are sorted primarily by their blocking `DateTime`, and
+  secondary by their IDs (if the blocking `DateTime` is the same), in
+  descending order.
 
   ## Pagination
 
   It's allowed to specify both `first` and `last` counts at the same time,
   provided that `after` and `before` cursors are equal. In such case the
-  returned page will include the `User` pointed by the cursor and the
-  requested count of `User`s preceding and following it.
+  returned page will include the `BlocklistRecord` pointed by the cursor
+  and the requested count of `BlocklistRecord`s preceding and following
+  it.
 
-  If it's desired to receive the `User`, pointed by the cursor, without
-  querying in both directions, one can specify `first` or `last` count as
-  `0`.
+  If it's desired to receive the `BlocklistRecord`, pointed by the cursor,
+  without querying in both directions, one can specify `first` or `last`
+  count as `0`.
   """
-  blacklist(
+  blocklist(
     """
-    Cursor indicating the `UsersEdge` position to return next `User`s after.
+    Cursor indicating the `BlocklistEdge` position to return next `BlocklistRecord`s after.
     """
-    after: BlacklistCursor
+    after: BlocklistCursor
 
     """
-    Cursor indicating the `UsersEdge` position to return prior `User`s before.
+    Cursor indicating the `BlocklistEdge` position to return prior `BlocklistRecord`s before.
     """
-    before: BlacklistCursor
+    before: BlocklistCursor
 
-    """Number of next `User`s to return."""
+    """Number of next `BlocklistRecord`s to return."""
     first: Int
 
-    """Number of prior `User`s to return."""
+    """Number of prior `BlocklistRecord`s to return."""
     last: Int
-  ): BlacklistConnection!
+  ): BlocklistConnection!
 
   """
   Returns a `Chat` by its ID.
@@ -6602,6 +6835,11 @@ type Query {
   """
   chatContacts(
     """
+    Indicator whether favorite `ChatContact`s should be excluded from the result.
+    """
+    noFavorite: Boolean = false
+
+    """
     Cursor indicating the `ChatContactsEdge` position to return next `ChatContact`s after.
     """
     after: ChatContactsCursor
@@ -6616,11 +6854,6 @@ type Query {
 
     """Number of prior `ChatContact`s to return."""
     last: Int
-
-    """
-    Indicator whether favorite `ChatContact`s should be excluded from the result.
-    """
-    noFavorite: Boolean = false
   ): ChatContactsConnection!
 
   """
@@ -6637,31 +6870,6 @@ type Query {
     """ID of the `ChatItem` to be returned."""
     id: ChatItemId!
   ): ChatItemsEdge
-
-  """
-  Indicates whether some `User` can be identified by the given `num`,
-  `login`, `email` or `phone`.
-
-  Exactly one of `num`/`login`/`email`/`phone` arguments must be specified
-  (be non-`null`).
-
-  ## Authentication
-
-  None.
-  """
-  checkUserIdentifiable(
-    """`UserEmail` address of the `User` for identification."""
-    email: UserEmail
-
-    """`UserLogin` of the `User` for identification."""
-    login: UserLogin
-
-    """`UserNum` of the `User` for identification."""
-    num: UserNum
-
-    """`UserPhone` number of the `User` for identification."""
-    phone: UserPhone
-  ): Boolean!
 
   """
   Indicates whether the specified `UserLogin` is occupied by some `User`,
@@ -6961,6 +7169,16 @@ type Query {
   `0`.
   """
   recentChats(
+    """Indicator whether favorite `Chat`s should be excluded from the result."""
+    noFavorite: Boolean = false
+
+    """
+    Indicator whether only `Chat`s with ongoing calls should be included into
+    the result (`true`), or whether they should be excluded from the result (`false`).
+    `null` means omitting filtering by this criteria.
+    """
+    withOngoingCalls: Boolean = null
+
     """
     Cursor indicating the `RecentChatsEdge` position to return next `Chat`s after.
     """
@@ -6976,16 +7194,6 @@ type Query {
 
     """Number of prior `Chat`s to return."""
     last: Int
-
-    """Indicator whether favorite `Chat`s should be excluded from the result."""
-    noFavorite: Boolean = false
-
-    """
-    Indicator whether only `Chat`s with ongoing calls should be included into
-    the result (`true`), or whether they should be excluded from the result (`false`).
-    `null` means omitting filtering by this criteria.
-    """
-    withOngoingCalls: Boolean = null
   ): RecentChatsConnection!
 
   """
@@ -7037,9 +7245,6 @@ type Query {
     """
     before: ChatContactsCursor
 
-    """`UserEmail` to search `ChatContact`s with."""
-    email: UserEmail
-
     """Number of next `ChatContactsEdge`s to return."""
     first: Int
 
@@ -7048,6 +7253,9 @@ type Query {
 
     """Part of `UserName` to search `ChatContact`s with."""
     name: UserName
+
+    """`UserEmail` to search `ChatContact`s with."""
+    email: UserEmail
 
     """`UserPhone` to search `ChatContact`s with."""
     phone: UserPhone
@@ -7105,9 +7313,6 @@ type Query {
     """
     before: UsersCursor
 
-    """`ChatDirectLinkSlug` to search owner of."""
-    directLink: ChatDirectLinkSlug
-
     """
     Number of next `UsersEdge`s to return.
 
@@ -7122,11 +7327,14 @@ type Query {
     """
     last: Int
 
-    """`UserLogin` to search `User`s with."""
-    login: UserLogin
-
     """Part of `UserName` to fuzzy search `User` with."""
     name: UserName
+
+    """`ChatDirectLinkSlug` to search owner of."""
+    directLink: ChatDirectLinkSlug
+
+    """`UserLogin` to search `User`s with."""
+    login: UserLogin
 
     """`UserNum` to search `User`s with."""
     num: UserNum
@@ -7259,16 +7467,6 @@ type RecentChatsTop {
 """Events emitted by `Subscription.recentChatsTopEvents`."""
 union RecentChatsTopEvents = EventRecentChatsTopChatDeleted | EventRecentChatsTopChatUpdated | RecentChatsTop | SubscriptionInitialized
 
-"""Possible error codes of performing `Mutation.recoverUserPassword`."""
-enum RecoverUserPasswordErrorCode {
-  """
-  Exceeded limit of sending recovery `ConfirmationCode`s. Try again in 1 hour.
-
-  Status code: 403 Forbidden.
-  """
-  CODE_LIMIT_EXCEEDED
-}
-
 """Error of performing `Mutation.redialChatCallMember`."""
 type RedialChatCallMemberError {
   """Code indicating why this error has happened."""
@@ -7316,6 +7514,16 @@ enum RedialChatCallMemberErrorCode {
 """Result of performing `Mutation.redialChatCallMember`."""
 union RedialChatCallMemberResult = ChatCallEventsVersioned | RedialChatCallMemberError
 
+"""
+Type of a `RememberedSession`'s refresh token.
+
+Its values are always considered to be non-empty and represent a
+[valid Base64 string][1].
+
+[1]: https://base64.guru/learn/base64-characters
+"""
+scalar RefreshToken
+
 """Possible error codes of performing `Mutation.registerFcmDevice`."""
 enum RegisterFcmDeviceErrorCode {
   """
@@ -7349,7 +7557,7 @@ type RememberedSession {
   expireAt: DateTime!
 
   """
-  Unique remember token of this `RememberedSession`.
+  Unique `RefreshToken` of this `RememberedSession`.
 
   This one should be used for a `Session` renewal via
   `Mutation.renewSession` and is **NOT** usable as a
@@ -7357,7 +7565,7 @@ type RememberedSession {
 
   [1]: https://tools.ietf.org/html/rfc6750#section-2.1
   """
-  token: RememberToken!
+  token: RefreshToken!
 
   """
   Version of this `RememberedSession`'s state.
@@ -7374,16 +7582,6 @@ Version of `RememberedSession`'s state.
 It increases monotonically, so may be used for tracking state's actuality.
 """
 scalar RememberedSessionVersion
-
-"""
-Type of a `RememberedSession`'s remember token.
-
-Its values are always considered to be non-empty and represent a
-[valid Base64 string][1].
-
-[1]: https://base64.guru/learn/base64-characters
-"""
-scalar RememberToken
 
 """Error of performing `Mutation.removeChatCallMember`."""
 type RemoveChatCallMemberError {
@@ -7479,11 +7677,11 @@ type RenewSessionError {
 """Possible error codes of performing `Mutation.renewSession`."""
 enum RenewSessionErrorCode {
   """
-  Provided `RememberToken` is wrong.
+  Provided `RefreshToken` is wrong.
 
   Status code: 403 Forbidden.
   """
-  WRONG_REMEMBER_TOKEN
+  WRONG_REFRESH_TOKEN
 }
 
 """Result of successful performing `Mutation.renewSession`."""
@@ -7563,18 +7761,11 @@ type ResetUserPasswordError {
 """Possible error codes of performing `Mutation.resetUserPassword`."""
 enum ResetUserPasswordErrorCode {
   """
-  Provided `ConfirmationCode` is wrong.
+  Provided `ConfirmationCode` is wrong or `MyUser` with the provided identifier doesn't exist.
 
   Status code: 403 Forbidden.
   """
   WRONG_CODE
-
-  """
-  `MyUser` with provided identifier doesn't exist.
-
-  Status code: 404 Not Found.
-  """
-  UNKNOWN_USER
 }
 
 """Result of performing `Mutation.resetUserPassword`."""
@@ -7628,13 +7819,13 @@ type StartChatCallError {
 """Possible error codes of performing `Mutation.startChatCall`."""
 enum StartChatCallErrorCode {
   """
-  Authenticated `MyUser` is blacklisted by the `User`, who responds to the `ChatCall`.
+  Authenticated `MyUser` is blocked by the `User`, who responds to the `ChatCall`.
 
   This error can happen only if `Chat` represents a dialog (consists only of two `User`s).
 
   Status code: 403 Forbidden.
   """
-  BLACKLISTED
+  BLOCKED
 
   """
   `Chat` with the provided ID doesn't exist.
@@ -8166,13 +8357,6 @@ type Subscription {
   """
   recentChatsTopEvents(
     """
-    Count of top recent `Chat`s to receive updates for. Value must be in range from 1 to 100.
-
-    Usually, you need just pass the count of `ChatConnection.nodes` returned by `Query.recentChats`.
-    """
-    count: Int!
-
-    """
     Indicator whether updates regarding favorite `Chat`s should be excluded from the result.
     """
     noFavorite: Boolean = false
@@ -8184,6 +8368,13 @@ type Subscription {
     `null` means omitting filtering by this criteria.
     """
     withOngoingCalls: Boolean = null
+
+    """
+    Count of top recent `Chat`s to receive updates for. Value must be in range from 1 to 100.
+
+    Usually, you need just pass the count of `ChatConnection.nodes` returned by `Query.recentChats`.
+    """
+    count: Int!
   ): RecentChatsTopEvents!
 
   """
@@ -8361,11 +8552,11 @@ Possible error codes of performing `Mutation.transformDialogCallIntoGroupCall`.
 """
 enum TransformDialogCallIntoGroupCallErrorCode {
   """
-  Authenticated `MyUser` is blacklisted by one of the specified members.
+  Authenticated `MyUser` is blocked by one of the specified members.
 
   Status code: 403 Forbidden.
   """
-  BLACKLISTED
+  BLOCKED
 
   """
   Specified `Chat` is not a dialog, so its call cannot be transformed into a group call.
@@ -8406,14 +8597,14 @@ enum TransformDialogCallIntoGroupCallErrorCode {
 """Result of performing `Mutation.transformDialogCallIntoGroupCall`."""
 union TransformDialogCallIntoGroupCallResult = ChatEventsVersioned | TransformDialogCallIntoGroupCallError
 
-"""Error of performing `Mutation.unblacklistUser`."""
-type UnblacklistUserError {
+"""Error of performing `Mutation.unblockUser`."""
+type UnblockUserError {
   """Code indicating why this error has happened."""
-  code: UnblacklistUserErrorCode!
+  code: UnblockUserErrorCode!
 }
 
-"""Possible error codes of performing `Mutation.unblacklistUser`."""
-enum UnblacklistUserErrorCode {
+"""Possible error codes of performing `Mutation.unblockUser`."""
+enum UnblockUserErrorCode {
   """
   `User` with the provided ID doesn't exist.
 
@@ -8422,8 +8613,8 @@ enum UnblacklistUserErrorCode {
   UNKNOWN_USER
 }
 
-"""Result of performing `Mutation.unblacklistUser`."""
-union UnblacklistUserResult = BlacklistEventsVersioned | UnblacklistUserError
+"""Result of performing `Mutation.unblockUser`."""
+union UnblockUserResult = BlocklistEventsVersioned | UnblockUserError
 
 """Error of performing `Mutation.unfavoriteChatContact`."""
 type UnfavoriteChatContactError {
@@ -8754,11 +8945,11 @@ type UseChatDirectLinkError {
 """Possible error codes of performing `Mutation.useChatDirectLink`."""
 enum UseChatDirectLinkErrorCode {
   """
-  Authenticated `MyUser` is blacklisted by the responder.
+  Authenticated `MyUser` is blocked by the responder.
 
   Status code: 403 Forbidden.
   """
-  BLACKLISTED
+  BLOCKED
 
   """
   `ChatDirectLink` with the provided slug doesn't exist or is not active anymore.
@@ -8870,10 +9061,9 @@ type User {
   id: UserId!
 
   """
-  Indicator whether this `User` is blacklisted by the authenticated
-  `MyUser`.
+  Indicator whether this `User` is blocked by the authenticated `MyUser`.
   """
-  isBlacklisted: IsBlacklisted!
+  isBlocked: IsBlocked!
 
   """Indicator whether this `User` is deleted."""
   isDeleted: Boolean!
@@ -8942,19 +9132,20 @@ type User {
 """Avatar of a `User`."""
 type UserAvatar {
   """
-  `big` `UserAvatar`'s view image `File`, square-cropped to its minimum
-  dimension (either width or height), and scaled to `70px`x`70px`.
+  `big` view `ImageFile` of this `UserAvatar`, square-cropped to its
+  minimum dimension (either width or height), and scaled to
+  `250px`x`250px`.
   """
-  big: File!
+  big: ImageFile!
 
   """`CropArea` applied to the `GalleryItem` to create this `UserAvatar`."""
   crop: CropArea
 
   """
-  Full-sized `UserAvatar`'s image `File`, keeping the `original`
-  dimensions.
+  Full-sized `ImageFile` representing this `UserAvatar`, keeping the
+  `original` dimensions.
   """
-  full: File!
+  full: ImageFile!
 
   """
   `GalleryItem` this `UserAvatar` was created from.
@@ -8964,19 +9155,20 @@ type UserAvatar {
   galleryItem: GalleryItem
 
   """
-  `medium` `UserAvatar`'s view image `File`, square-cropped to its minimum
-  dimension (either width or height), and scaled to `46px`x`46px`.
+  `medium` view `ImageFile` of this `UserAvatar`, square-cropped to its
+  minimum dimension (either width or height), and scaled to
+  `100px`x`100px`.
   """
-  medium: File!
+  medium: ImageFile!
 
-  """Original image `File` representing this `UserAvatar`."""
-  original: File!
+  """Original `ImageFile` representing this `UserAvatar`."""
+  original: ImageFile!
 
   """
-  `small` `UserAvatar`'s view image `File`, square-cropped to its minimum
-  dimension (either width or height), and scaled to `25px`x`25px`.
+  `small` view `ImageFile` of this `UserAvatar`, square-cropped to its
+  minimum dimension (either width or height), and scaled to `46px`x`46px`.
   """
-  small: File!
+  small: ImageFile!
 }
 
 """
@@ -8996,10 +9188,10 @@ type UserCallCover {
   crop: CropArea
 
   """
-  Full-sized `UserCallCover`'s image `File`, keeping the `original`
-  dimensions.
+  Full-sized `ImageFile` representing this `UserCallCover`, keeping the
+  `original` dimensions.
   """
-  full: File!
+  full: ImageFile!
 
   """
   `GalleryItem` this `UserCallCover` was created from.
@@ -9008,22 +9200,22 @@ type UserCallCover {
   """
   galleryItem: GalleryItem
 
-  """Original image `File` representing this `UserCallCover`."""
-  original: File!
+  """Original `ImageFile` representing this `UserCallCover`."""
+  original: ImageFile!
 
   """
-  `square` `UserCallCover`'s view image `File`, square-cropped to its
+  `square` view `ImageFile` of this `UserCallCover`, square-cropped to its
   minimum dimension (either width or height), and scaled to
   `300px`x`300px`.
   """
-  square: File!
+  square: ImageFile!
 
   """
-  `vertical` `UserCallCover`'s view image `File`, rectangular-cropped to
-  its minimum dimension (either width or height), and proportionally
+  `vertical` view `ImageFile` of this `UserCallCover`, rectangular-cropped
+  to its minimum dimension (either width or height), and proportionally
   scaled to `675px`x`900px`.
   """
-  vertical: File!
+  vertical: ImageFile!
 }
 
 """
@@ -9064,7 +9256,7 @@ interface UserEvent {
 }
 
 """Events emitted by `Subscription.userEvents`."""
-union UserEvents = BlacklistEventsVersioned | IsBlacklisted | SubscriptionInitialized | User | UserEventsVersioned
+union UserEvents = BlocklistEventsVersioned | IsBlocked | SubscriptionInitialized | User | UserEventsVersioned
 
 """`UserEvent` along with the corresponding `UserVersion`."""
 type UserEventsVersioned {
@@ -9319,16 +9511,9 @@ Possible error codes of performing `Mutation.validateUserPasswordRecoveryCode`.
 """
 enum ValidateUserPasswordRecoveryErrorCode {
   """
-  Provided `ConfirmationCode` is wrong.
+  Provided `ConfirmationCode` is wrong or `MyUser` with the provided identifier doesn't exist.
 
   Status code: 403 Forbidden.
   """
   WRONG_CODE
-
-  """
-  `MyUser` with the provided identifier doesn't exist.
-
-  Status code: 404 Not Found.
-  """
-  UNKNOWN_USER
 }


### PR DESCRIPTION
## Synopsis

0.1.0-beta.9 backend has been released.

Accessible for testing from:
https://messenger.soc.stg.t11913.org/api



## Changelog

### BC Breaks

- GraphQL API:
    - Types:
        - Renamed `RememberToken` scalar as `RefreshToken`;
        - Renamed `WRONG_REMEMBER_TOKEN` value of `RenewSessionErrorCode` enum as `WRONG_REFRESH_TOKEN`;
        - Renamed `IsBlacklisted` object as `IsBlocked`;
        - Renamed `BlacklistReason` scalar as `BlocklistReason`;
        - Renamed `BlacklistCursor` scalar as `BlocklistCursor`;
        - Renamed `BlacklistConnection` object as `BlocklistConnection`;
        - Renamed `BLACKLISTED` error codes of GraphQL mutations to `BLOCKED`;
        - Replaced `File` object with `File` interface;
        - Replaced `ImageGalleryItem` object and `GalleryItem` interface with `GalleryItem` object;
        - Replaced `BlacklistEdge` object with `BlocklistEdge` object;
        - Replaced `BlacklistRecord` object with `BlocklistRecord` object;
        - Replaced `BlacklistEvent` interface with `BlocklistEvent` interface;
        - Replaced `EventBlacklistRecordAdded` object with `EventBlocklistRecordAdded` object;
        - Replaced `EventBlacklistRecordRemoved` object with `EventBlocklistRecordRemoved` object;
        - Removed `RecoverUserPasswordErrorCode` enum;
        - Removed `UNKNOWN_USER` value from `ResetUserPasswordErrorCode` and `ValidateUserPasswordRecoveryErrorCode` enums. 
    - Queries:
        - Changed return type of `FileAttachment.original` field to `PlainFile` object;
        - Changed return type of `ChatAvatar.original`, `ChatAvatar.full`, `ChatAvatar.big`, `ChatAvatar.medium`, `ChatAvatar.small`, `UserAvatar.original`, `UserAvatar.full`, `UserAvatar.big`, `UserAvatar.medium`, `UserAvatar.small`, `UserCallCover.original`, `UserCallCover.full`, `UserCallCover.vertical`, `UserCallCover.square`, `ImageAttachment.original`, `ImageAttachment.big`, `ImageAttachment.medium` and `ImageAttachment.small` fields to `ImageFile` object;
        - Renamed `blacklist` as `blocklist`;
        - Renamed `User.isBlacklisted` field as `isBlocked`;
        - Removed `checkUserIdentifiable`;
        - Removed `ChatInfo.authorId` and `ChatCall.authorId` fields;
        - Replaced `ChatItem.authorId` field with `ChatItem.author`;
        - Replaced `ChatForward.authorId` field with `ChatForward.author`;
        - Replaced `ChatMessage.authorId` field with `ChatMessage.author`;
        - Replaced `ChatCall.caller` field with `ChatCall.author`;
        - Changed `ImageAttachment.big` size to `800px` over maximum dimension;
        - Changed `ChatAvatar.big` and `UserAvatar.big` size to `250px` over maximum dimension, `ChatAvatar.medium` and `UserAvatar.medium` size to `100px` over maximum dimension, `ChatAvatar.small` and `UserAvatar.small` size to `46px` over maximum dimension.
    - Mutations:
        - Renamed `blacklistUser` as `blockUser`;
        - Renamed `unblacklistUser` as `unblockUser`;
        - Changed return type of `recoverUserPassword` to `bool`.

### Added

- GraphQL API:
    - Types:
        - `PlainFile` and `ImageFile` objects to `File` GraphQL interface;
        - `EventChatCallConversationStarted` object to `ChatEvent` and `ChatCallEvent` GraphQL interfaces;
        - `EventChatCallMemberUndialed` object to `ChatEvent` and `ChatCallEvent` interfaces.
    - Queries:
        - `MyUser.blocklist` and `BlocklistEventsVersioned.blocklist` fields;
        - `BlocklistConnection.totalCount` field;
        - `readItem` argument to `Chat.members`.
- FCM notifications:
    - On `ChatMember` himself being removed from `Chat`-group;
    - On updating or removing `ChatAvatar` and `ChatName`;
    - Tag on Web.
- Configuration:
    - `[security.time.padding]` section.

### Changed

- GraphQL API:
    - Mutations:
        - Allowed `removeChatCallMember` to undial a currently dialed `ChatMember`.
- FCM notifications:
    - Mentioned `Attachment`s count for `ChatMessage`;
    - Sound to `notification.caf`.

### Fixed

- GraphQL API:
    - Queries:
        - `MyUser.unreadChatsCount` counting hidden and cleared `Chat`s never being read by `MyUser`.
- File storage:
    - `Content-Type` header being always `application/octet-stream`.
- FCM notifications:
    - Undesired symbols of unicode directionality isolation.




## Solution

- [x] Update GraphQL schema
- [x] Update Docker Compose environment




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
