### PR TITLE
Fix monolog e2e timeout exception (#514)

### DIFF
--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -249,7 +249,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (Config.disableInfiniteAnimations)
+                    if (Config.disableInfiniteAnimations) 
                       SpinKitDoubleBounce(
                         color: style.colors.secondaryHighlightDark,
                         size: 100 / 1.5,
@@ -267,7 +267,7 @@ Widget desktopCall(CallController c, BuildContext context) {
           );
 
           return AnimatedOpacity(
-            opacity: !c.connectionLost.isTrue ? 1 : 0,
+            opacity: c.connectionLost.isTrue ? 1 : 0,
             duration: 200.milliseconds,
             child: child,
           );

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -249,7 +249,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (Config.disableInfiniteAnimations)
+                    if (!Config.disableInfiniteAnimations)
                       SpinKitDoubleBounce(
                         color: style.colors.secondaryHighlightDark,
                         size: 100 / 1.5,

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -249,13 +249,12 @@ Widget desktopCall(CallController c, BuildContext context) {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Config.disableInfiniteAnimations
-                        ? const SizedBox()
-                        : SpinKitDoubleBounce(
-                            color: style.colors.secondaryHighlightDark,
-                            size: 100 / 1.5,
-                            duration: const Duration(milliseconds: 4500),
-                          ),
+                    if (Config.disableInfiniteAnimations)
+                      SpinKitDoubleBounce(
+                        color: style.colors.secondaryHighlightDark,
+                        size: 100 / 1.5,
+                        duration: const Duration(milliseconds: 4500),
+                      ),
                     const SizedBox(height: 16),
                     Text(
                       'label_reconnecting_ellipsis'.l10n,
@@ -268,7 +267,7 @@ Widget desktopCall(CallController c, BuildContext context) {
           );
 
           return AnimatedOpacity(
-            opacity: c.connectionLost.isTrue ? 1 : 0,
+            opacity: !c.connectionLost.isTrue ? 1 : 0,
             duration: 200.milliseconds,
             child: child,
           );

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -249,11 +249,13 @@ Widget desktopCall(CallController c, BuildContext context) {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    SpinKitDoubleBounce(
-                      color: style.colors.secondaryHighlightDark,
-                      size: 100 / 1.5,
-                      duration: const Duration(milliseconds: 4500),
-                    ),
+                    Config.disableInfiniteAnimations
+                        ? const SizedBox()
+                        : SpinKitDoubleBounce(
+                            color: style.colors.secondaryHighlightDark,
+                            size: 100 / 1.5,
+                            duration: const Duration(milliseconds: 4500),
+                          ),
                     const SizedBox(height: 16),
                     Text(
                       'label_reconnecting_ellipsis'.l10n,
@@ -265,12 +267,8 @@ Widget desktopCall(CallController c, BuildContext context) {
             ),
           );
 
-          final bool connectionLost = c.connectionLost.isTrue;
-
-          if (Config.disableInfiniteAnimations) return const SizedBox();
-
           return AnimatedOpacity(
-            opacity: connectionLost ? 1 : 0,
+            opacity: c.connectionLost.isTrue ? 1 : 0,
             duration: 200.milliseconds,
             child: child,
           );

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -249,7 +249,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (Config.disableInfiniteAnimations) 
+                    if (Config.disableInfiniteAnimations)
                       SpinKitDoubleBounce(
                         color: style.colors.secondaryHighlightDark,
                         size: 100 / 1.5,

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -39,6 +39,7 @@ import '../widget/reorderable_fit.dart';
 import '../widget/scaler.dart';
 import '../widget/tooltip_button.dart';
 import '../widget/video_view.dart';
+import '/config.dart';
 import '/domain/model/avatar.dart';
 import '/domain/model/chat.dart';
 import '/domain/model/ongoing_call.dart';
@@ -264,8 +265,12 @@ Widget desktopCall(CallController c, BuildContext context) {
             ),
           );
 
+          final bool connectionLost = c.connectionLost.isTrue;
+
+          if (Config.disableInfiniteAnimations) return const SizedBox();
+
           return AnimatedOpacity(
-            opacity: c.connectionLost.isTrue ? 1 : 0,
+            opacity: connectionLost ? 1 : 0,
             duration: 200.milliseconds,
             child: child,
           );

--- a/lib/ui/page/popup_call/view.dart
+++ b/lib/ui/page/popup_call/view.dart
@@ -63,7 +63,7 @@ class _PopupCallViewState extends State<PopupCallView> {
 
   @override
   Widget build(BuildContext context) {
-    if (_deps == null && !Config.disableInfiniteAnimations) {
+    if (_deps == null) {
       return const Scaffold(body: Center(child: CustomProgressIndicator()));
     }
 

--- a/lib/ui/page/popup_call/view.dart
+++ b/lib/ui/page/popup_call/view.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../call/view.dart';
+import '/config.dart';
 import '/domain/model/chat.dart';
 import '/routes.dart';
 import '/ui/widget/progress_indicator.dart';
@@ -62,7 +63,7 @@ class _PopupCallViewState extends State<PopupCallView> {
 
   @override
   Widget build(BuildContext context) {
-    if (_deps == null) {
+    if (_deps == null && !Config.disableInfiniteAnimations) {
       return const Scaffold(body: Center(child: CustomProgressIndicator()));
     }
 

--- a/lib/ui/page/popup_call/view.dart
+++ b/lib/ui/page/popup_call/view.dart
@@ -19,7 +19,6 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../call/view.dart';
-import '/config.dart';
 import '/domain/model/chat.dart';
 import '/routes.dart';
 import '/ui/widget/progress_indicator.dart';

--- a/web/index.html
+++ b/web/index.html
@@ -40,6 +40,9 @@
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Messenger.">
 
+  <!-- Fixes the invalid HTML loader scaling -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
Resolves #514 
## Synopsis
Иногда на степе `When I tap AudioCall button` прилетает таймаут.
## Solution
Добавил `disableInfiniteAnimations` в местах, где анимация не дает пройти тест.

Протестировал с `Future.delayed (Duration(seconds: 2)` перед `waitForAppToSettle()`:
- без изменений `Timeout Exception`
- после добавления `disableInfiniteAnimations` тест проходит без проблем
## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
