### PR TITLE
Pin `chromedriver` version to `114.0.5735.90` in `test E2E` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,10 @@ jobs:
       #
       # Use `grep` to remove the meaningless logs from the output.
       - uses: nanasess/setup-chromedriver@v1
+        with:
+          # TODO: Unpin when nanasess/setup-chromedriver#190 is fixed:
+          #       https://github.com/nanasess/setup-chromedriver/issues/190
+          chromedriver-version: '114.0.5735.90'
       - run: |
           chromedriver --port=4444 --enable-chrome-logs \
                        --disable-dev-shm-usage \


### PR DESCRIPTION
## Synopsis

`nanasess/setup-chromedriver` action throws 404:
```
##setup chromedriver
/home/runner/work/_actions/nanasess/setup-chromedriver/v1/lib/setup-chromedriver.sh  linux64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0   1[9](https://github.com/team113/messenger/actions/runs/5667596598/job/15356626973?pr=476#step:9:10)3    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
Error: The process '/home/runner/work/_actions/nanasess/setup-chromedriver/v1/lib/setup-chromedriver.sh' failed with exit code 22
```




## Solution

Since [fixing the error requires some work from mainainers](https://github.com/nanasess/setup-chromedriver/issues/175#issuecomment-1651173572), as `chromedriver 115+` uses a new download links, this PR just pins temporary the `chromedriver` version to the [latest available in the old download link style](https://chromedriver.chromium.org/downloads): `114.0.5735.90`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
