### PR TITLE
Cancel `keepOnline` when app is not active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,14 @@ All user visible changes to this project will be documented in this file. This p
     - Context menu with fading effect on desktop. ([#506])
     - Profile page:
         - Sections highlighting. ([#513], [#385])
+    - Display online status only when application is active. ([#522])
 
 [#385]: /../../issues/385
 [#439]: /../../issues/439
 [#492]: /../../pull/492
 [#506]: /../../pull/506
 [#513]: /../../pull/513
+[#522]: /../../pull/522
 
 
 

--- a/lib/store/my_user.dart
+++ b/lib/store/my_user.dart
@@ -116,8 +116,10 @@ class MyUserRepository implements AbstractMyUserRepository {
     if (await PlatformUtils.isActive) _initKeepOnlineSubscription();
 
     _onActivityChanged = PlatformUtils.onActivityChanged.listen((active) {
-      if (active && _keepOnlineSubscription == null) {
-        _initKeepOnlineSubscription();
+      if (active) {
+        if (_keepOnlineSubscription == null) {
+          _initKeepOnlineSubscription();
+        }
       } else {
         _keepOnlineSubscription?.cancel();
         _keepOnlineSubscription = null;

--- a/lib/store/my_user.dart
+++ b/lib/store/my_user.dart
@@ -113,7 +113,9 @@ class MyUserRepository implements AbstractMyUserRepository {
     _initRemoteSubscription();
     _initBlacklistSubscription();
 
-    if (await PlatformUtils.isActive) _initKeepOnlineSubscription();
+    if (await PlatformUtils.isActive) {
+      _initKeepOnlineSubscription();
+    }
 
     _onActivityChanged = PlatformUtils.onActivityChanged.listen((active) {
       if (active) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,7 +107,7 @@ dev_dependencies:
   gherkin: ^2.0.8
   hive_generator: ^2.0.0
   json_serializable: ^6.6.2
-  mockito: ^5.3.2
+  mockito: ^5.4.2
   sentry_dart_plugin: ^1.2.0
   yaml: ^3.1.2
 


### PR DESCRIPTION
## Synopsis

Сейчас пользователь отображается в онлайне всегда когда приложение запущено. Это не правильно, так как пользователь может отойти на долгое время от устройсква и все это время отображаться как оналйн.




## Solution

Пользователь будет отображаться в статусе онлайн, только когда приложение активно.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
