### PR TITLE
Refactor `GalleryPopup` to use `RetryImage` instead of `NetworkImage`s (#524)

### DIFF
--- a/lib/ui/page/home/widget/gallery_popup.dart
+++ b/lib/ui/page/home/widget/gallery_popup.dart
@@ -18,6 +18,7 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -322,6 +323,10 @@ class _GalleryPopupState extends State<GalleryPopup>
 
     Future.delayed(Duration.zero, _displayControls);
 
+    if (PlatformUtils.isMobile) {
+      BackButtonInterceptor.add(_onBack);
+    }
+
     super.initState();
   }
 
@@ -333,6 +338,11 @@ class _GalleryPopupState extends State<GalleryPopup>
     if (_isFullscreen.isTrue) {
       _exitFullscreen();
     }
+
+    if (PlatformUtils.isMobile) {
+      BackButtonInterceptor.remove(_onBack);
+    }
+
     super.dispose();
   }
 
@@ -1168,6 +1178,16 @@ class _GalleryPopupState extends State<GalleryPopup>
     _photo
       ..reset()
       ..forward();
+  }
+
+  /// Invokes [_dismiss].
+  ///
+  /// Intended to be used as a [BackButtonInterceptor] callback, thus returns
+  /// `true`, if back button should be intercepted, or otherwise returns
+  /// `false`.
+  bool _onBack(bool _, RouteInfo __) {
+    _dismiss();
+    return true;
   }
 }
 

--- a/lib/ui/page/home/widget/gallery_popup.dart
+++ b/lib/ui/page/home/widget/gallery_popup.dart
@@ -277,6 +277,9 @@ class _GalleryPopupState extends State<GalleryPopup>
   /// [PhotoViewController] for zooming [PhotoViewGallery] in and out.
   final PhotoViewController _photoController = PhotoViewController();
 
+  // TODO: This is a hack for a feature that should be implemented in
+  //       `photo_view` directly:
+  //       https://github.com/bluefireteam/photo_view/issues/425
   /// [AnimationController] animating the [_photoController] scaling in.
   late final AnimationController _photo = AnimationController(
     vsync: this,

--- a/lib/ui/page/home/widget/gallery_popup.dart
+++ b/lib/ui/page/home/widget/gallery_popup.dart
@@ -33,7 +33,6 @@ import '/ui/page/call/widget/conditional_backdrop.dart';
 import '/ui/page/call/widget/round_button.dart';
 import '/ui/page/home/page/chat/widget/video/video.dart';
 import '/ui/page/home/page/chat/widget/web_image/web_image.dart';
-import '/ui/page/home/widget/init_callback.dart';
 import '/ui/page/home/widget/retry_image.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
@@ -173,7 +172,32 @@ class _GalleryPopupState extends State<GalleryPopup>
     with TickerProviderStateMixin {
   /// [AnimationController] controlling the opening and closing gallery
   /// animation.
-  late final AnimationController _fading;
+  late final AnimationController _fading = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 250),
+    debugLabel: '$runtimeType',
+  )..addStatusListener(
+      (status) {
+        switch (status) {
+          case AnimationStatus.dismissed:
+            _curveOut = Curves.easeOutQuint;
+            _pageController.dispose();
+            _ignoreSnappingTimer?.cancel();
+            _sliding?.dispose();
+            _pop?.call();
+            break;
+
+          case AnimationStatus.reverse:
+          case AnimationStatus.forward:
+            // No-op.
+            break;
+
+          case AnimationStatus.completed:
+            _curveOut = Curves.easeInQuint;
+            break;
+        }
+      },
+    );
 
   /// [AnimationController] controlling the sliding upward or downward
   /// animation.
@@ -250,35 +274,24 @@ class _GalleryPopupState extends State<GalleryPopup>
   /// Indicator whether the currently visible [GalleryItem] is zoomed.
   bool _isZoomed = false;
 
+  /// [PhotoViewController] for zooming [PhotoViewGallery] in and out.
+  final PhotoViewController _photoController = PhotoViewController();
+
+  /// [AnimationController] animating the [_photoController] scaling in.
+  late final AnimationController _photo = AnimationController(
+    vsync: this,
+    debugLabel: '$runtimeType',
+    duration: const Duration(milliseconds: 200),
+  )..addListener(() {
+      _photoController.scale = 1 +
+          CurveTween(curve: Curves.ease).evaluate(_photo) * (_photoScale - 1);
+    });
+
+  /// Scale to apply the [_photoController] to during its [_photo] animation.
+  double _photoScale = 1;
+
   @override
   void initState() {
-    _fading = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 250),
-      debugLabel: '$runtimeType',
-    )..addStatusListener(
-        (status) {
-          switch (status) {
-            case AnimationStatus.dismissed:
-              _curveOut = Curves.easeOutQuint;
-              _pageController.dispose();
-              _ignoreSnappingTimer?.cancel();
-              _sliding?.dispose();
-              _pop?.call();
-              break;
-
-            case AnimationStatus.reverse:
-            case AnimationStatus.forward:
-              // No-op.
-              break;
-
-            case AnimationStatus.completed:
-              _curveOut = Curves.easeInQuint;
-              break;
-          }
-        },
-      );
-
     _bounds = _calculatePosition() ?? Rect.largest;
 
     _page = widget.initial;
@@ -311,6 +324,8 @@ class _GalleryPopupState extends State<GalleryPopup>
 
   @override
   void dispose() {
+    _photo.dispose();
+    _fading.dispose();
     _onFullscreen?.cancel();
     if (_isFullscreen.isTrue) {
       _exitFullscreen();
@@ -439,51 +454,63 @@ class _GalleryPopupState extends State<GalleryPopup>
           },
           wantKeepAlive: false,
           builder: (BuildContext context, int index) {
-            GalleryItem e = widget.children[index];
-
-            if (!e.isVideo) {
-              return PhotoViewGalleryPageOptions(
-                imageProvider: NetworkImage(e.link),
-                initialScale: PhotoViewComputedScale.contained * 0.99,
-                minScale: PhotoViewComputedScale.contained * 0.99,
-                maxScale: PhotoViewComputedScale.contained * 3,
-                errorBuilder: (_, __, ___) {
-                  return InitCallback(
-                    callback: e.onError,
-                    child: const SizedBox(
-                      height: 300,
-                      child: Center(child: CustomProgressIndicator()),
-                    ),
-                  );
-                },
-              );
-            }
+            final GalleryItem e = widget.children[index];
 
             return PhotoViewGalleryPageOptions.customChild(
+              controller: _photoController,
               disableGestures: e.isVideo,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 1),
-                child: VideoView(
-                  e.link,
-                  showInterfaceFor: _isInitialPage ? 3.seconds : null,
-                  onClose: _dismiss,
-                  isFullscreen: _isFullscreen,
-                  toggleFullscreen: () {
-                    node.requestFocus();
-                    _toggleFullscreen();
-                  },
-                  onController: (c) {
-                    if (c == null) {
-                      _videoControllers.remove(index);
-                    } else {
-                      _videoControllers[index] = c;
-                    }
-                  },
-                  onError: e.onError,
-                ),
-              ),
+              initialScale: PhotoViewComputedScale.contained,
               minScale: PhotoViewComputedScale.contained,
               maxScale: PhotoViewComputedScale.contained * 3,
+              scaleStateCycle: (s) {
+                switch (s) {
+                  case PhotoViewScaleState.initial:
+                    _animatePhotoScaleTo(
+                      (PhotoViewComputedScale.contained * 2).multiplier,
+                    );
+                    return PhotoViewScaleState.zoomedIn;
+
+                  case PhotoViewScaleState.covering:
+                    return PhotoViewScaleState.covering;
+
+                  case PhotoViewScaleState.originalSize:
+                    return PhotoViewScaleState.initial;
+
+                  case PhotoViewScaleState.zoomedIn:
+                  case PhotoViewScaleState.zoomedOut:
+                    return PhotoViewScaleState.initial;
+
+                  default:
+                    return PhotoViewScaleState.initial;
+                }
+              },
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 1),
+                child: e.isVideo
+                    ? VideoView(
+                        e.link,
+                        showInterfaceFor: _isInitialPage ? 3.seconds : null,
+                        onClose: _dismiss,
+                        isFullscreen: _isFullscreen,
+                        toggleFullscreen: () {
+                          node.requestFocus();
+                          _toggleFullscreen();
+                        },
+                        onController: (c) {
+                          if (c == null) {
+                            _videoControllers.remove(index);
+                          } else {
+                            _videoControllers[index] = c;
+                          }
+                        },
+                        onError: e.onError,
+                      )
+                    : RetryImage(
+                        e.link,
+                        checksum: e.checksum,
+                        onForbidden: e.onError,
+                      ),
+              ),
             );
           },
           itemCount: widget.children.length,
@@ -1129,6 +1156,15 @@ class _GalleryPopupState extends State<GalleryPopup>
         setState(() => _showControls = false);
       }
     });
+  }
+
+  /// Animates the [_photoController] to the provided [scale] by starting the
+  /// [_photo] animation.
+  void _animatePhotoScaleTo(double scale) {
+    _photoScale = scale;
+    _photo
+      ..reset()
+      ..forward();
   }
 }
 


### PR DESCRIPTION
Resolves #524




## Synopsis

Mobile platforms use `NetworkImage`s, so no caching in `GalleryPopup`s.




## Solution

This PR refactors `GalleryPopup` to use `RetryImage`s via `customChild`. It fixes double tap to zoom bug via seperate `AnimationController`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
