### PR TITLE
Fix `ChatRepository.readUntil` spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.1.0-alpha.9.1] · 2023-07-??
+[0.1.0-alpha.9.1]: /../../tree/v0.1.0-alpha.9.1
+
+[Diff](/../../compare/v0.1.0-alpha.9...v0.1.0-alpha.9.1) | [Milestone](/../../milestone/7)
+
+### Fixed
+
+- Performance:
+    - Spamming backend API when reading a chat ([#487]).
+- Web:
+    - Avatar not uploading due to simultaneous file read. ([#487])
+
+[#487]: /../../pull/487
+
+
+
+
 ## [0.1.0-alpha.9] · 2023-07-17
 [0.1.0-alpha.9]: /../../tree/v0.1.0-alpha.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ All user visible changes to this project will be documented in this file. This p
 ### Fixed
 
 - Performance:
-    - Spamming backend API when reading a chat ([#487]).
+    - Spamming backend API when reading a chat. ([#487])
+- iOS:
+    - Unreadable status bar text color. ([#487])
 - Web:
     - Avatar not uploading due to simultaneous file read. ([#487])
 

--- a/lib/api/backend/extension/chat.dart
+++ b/lib/api/backend/extension/chat.dart
@@ -63,7 +63,7 @@ extension ChatConversion on ChatMixin {
             lastReads.map((e) => LastChatRead(e.memberId, e.at)).toList(),
         lastDelivery: lastDelivery,
         lastItem: lastItem?.toHive().value,
-        lastReadItem: lastReadItem?.toHive().value,
+        lastReadItem: lastReadItem?.toHive().value.id,
         unreadCount: unreadCount,
         totalCount: totalCount,
         ongoingCall: ongoingCall?.toModel(),

--- a/lib/domain/model/chat.dart
+++ b/lib/domain/model/chat.dart
@@ -131,12 +131,13 @@ class Chat extends HiveObject {
   @HiveField(12)
   ChatItem? lastItem;
 
-  /// Last [ChatItem] read by the authenticated [MyUser] in this [Chat].
+  /// ID of the last [ChatItem] read by the authenticated [MyUser] in this
+  /// [Chat].
   ///
   /// If [Chat] hasn't been read yet, or has no visible [ChatItem]s for the
   /// authenticated [MyUser], then it's `null`.
   @HiveField(13)
-  ChatItem? lastReadItem;
+  ChatItemId? lastReadItem;
 
   /// Count of [ChatItem]s unread by the authenticated [MyUser] in this [Chat].
   @HiveField(14)

--- a/lib/domain/service/notification.dart
+++ b/lib/domain/service/notification.dart
@@ -93,7 +93,10 @@ class NotificationService extends DisposableService {
     _onActivityChanged?.cancel();
     _audioPlayer?.dispose();
     _audioPlayer = null;
-    AudioCache.instance.clear('audio/notification.mp3');
+
+    AudioCache.instance
+        .clear('audio/notification.mp3')
+        .onError((_, __) => null);
   }
 
   // TODO: Implement icons and attachments on non-web platforms.

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -386,6 +386,7 @@ class HiveRxChat extends RxChat {
           }
         },
       );
+
       await _readTimer?.future;
     }
   }

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -365,22 +365,29 @@ class HiveRxChat extends RxChat {
       unreadCount.value = messages.skip(messages.length - readUntil).length;
     }
 
-    _readTimer?.cancel();
-    _readTimer = AwaitableTimer(
+    final ChatItemId? lastReadItem = chat.value.lastReadItem;
+    if (lastReadItem != untilId) {
+      chat.update((e) => e?..lastReadItem = untilId);
+
+      _readTimer?.cancel();
+      _readTimer = AwaitableTimer(
         chat.value.lastItem?.id == untilId
             ? Duration.zero
-            : const Duration(seconds: 1), () async {
-      try {
-        await _chatRepository.readUntil(id, untilId);
-      } catch (_) {
-        unreadCount.value = chat.value.unreadCount;
-        rethrow;
-      } finally {
-        _readTimer = null;
-      }
-    });
-
-    await _readTimer?.future;
+            : const Duration(seconds: 1),
+        () async {
+          try {
+            await _chatRepository.readUntil(id, untilId);
+          } catch (_) {
+            chat.update((e) => e?..lastReadItem = lastReadItem);
+            unreadCount.value = chat.value.unreadCount;
+            rethrow;
+          } finally {
+            _readTimer = null;
+          }
+        },
+      );
+      await _readTimer?.future;
+    }
   }
 
   /// Posts a new [ChatMessage] to the specified [Chat] by the authenticated

--- a/lib/themes.dart
+++ b/lib/themes.dart
@@ -98,6 +98,14 @@ class Themes {
       bodySmall: textStyle.copyWith(fontSize: 13, fontWeight: FontWeight.w300),
     );
 
+    SystemChrome.setSystemUIOverlayStyle(
+      SystemUiOverlayStyle(
+        systemNavigationBarColor: colors.primaryHighlight,
+        statusBarColor: colors.transparent,
+        statusBarBrightness: Brightness.light,
+      ),
+    );
+
     final ThemeData theme = ThemeData.light();
 
     return theme.copyWith(
@@ -154,10 +162,6 @@ class Themes {
           ),
           actionsIconTheme: theme.appBarTheme.iconTheme?.copyWith(
             color: colors.secondary,
-          ),
-          systemOverlayStyle: SystemUiOverlayStyle(
-            systemNavigationBarColor: colors.primaryHighlight,
-            statusBarColor: colors.transparent,
           ),
           elevation: 0,
           centerTitle: true,

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -570,7 +570,10 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
           });
         } else {
           final Map<String, dynamic> args = {
-            'author': action.user.name?.val ?? action.user.num.val,
+            'author': widget.user?.user.value.name?.val ??
+                widget.user?.user.value.num.val ??
+                action.user.name?.val ??
+                action.user.num.val,
           };
 
           content = Text.rich(

--- a/lib/ui/page/home/page/chat/widget/web_image/src/web.dart
+++ b/lib/ui/page/home/page/chat/widget/web_image/src/web.dart
@@ -87,7 +87,10 @@ class _WebImageState extends State<WebImage> {
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        if (_loading) const Center(child: CircularProgressIndicator()),
+        if (_loading)
+          const Positioned.fill(
+            child: Center(child: CircularProgressIndicator()),
+          ),
         if (!_backoffRunning)
           IgnorePointer(
             child: _HtmlImage(

--- a/lib/ui/page/home/page/my_profile/camera_switch/controller.dart
+++ b/lib/ui/page/home/page/my_profile/camera_switch/controller.dart
@@ -98,7 +98,7 @@ class CameraSwitchController extends GetxController {
     renderer.value?.dispose();
     _localTrack?.free();
 
-    final String? camera = this.camera.value;
+    String? camera = this.camera.value;
 
     await _initRendererGuard.protect(() async {
       final List<LocalMediaTrack> tracks =
@@ -112,6 +112,11 @@ class CameraSwitchController extends GetxController {
       }
 
       if (_localTrack != null) {
+        if (camera == null) {
+          camera = _localTrack?.getTrack().deviceId();
+          this.camera.value = camera;
+        }
+
         final RtcVideoRenderer renderer = RtcVideoRenderer(_localTrack!);
         await renderer.initialize();
 

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -448,7 +448,7 @@ class MyProfileController extends GetxController {
       FilePickerResult? result = await FilePicker.platform.pickFiles(
         type: FileType.image,
         allowMultiple: false,
-        withReadStream: true,
+        withData: true,
       );
 
       if (result?.files.isNotEmpty == true) {

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -545,25 +545,25 @@ class RecentChatTile extends StatelessWidget {
             case ChatInfoActionKind.memberAdded:
               final action = item.action as ChatInfoActionMemberAdded;
 
-              if (item.author.id != action.user.id) {
-                content = userBuilder(action.user.id, (context, user) {
-                  final User author = (item as ChatInfo).author;
-                  user ??= action.user;
+              content = userBuilder(action.user.id, (context, user) {
+                final User author = (item as ChatInfo).author;
+                user ??= action.user;
 
+                if (item.author.id != action.user.id) {
                   final Map<String, dynamic> args = {
                     'author': author.name?.val ?? author.num.val,
                     'user': user.name?.val ?? user.num.val,
                   };
 
                   return Text('label_user_added_user'.l10nfmt(args));
-                });
-              } else {
-                content = Text(
-                  'label_was_added'.l10nfmt(
-                    {'author': '${action.user.name ?? action.user.num}'},
-                  ),
-                );
-              }
+                } else {
+                  return Text(
+                    'label_was_added'.l10nfmt(
+                      {'author': user.name?.val ?? user.num.val},
+                    ),
+                  );
+                }
+              });
               break;
 
             case ChatInfoActionKind.memberRemoved:

--- a/lib/ui/page/home/widget/avatar.dart
+++ b/lib/ui/page/home/widget/avatar.dart
@@ -458,16 +458,20 @@ class AvatarWidget extends StatelessWidget {
               Positioned.fill(
                 child: ClipOval(
                   child: RetryImage(
-                    maxWidth > 70
+                    maxWidth > 250
                         ? avatar!.full.url
-                        : maxWidth > 26
+                        : maxWidth > 100
                             ? avatar!.big.url
-                            : avatar!.medium.url,
-                    checksum: maxWidth > 70
+                            : maxWidth > 46
+                                ? avatar!.medium.url
+                                : avatar!.small.url,
+                    checksum: maxWidth > 250
                         ? avatar!.full.checksum
-                        : maxWidth > 26
+                        : maxWidth > 100
                             ? avatar!.big.checksum
-                            : avatar!.medium.checksum,
+                            : maxWidth > 46
+                                ? avatar!.medium.checksum
+                                : avatar!.small.checksum,
                     fit: BoxFit.cover,
                     height: double.infinity,
                     width: double.infinity,

--- a/lib/ui/page/home/widget/gallery_popup.dart
+++ b/lib/ui/page/home/widget/gallery_popup.dart
@@ -571,16 +571,20 @@ class _GalleryPopupState extends State<GalleryPopup>
                       fit: _isFullscreen.isTrue
                           ? BoxFit.contain
                           : BoxFit.scaleDown,
-                      child: PlatformUtils.isWeb
-                          ? WebImage(
-                              e.link,
-                              onForbidden: e.onError,
-                            )
-                          : RetryImage(
-                              e.link,
-                              checksum: e.checksum,
-                              onForbidden: e.onError,
-                            ),
+                      child: ConstrainedBox(
+                        constraints:
+                            const BoxConstraints(minWidth: 1, minHeight: 1),
+                        child: PlatformUtils.isWeb
+                            ? WebImage(
+                                e.link,
+                                onForbidden: e.onError,
+                              )
+                            : RetryImage(
+                                e.link,
+                                checksum: e.checksum,
+                                onForbidden: e.onError,
+                              ),
+                      ),
                     ),
                   ),
           ),

--- a/lib/ui/worker/call.dart
+++ b/lib/ui/worker/call.dart
@@ -288,9 +288,9 @@ class CallWorker extends DisposableService {
     _audioPlayer?.dispose();
     _audioPlayer = null;
 
-    AudioCache.instance.clear('audio/$_incoming');
-    AudioCache.instance.clear('audio/$_outgoing');
-    AudioCache.instance.clear('audio/pop.mp3');
+    AudioCache.instance.clear('audio/$_incoming').onError((_, __) => null);
+    AudioCache.instance.clear('audio/$_outgoing').onError((_, __) => null);
+    AudioCache.instance.clear('audio/pop.mp3').onError((_, __) => null);
 
     _subscription.cancel();
     _storageSubscription?.cancel();

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -460,8 +460,10 @@ class PlatformUtilsImpl {
 
   /// Keeps the [_isActive] status as [active].
   void keepActive([bool active = true]) {
-    _isActive = active;
-    _activityController?.add(active);
+    if (_isActive != active) {
+      _isActive = active;
+      _activityController?.add(active);
+    }
 
     _activityTimer?.cancel();
 

--- a/test/e2e/features/chat/draft/.feature
+++ b/test/e2e/features/chat/draft/.feature
@@ -25,6 +25,7 @@ Feature: Drafts
 
     When I attach "test.txt" file
     And I fill `MessageField` field with "He-he, draft!"
+    And I pause for 2 seconds
     And I return to previous page
     Then I see draft "He-he, draft!" in chat with Bob
 

--- a/test/e2e/steps/see_chat_avatar.dart
+++ b/test/e2e/steps/see_chat_avatar.dart
@@ -44,7 +44,7 @@ final StepDefinitionGeneric seeChatAvatarAs = then1<String, CustomWorld>(
           context.world.appDriver
               .findBy('ChatAvatar_${chat?.id}', FindType.key),
           context.world.appDriver.findBy(
-            'Image_${chat?.avatar.value?.full.url}',
+            'Image_${chat?.avatar.value?.big.url}',
             FindType.key,
           ),
           firstMatchOnly: true,

--- a/test/e2e/steps/see_draft.dart
+++ b/test/e2e/steps/see_draft.dart
@@ -46,10 +46,13 @@ final StepDefinitionGeneric seeDraftInDialog =
         context.world.appDriver.findBy('Draft', FindType.key),
         firstMatchOnly: true,
       );
-      expect(await context.world.appDriver.isPresent(finder), true);
 
-      final RxChat? chat = Get.find<ChatService>().chats[dialog];
-      return (chat?.draft.value as ChatMessage).text?.val == text;
+      if (await context.world.appDriver.isPresent(finder)) {
+        final RxChat? chat = Get.find<ChatService>().chats[dialog];
+        return (chat?.draft.value as ChatMessage).text?.val == text;
+      }
+
+      return false;
     });
   },
 );

--- a/test/e2e/steps/see_draft.dart
+++ b/test/e2e/steps/see_draft.dart
@@ -38,16 +38,18 @@ final StepDefinitionGeneric seeDraftInDialog =
   (text, user, context) async {
     await context.world.appDriver.waitForAppToSettle();
 
-    final ChatId dialog = context.world.sessions[user.name]!.dialog!;
+    await context.world.appDriver.waitUntil(() async {
+      final ChatId dialog = context.world.sessions[user.name]!.dialog!;
 
-    final Finder finder = context.world.appDriver.findByDescendant(
-      context.world.appDriver.findBy('Chat_$dialog', FindType.key),
-      context.world.appDriver.findBy('Draft', FindType.key),
-      firstMatchOnly: true,
-    );
-    expect(await context.world.appDriver.isPresent(finder), true);
+      final Finder finder = context.world.appDriver.findByDescendant(
+        context.world.appDriver.findBy('Chat_$dialog', FindType.key),
+        context.world.appDriver.findBy('Draft', FindType.key),
+        firstMatchOnly: true,
+      );
+      expect(await context.world.appDriver.isPresent(finder), true);
 
-    final RxChat? chat = Get.find<ChatService>().chats[dialog];
-    expect((chat!.draft.value as ChatMessage).text?.val, text);
+      final RxChat? chat = Get.find<ChatService>().chats[dialog];
+      return (chat?.draft.value as ChatMessage).text?.val == text;
+    });
   },
 );

--- a/test/unit/chat_read_test.dart
+++ b/test/unit/chat_read_test.dart
@@ -247,11 +247,12 @@ void main() async {
     when(graphQlProvider.getChat(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
     )).thenAnswer(
-        (_) => Future.value(GetChat$Query.fromJson({'chat': chatData})));
+      (_) => Future.value(GetChat$Query.fromJson({'chat': chatData})),
+    );
 
     when(graphQlProvider.readChat(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-      const ChatItemId(''),
+      const ChatItemId('0'),
     )).thenThrow(const ReadChatException(ReadChatErrorCode.unknownChat));
 
     Get.put(chatProvider);
@@ -288,23 +289,24 @@ void main() async {
       ),
     );
     ChatService chatService = Get.put(ChatService(chatRepository, authService));
+    await chatService.get(const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'));
 
     Exception? exception;
 
     try {
       await chatService.readChat(
         const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-        const ChatItemId(''),
+        const ChatItemId('0'),
       );
     } on ReadChatException catch (e) {
       exception = e;
     }
 
-    assert(exception is ReadChatException);
-
     verify(graphQlProvider.readChat(
       const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
-      const ChatItemId(''),
+      const ChatItemId('0'),
     ));
+
+    assert(exception is ReadChatException);
   });
 }


### PR DESCRIPTION
## Synopsis

`ChatRepository.readUntil` is spammed due to `ChatItem` being the last in the `Chat`.




## Solution

Account whether the last read `ChatItem` is not the one we're reading until currently.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
