### PR TITLE
Use `ImageFile` width and height in `MediaAttachment`s (#525)

### DIFF
--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -37,6 +37,7 @@ import '/domain/model/chat_info.dart';
 import '/domain/model/chat_item.dart';
 import '/domain/model/chat_item_quote.dart';
 import '/domain/model/chat_item_quote_input.dart';
+import '/domain/model/file.dart';
 import '/domain/model/my_user.dart';
 import '/domain/model/precise_date_time/precise_date_time.dart';
 import '/domain/model/sending_status.dart';
@@ -222,15 +223,48 @@ class ChatItemWidget extends StatefulWidget {
         ],
       );
     } else {
-      attachment = MediaAttachment(
-        key: key,
-        attachment: e,
-        height: 300,
-        width: filled ? double.infinity : null,
-        fit: BoxFit.cover,
-        autoLoad: autoLoad,
-        onError: onError,
-      );
+      if (!filled && e is ImageAttachment) {
+        final ImageFile file = e.original as ImageFile;
+
+        double width = double.infinity;
+        double height = 300;
+
+        if (file.width != null && file.height != null) {
+          width = file.width!.toDouble();
+          height = file.height!.toDouble();
+
+          final double aspect = width / height;
+
+          final double ratio = height / min(height, 300);
+          height = min(height, 300);
+          width = (file.width! * aspect) / ratio;
+        }
+
+        attachment = Stack(
+          children: [
+            MediaAttachment(
+              key: key,
+              attachment: e,
+              height: height,
+              width: width,
+              fit: BoxFit.cover,
+              autoLoad: autoLoad,
+              onError: onError,
+            ),
+            Text('$width $height'),
+          ],
+        );
+      } else {
+        attachment = MediaAttachment(
+          key: key,
+          attachment: e,
+          height: 300,
+          width: filled ? double.infinity : null,
+          fit: BoxFit.cover,
+          autoLoad: autoLoad,
+          onError: onError,
+        );
+      }
 
       if (!isLocal) {
         attachment = KeyedSubtree(
@@ -284,9 +318,9 @@ class ChatItemWidget extends StatefulWidget {
                     : Container(
                         constraints: filled
                             ? const BoxConstraints(
-                                minWidth: 300,
-                                minHeight: 300,
-                              )
+                                // minWidth: 300,
+                                // minHeight: 300,
+                                )
                             : null,
                         child: e.status.value == SendingStatus.sending
                             ? SizedBox(


### PR DESCRIPTION
Resolves #525




## Synopsis

`MediaAttachment`s ignore width and height of `ImageFile`.




## Solution

Perhaps a `ChatItemWidget` should manipulate the width and height of `MediaAttachment`s, since only it knows its layout (whether `MediaAttachment` is within a `FitView`).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
