### PR TITLE
Display chat links with "`-`" correctly

### DIFF
--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -317,16 +317,16 @@ class ChatDirectLinkSlug extends NewType<String> {
     final Random r = Random();
     const String chars =
         'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890_-';
-    String generatedString =
-        List.generate(length, (_) => chars[r.nextInt(chars.length)]).join();
-
-    if (generatedString.endsWith('-')) {
-      String randomChar = chars[r.nextInt(chars.length)].replaceAll('-', '');
-      generatedString =
-          generatedString.substring(0, generatedString.length - 1) + randomChar;
-    }
-
-    return ChatDirectLinkSlug(generatedString);
+    return ChatDirectLinkSlug(
+      List.generate(
+        length,
+        (i) => i == length - 1
+            // `-` being the last might not be parsed as a link by some
+            // applications.
+            ? chars.replaceFirst('-', '')[r.nextInt(chars.length)]
+            : chars[r.nextInt(chars.length)],
+      ).join(),
+    );
   }
 
   /// Regular expression for basic [ChatDirectLinkSlug] validation.

--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -319,16 +319,16 @@ class ChatDirectLinkSlug extends NewType<String> {
         'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890_-';
 
     return ChatDirectLinkSlug(
-      List.generate(
-        length,
-        (i) => i == length - 1
-            // `-` and `_` being the last might not be parsed as a link by some
-            // applications.
-            ? chars
-                .replaceFirst('-', '')
-                .replaceFirst('_', '')[r.nextInt(chars.length - 2)]
-            : chars[r.nextInt(chars.length)],
-      ).join(),
+      List.generate(length, (i) {
+        // `-` and `_` being the last might not be parsed as a link by some
+        // applications.
+        if (i == length - 1) {
+          final str = chars.replaceFirst('-', '').replaceFirst('_', '');
+          return str[r.nextInt(str.length)];
+        }
+
+        return chars[r.nextInt(chars.length)];
+      }).join(),
     );
   }
 

--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -321,9 +321,11 @@ class ChatDirectLinkSlug extends NewType<String> {
       List.generate(
         length,
         (i) => i == length - 1
-            // `-` being the last might not be parsed as a link by some
+            // `-` and `_` being the last might not be parsed as a link by some
             // applications.
-            ? chars.replaceFirst('-', '')[r.nextInt(chars.length)]
+            ? chars
+                .replaceFirst('-', '')
+                .replaceFirst('_', '')[r.nextInt(chars.length)]
             : chars[r.nextInt(chars.length)],
       ).join(),
     );

--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -317,9 +317,16 @@ class ChatDirectLinkSlug extends NewType<String> {
     final Random r = Random();
     const String chars =
         'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890_-';
-    return ChatDirectLinkSlug(
-      List.generate(length, (_) => chars[r.nextInt(chars.length)]).join(),
-    );
+    String generatedString =
+        List.generate(length, (_) => chars[r.nextInt(chars.length)]).join();
+
+    if (generatedString.endsWith('-')) {
+      String randomChar = chars[r.nextInt(chars.length)].replaceAll('-', '');
+      generatedString =
+          generatedString.substring(0, generatedString.length - 1) + randomChar;
+    }
+
+    return ChatDirectLinkSlug(generatedString);
   }
 
   /// Regular expression for basic [ChatDirectLinkSlug] validation.

--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -317,6 +317,7 @@ class ChatDirectLinkSlug extends NewType<String> {
     final Random r = Random();
     const String chars =
         'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890_-';
+
     return ChatDirectLinkSlug(
       List.generate(
         length,

--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -318,6 +318,10 @@ class ChatDirectLinkSlug extends NewType<String> {
     const String chars =
         'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890_-';
 
+    final index = r.nextInt(chars.length) % chars.length;
+
+    print(index);
+
     return ChatDirectLinkSlug(
       List.generate(
         length,
@@ -326,7 +330,7 @@ class ChatDirectLinkSlug extends NewType<String> {
             // applications.
             ? chars
                 .replaceFirst('-', '')
-                .replaceFirst('_', '')[r.nextInt(chars.length)]
+                .replaceFirst('_', '')[r.nextInt(chars.length - 1)]
             : chars[r.nextInt(chars.length)],
       ).join(),
     );

--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -318,10 +318,6 @@ class ChatDirectLinkSlug extends NewType<String> {
     const String chars =
         'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890_-';
 
-    final index = r.nextInt(chars.length) % chars.length;
-
-    print(index);
-
     return ChatDirectLinkSlug(
       List.generate(
         length,
@@ -330,7 +326,7 @@ class ChatDirectLinkSlug extends NewType<String> {
             // applications.
             ? chars
                 .replaceFirst('-', '')
-                .replaceFirst('_', '')[r.nextInt(chars.length - 1)]
+                .replaceFirst('_', '')[r.nextInt(chars.length - 2)]
             : chars[r.nextInt(chars.length)],
       ).join(),
     );

--- a/test/unit/direct_link_slug_test.dart
+++ b/test/unit/direct_link_slug_test.dart
@@ -19,24 +19,24 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:messenger/domain/model/user.dart';
 
 void main() {
-  group('ChatDirectLinkSlug', () {
-    test('Should generate slug with random chars', () {
-      final slug = ChatDirectLinkSlug.generate();
-      expect(slug.val, isNotNull);
-      expect(slug.val, isNotEmpty);
-      expect(slug.val.length, equals(10));
-    });
+  test('ChatDirectLinkSlug generates slug of the specified length', () {
+    expect(ChatDirectLinkSlug.generate(1).val.length, 1);
+    expect(ChatDirectLinkSlug.generate(10).val.length, 10);
+    expect(ChatDirectLinkSlug.generate(100).val.length, 100);
+  });
 
-    test('Should generate a slug with valid characters', () {
-      final slug = ChatDirectLinkSlug.generate(10);
-      final validChars = RegExp(r'^[A-Za-z0-9_-]+$');
-      expect(validChars.hasMatch(slug.val), isTrue);
-    });
+  test('ChatDirectLinkSlug generates slug with valid characters', () {
+    final slug = ChatDirectLinkSlug.generate(100);
+    final validChars = RegExp(r'^[A-Za-z0-9_-]+$');
+    expect(validChars.hasMatch(slug.val), isTrue);
+  });
 
-    test('Should not end with "-" or "_"', () {
+  test('ChatDirectLinkSlug generates slug that doesn\'t end with `-` or `_`',
+      () {
+    for (int i = 0; i < 10; ++i) {
       final slug = ChatDirectLinkSlug.generate();
       expect(slug.val.endsWith('-'), isFalse);
       expect(slug.val.endsWith('_'), isFalse);
-    });
+    }
   });
 }

--- a/test/unit/direct_links_generator_test.dart
+++ b/test/unit/direct_links_generator_test.dart
@@ -1,3 +1,20 @@
+// Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:messenger/domain/model/user.dart';
 

--- a/test/unit/direct_links_generator_test.dart
+++ b/test/unit/direct_links_generator_test.dart
@@ -22,8 +22,6 @@ void main() {
   group('ChatDirectLinkSlug', () {
     test('Should generate slug with random chars', () {
       final slug = ChatDirectLinkSlug.generate();
-      print(slug);
-
       expect(slug.val, isNotNull);
       expect(slug.val, isNotEmpty);
       expect(slug.val.length, equals(10));
@@ -32,13 +30,11 @@ void main() {
     test('Should generate a slug with valid characters', () {
       final slug = ChatDirectLinkSlug.generate(10);
       final validChars = RegExp(r'^[A-Za-z0-9_-]+$');
-      print(slug);
       expect(validChars.hasMatch(slug.val), isTrue);
     });
 
     test('Should not end with "-" or "_"', () {
       final slug = ChatDirectLinkSlug.generate();
-      print(slug);
       expect(slug.val.endsWith('-'), isFalse);
       expect(slug.val.endsWith('_'), isFalse);
     });

--- a/test/unit/direct_links_generator_test.dart
+++ b/test/unit/direct_links_generator_test.dart
@@ -33,7 +33,7 @@ void main() {
 
     test('Should not end with a hyphen', () {
       final slug = ChatDirectLinkSlug.generate();
-      expect(slug.val.endsWith('-'), isFalse);
+      expect(slug.val.endsWith('-') && slug.val.endsWith('_'), isFalse);
     });
   });
 }

--- a/test/unit/direct_links_generator_test.dart
+++ b/test/unit/direct_links_generator_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:messenger/domain/model/user.dart';
+
+void main() {
+  group('ChatDirectLinkSlug', () {
+    test('Should generate a slug of given length', () {
+      final slug = ChatDirectLinkSlug.generate(10);
+      expect(slug.val.length, equals(10));
+    });
+
+    test('Should generate a slug with valid characters', () {
+      final slug = ChatDirectLinkSlug.generate(10);
+      final validChars = RegExp(r'^[A-Za-z0-9_-]+$');
+      expect(validChars.hasMatch(slug.val), isTrue);
+    });
+
+    test('Should not end with a hyphen', () {
+      final slug = ChatDirectLinkSlug.generate();
+      expect(slug.val.endsWith('-'), isFalse);
+    });
+  });
+}

--- a/test/unit/direct_links_generator_test.dart
+++ b/test/unit/direct_links_generator_test.dart
@@ -20,20 +20,27 @@ import 'package:messenger/domain/model/user.dart';
 
 void main() {
   group('ChatDirectLinkSlug', () {
-    test('Should generate a slug of given length', () {
-      final slug = ChatDirectLinkSlug.generate(10);
+    test('Should generate slug with random chars', () {
+      final slug = ChatDirectLinkSlug.generate();
+      print(slug);
+
+      expect(slug.val, isNotNull);
+      expect(slug.val, isNotEmpty);
       expect(slug.val.length, equals(10));
     });
 
     test('Should generate a slug with valid characters', () {
       final slug = ChatDirectLinkSlug.generate(10);
       final validChars = RegExp(r'^[A-Za-z0-9_-]+$');
+      print(slug);
       expect(validChars.hasMatch(slug.val), isTrue);
     });
 
-    test('Should not end with a hyphen', () {
+    test('Should not end with "-" or "_"', () {
       final slug = ChatDirectLinkSlug.generate();
-      expect(slug.val.endsWith('-') && slug.val.endsWith('_'), isFalse);
+      print(slug);
+      expect(slug.val.endsWith('-'), isFalse);
+      expect(slug.val.endsWith('_'), isFalse);
     });
   });
 }


### PR DESCRIPTION
Resolves #484 


## Synopsis

Ссылки с "-" в конце некорректно отображаются на различных сайтах.




## Solution

В создании ссылки будет проверка, и если ссылка заканчивается на "-", то будет браться еще один рандомный символ не считая "-".




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
