### PR TITLE
Add documentation, import and ordering rules to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,139 @@ All [Dart] source code must follow [Effective Dart] official recommendations, an
 Any rules described here are in priority if they have conflicts with [Effective Dart] recommendations.
 
 
+### Documentation
+
+__DO__ document your code. Documentation must follow [Effective Dart] official recommendations with the following exception:
+- prefer omitting leading `A`, `An` or `The` article.
+
+
+### Imports inside `/lib` directory
+
+__DO__ use absolute or relative imports within `/lib` directory.
+
+#### 🚫 Wrong
+```dart
+import '../../../../ui/widget/animated_button.dart'; // Too deep.
+import 'package:messenger/ui/widget/modal_popup.dart'; // `package:` import.
+```
+
+#### 👍 Correct
+```dart
+import '../animated_button.dart';
+import '/ui/widget/modal_popup.dart';
+import 'home/page/widget/animated_button.dart';
+import 'widget/animated_button.dart';
+```
+
+
+### Classes, constructors, fields and methods ordering
+
+__DO__ place constructors first in class, as stated in [Flutter style guidelines][3]:
+
+> This helps readers determine whether the class has a default implied constructor or not at a glance. If it was possible for a constructor to be anywhere in the class, then the reader would have to examine every line of the class to determine whether or not there was an implicit constructor or not.
+
+The methods, fields, getters, etc should sustain a consistent ordering to help read and understand code fluently. First rule is public first: when reading code someone else wrote, you usually interested in API you're working with: public classes, fields, methods, etc. Private counterparts are consider implementation-specific and should be moved lower in a file. Second rule is a recommendation towards ordering of constructors, methods, fields, etc, inside a class. The following order is suggested (notice the public/private rule being applied as well):
+1. Default constructor
+2. Named/other constructors
+3. Public fields
+4. Private fields
+5. Public getters/setters
+6. Private getters/setters
+7. Public methods
+8. Private methods
+
+#### 🚫 Wrong
+```dart
+class _ChatWatcher {
+    // ...
+}
+
+class Chat {
+    final ChatId id;
+    final ChatKind kind;
+
+    final Map<UserId, _ChatWatcher> _reads = {};
+
+    Chat.monolog(this.id) : kind = ChatKind.monolog;
+    Chat.dialog(this.id) : kind = ChatKind.dialog;
+    Chat.group(this.id) : kind = ChatKind.group;
+    Chat(this.id, this.kind);
+
+    void _ensureWatcher(UserId userId) {
+        // ...
+    }
+    
+    void dispose() {
+        // ...
+    }
+
+    bool isReadBy(UserId userId) {
+        // ...
+    }
+
+    bool get isMonolog => kind == ChatKind.monolog;
+    bool get isDialog => kind == ChatKind.dialog;
+    bool get isGroup => kind == ChatKind.group;
+}
+
+class ChatId {
+    // ...
+}
+
+enum ChatKind {
+    monolog,
+    dialog,
+    group,
+}
+```
+
+#### 👍 Correct
+```dart
+enum ChatKind {
+    monolog,
+    dialog,
+    group,
+}
+
+class Chat {
+    Chat(this.id, this.kind);
+
+    Chat.monolog(this.id) : kind = ChatKind.monolog;
+    Chat.dialog(this.id) : kind = ChatKind.dialog;
+    Chat.group(this.id) : kind = ChatKind.group;
+
+    final ChatId id;
+    final ChatKind kind;
+
+    final Map<UserId, _ChatWatcher> _reads = {};
+
+    bool get isMonolog => kind == ChatKind.monolog;
+    bool get isDialog => kind == ChatKind.dialog;
+    bool get isGroup => kind == ChatKind.group;
+
+    void dispose() {
+        // ...
+    }
+
+    bool isReadBy(UserId userId) {
+        // ...
+    }
+
+    void _ensureWatcher(UserId userId) {
+        // ...
+    }
+}
+
+class ChatId {
+    // ...
+}
+
+class _ChatWatcher {
+    // ...
+}
+```
+
+
 ### Explicit dependencies injection
 
 __DO__ pass all the dependencies of your class/service/etc needs via its constructor.
@@ -317,3 +450,4 @@ class UserBio {
 
 [1]: https://flutter.dev/docs/get-started/install
 [2]: https://api.flutter.dev/flutter/dart-ui/Locale/toLanguageTag.html
+[3]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#constructors-come-first-in-a-class


### PR DESCRIPTION
## Synopsis

`CONTRIBUTING.md` doesn't have some common rules built since it was first formed.




## Solution

Add the common rules to contrubution guide.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
