### PR TITLE
Account `Locale` mismatches in `L10n.init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.1.0-alpha.10] · 2023-??-??
+[0.1.0-alpha.10]: /../../tree/v0.1.0-alpha.10
+
+[Diff](/../../compare/v0.1.0-alpha.9.1...v0.1.0-alpha.10) | [Milestone](/../../milestone/6)
+
+### Fixed
+
+- Web:
+    - Default locale not detecting in Safari. ([#491])
+
+[#487]: /../../pull/491
+
+
+
+
 ## [0.1.0-alpha.9.1] · 2023-07-20
 [0.1.0-alpha.9.1]: /../../tree/v0.1.0-alpha.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All user visible changes to this project will be documented in this file. This p
 - Web:
     - Default locale not detecting in Safari. ([#491])
 
-[#487]: /../../pull/491
+[#491]: /../../pull/491
 
 
 

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -48,7 +48,7 @@ class L10n {
     if (lang == null) {
       List<Locale> locales = WidgetsBinding.instance.platformDispatcher.locales;
       for (int i = 0; i < locales.length && chosen.value == null; ++i) {
-        Language? language = Language.from(locales[i].toLanguageTag());
+        final Language? language = Language.fromLocale(locales[i]);
         if (language != null) {
           await set(language, refresh: false);
         }
@@ -98,8 +98,20 @@ class Language {
 
   /// Returns a [Language] identified by its [tag] from the [L10n.languages], if
   /// any.
-  static Language? from(String? tag) {
+  static Language? fromTag(String? tag) {
     return L10n.languages.firstWhereOrNull((e) => e.toString() == tag);
+  }
+
+  /// Returns a [Language] from the [L10n.languages] matching the provided
+  /// [locale], if any.
+  static Language? fromLocale(Locale locale) {
+    return L10n.languages.firstWhereOrNull((e) => e.locale == locale) ??
+        // If exact match wasn't found, then find any matching the language or
+        // country code.
+        L10n.languages.firstWhereOrNull(
+            (e) => e.locale.languageCode == locale.languageCode) ??
+        L10n.languages.firstWhereOrNull(
+            (e) => e.locale.countryCode == locale.countryCode);
   }
 
   @override

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -46,12 +46,15 @@ class L10n {
     await initializeDateFormatting();
 
     if (lang == null) {
-      List<Locale> locales = WidgetsBinding.instance.platformDispatcher.locales;
-      for (int i = 0; i < locales.length && chosen.value == null; ++i) {
-        final Language? language = Language.fromLocale(locales[i]);
-        if (language != null) {
-          await set(language, refresh: false);
-        }
+      final Language? language = Language.fromLocale(
+        basicLocaleListResolution(
+          WidgetsBinding.instance.platformDispatcher.locales,
+          L10n.languages.map((e) => e.locale),
+        ),
+      );
+
+      if (language != null) {
+        await set(language, refresh: false);
       }
     } else {
       await set(lang, refresh: false);
@@ -105,13 +108,7 @@ class Language {
   /// Returns a [Language] from the [L10n.languages] matching the provided
   /// [locale], if any.
   static Language? fromLocale(Locale locale) {
-    return L10n.languages.firstWhereOrNull((e) => e.locale == locale) ??
-        // If exact match wasn't found, then find any matching the language or
-        // country code.
-        L10n.languages.firstWhereOrNull(
-            (e) => e.locale.languageCode == locale.languageCode) ??
-        L10n.languages.firstWhereOrNull(
-            (e) => e.locale.countryCode == locale.countryCode);
+    return L10n.languages.firstWhereOrNull((e) => e.locale == locale);
   }
 
   @override

--- a/lib/ui/worker/background/src/main.dart
+++ b/lib/ui/worker/background/src/main.dart
@@ -264,7 +264,7 @@ class _BackgroundService {
 
     _service.on('l10n').listen((event) {
       _resetConnectionTimer();
-      L10n.set(Language.from(event!['locale']));
+      L10n.set(Language.fromTag(event!['locale']));
     });
 
     _service.on('ka').listen((_) {

--- a/lib/ui/worker/settings.dart
+++ b/lib/ui/worker/settings.dart
@@ -41,7 +41,7 @@ class SettingsWorker extends DisposableService {
     if (locale == null) {
       _settingsRepository.setLocale(L10n.chosen.value!.toString());
     } else {
-      await L10n.set(Language.from(locale));
+      await L10n.set(Language.fromTag(locale));
     }
 
     _worker = ever(
@@ -49,7 +49,7 @@ class SettingsWorker extends DisposableService {
       (ApplicationSettings? settings) {
         if (locale != settings?.locale) {
           locale = settings?.locale;
-          L10n.set(Language.from(locale) ?? L10n.languages.first);
+          L10n.set(Language.fromTag(locale) ?? L10n.languages.first);
         }
       },
     );


### PR DESCRIPTION
## Synopsis

Currently the default language being used in determined in the `L10n.init` method. It uses the [`WidgetsBinding.instance.platformDispatcher.locales`](https://api.flutter.dev/flutter/dart-ui/SingletonFlutterWindow/locales.html) getter, which under the hood parses the locales used by the device and returns those in priority ordered `Locale` list. The problem lies within our `Language.from` constructor, as it expects the returned `Locale` to match both country code and language code in order for it to be recognized as a `Language` available in the application.

```dart
static List<Language> languages = const [
  Language('English', Locale('en', 'US')),
  Language('Русский', Locale('ru', 'RU')),
];

...

static Language? from(String? tag) {
  return L10n.languages.firstWhereOrNull((e) => e.locale.toString() == tag);
}
```




## Solution

Improve the constructor by searching through the language codes and country codes.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
