### PR TITLE
Replace `FixedDigitsExtension` with `FontFeature.tabularFigures` (#482)

### DIFF
--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -17,6 +17,7 @@
 
 import 'dart:async';
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
@@ -1378,8 +1379,11 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                         overflow: TextOverflow.ellipsis,
                         style: fonts.labelLarge!.copyWith(
                           color: style.colors.secondary,
+                          fontFeatures: [
+                            const FontFeature.tabularFigures(),
+                          ],
                         ),
-                      ).fixedDigits(),
+                      ),
                     ],
                   ),
                 ),
@@ -2039,39 +2043,5 @@ extension LinkParsingExtension on String {
     }
 
     return TextSpan(children: spans);
-  }
-}
-
-/// Extension adding a fixed-length digits [Text] transformer.
-extension FixedDigitsExtension on Text {
-  /// [RegExp] detecting numbers.
-  static final RegExp _regex = RegExp(r'\d');
-
-  /// Returns a [Text] guaranteed to have fixed width of digits in it.
-  Widget fixedDigits() {
-    Text copyWith(String string) {
-      return Text(
-        string,
-        style: style,
-        strutStyle: strutStyle,
-        textAlign: textAlign,
-        textDirection: textDirection,
-        locale: locale,
-        softWrap: softWrap,
-        overflow: overflow,
-        textScaleFactor: textScaleFactor,
-        maxLines: maxLines,
-        textWidthBasis: textWidthBasis,
-        textHeightBehavior: textHeightBehavior,
-        selectionColor: selectionColor,
-      );
-    }
-
-    return Stack(
-      children: [
-        Opacity(opacity: 0, child: copyWith(data!.replaceAll(_regex, '0'))),
-        copyWith(data!),
-      ],
-    );
   }
 }

--- a/lib/ui/page/home/tab/chats/widget/rectangular_call_button.dart
+++ b/lib/ui/page/home/tab/chats/widget/rectangular_call_button.dart
@@ -15,6 +15,8 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 import '/ui/page/home/page/chat/widget/chat_item.dart';
@@ -71,9 +73,13 @@ class RectangularCallButton extends StatelessWidget {
                 const SizedBox(width: 6),
                 Text(
                   text,
-                  style:
-                      fonts.bodyMedium!.copyWith(color: style.colors.onPrimary),
-                ).fixedDigits(),
+                  style: fonts.bodyMedium!.copyWith(
+                    color: style.colors.onPrimary,
+                    fontFeatures: [
+                      const FontFeature.tabularFigures(),
+                    ],
+                  ),
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
Resolves #482




## Synopsis

Для того, чтобы цифры не прыгали, используется расширение `FixedDigitsExtension` - это Stack с двумя Textами. Решение корявое.




## Solution

`FixedDigitsExtension` будет заменено на `FontFeature.tabularFigures`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
