### PR TITLE
Cover `MyProfile` with e2e tests (#111)

### DIFF
--- a/assets/conf.toml
+++ b/assets/conf.toml
@@ -2,7 +2,7 @@
 # Indicator whether remote configuration should be respected, if available.
 #
 # Default:
-#   remote = true
+  remote = false
 
 [server.http]
 # URL address of HTTP backend server.
@@ -10,19 +10,19 @@
 # Unused for web, browser location is used instead.
 #
 # Default:
-#   url = "http://localhost"
+  url = "https://messenger.soc.stg.t11913.org"
 
 # Port of HTTP backend server.
 #
 # Unused for web, browser location is used instead.
 #
 # Default:
-#   port = 80
+   port = 443
 
 # GraphQL API endpoint of HTTP backend server.
 #
 # Default:
-#   graphql = "/api/graphql"
+   graphql = "/api/graphql"
 
 [server.ws]
 # URL address of WebSocket backend server.
@@ -30,26 +30,26 @@
 # Unused for web, browser location is used instead.
 #
 # Default:
-#   url = "ws://localhost"
+   url = "wss://messenger.soc.stg.t11913.org"
 
 # Port of WebSocket backend server.
 #
 # Unused for web, browser location is used instead.
 #
 # Default:
-#   port = 80
+   port = 443
 
 [files]
 # URL address of file storage server.
 #
 # Default:
-#   url = "http://localhost/files"
+   url = "https://messenger.soc.stg.t11913.org/files"
 
 [sentry]
 # Sentry DSN (Data Source Name) to send events to.
 #
 # Default:
-#   dsn = ""
+   dsn = ""
 
 [downloads]
 # Directory to download files to.
@@ -59,7 +59,7 @@
 # Unused for Web, as browser picks the directory itself.
 #
 # Default:
-#   directory = ""
+   directory = ""
 
 [user.agent]
 # Product identifier of `User-Agent` header to put in network queries.
@@ -67,7 +67,7 @@
 # Unused for Web, as browser picks the `User-Agent` itself.
 #
 # Default:
-#   product = "Gapopa"
+   product = "Gapopa"
 
 # Product version of `User-Agent` header to put in network queries.
 #
@@ -76,10 +76,10 @@
 # Unused for Web, as browser picks the `User-Agent` itself.
 #
 # Default:
-#   version = "$(git describe --tags --dirty)"
+   version = "$(git describe --tags --dirty)"
 
 [windows]
 # Unique identifier of Windows application.
 #
 # Default:
-#   clsid = "00000000-0000-0000-0000-000000000000"
+   clsid = "00000000-0000-0000-0000-000000000000"

--- a/lib/ui/page/home/page/my_profile/widget/background_preview.dart
+++ b/lib/ui/page/home/page/my_profile/widget/background_preview.dart
@@ -112,6 +112,9 @@ class BackgroundPreview extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 WidgetButton(
+                  key: background == null
+                      ? const Key('UploadBackground')
+                      : const Key('DeleteBackground'),
                   onPressed: background == null ? onPick : onRemove,
                   child: Text(
                     background == null ? 'btn_upload'.l10n : 'btn_delete'.l10n,

--- a/lib/ui/page/home/tab/menu/view.dart
+++ b/lib/ui/page/home/tab/menu/view.dart
@@ -202,6 +202,7 @@ class MenuTabView extends StatelessWidget {
 
                   case ProfileTab.background:
                     child = card(
+                      key: const Key('Background'),
                       icon: Icons.image,
                       title: 'label_background'.l10n,
                       subtitle: 'label_app_background'.l10n,

--- a/test/e2e/configuration.dart
+++ b/test/e2e/configuration.dart
@@ -100,6 +100,7 @@ import 'steps/tap_text.dart';
 import 'steps/tap_widget.dart';
 import 'steps/text_field.dart';
 import 'steps/update_avatar.dart';
+import 'steps/update_background.dart';
 import 'steps/updates_name.dart';
 import 'steps/users.dart';
 import 'steps/wait_to_settle.dart';
@@ -198,6 +199,7 @@ final FlutterTestConfiguration gherkinTestConfiguration =
         untilTextExists,
         untilTextExistsWithin,
         updateAvatar,
+        updateBackground,
         updateName,
         user,
         waitForAppToSettle,

--- a/test/e2e/features/profile/background/.feature
+++ b/test/e2e/features/profile/background/.feature
@@ -1,0 +1,32 @@
+# Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
+#                       <https://github.com/team113>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0 as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+# more details.
+#
+# You should have received a copy of the GNU Affero General Public License v3.0
+# along with this program. If not, see
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+Feature: Update background
+
+  Scenario: User sets and deletes background
+    Given I am Alice
+    And I wait until `HomeView` is present
+    
+    When I tap `MenuButton` button
+    And I tap `Background` button
+    And I update my background with "test.jpg"
+    Then I wait until `DeleteBackground` is present
+
+    When I tap `DeleteBackground` button
+    Then I wait until `UploadBackground` is present
+    
+   

--- a/test/e2e/parameters/keys.dart
+++ b/test/e2e/parameters/keys.dart
@@ -29,6 +29,7 @@ enum WidgetKey {
   Approve,
   AudioCall,
   AuthView,
+  Background,
   Block,
   ChangeAvatar,
   ChangeLanguage,
@@ -61,6 +62,7 @@ enum WidgetKey {
   Delete,
   DeleteAccount,
   DeleteAvatar,
+  DeleteBackground,
   DeleteChats,
   DeleteContacts,
   DeleteEmail,
@@ -138,6 +140,7 @@ enum WidgetKey {
   UnmuteChatsButton,
   Unmuted,
   Unselected,
+  UploadBackground,
   UserScrollable,
   UsernameField,
 }

--- a/test/e2e/steps/update_background.dart
+++ b/test/e2e/steps/update_background.dart
@@ -1,0 +1,48 @@
+// Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:convert';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:get/get.dart';
+import 'package:gherkin/gherkin.dart';
+import 'package:messenger/domain/repository/settings.dart';
+
+import '../world/custom_world.dart';
+
+/// Uploads a new image for background in the currently opened.
+///
+/// Examples:
+/// - Then I update my background with "test.jpg"
+final StepDefinitionGeneric updateBackground = then1<String, CustomWorld>(
+  'I update my background with {string}',
+  (fileName, context) async {
+    final AbstractSettingsRepository settingsRepo = Get.find();
+
+    final PlatformFile image = PlatformFile(
+      name: fileName,
+      size: 2,
+      bytes: base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+      ),
+    );
+
+    await settingsRepo.setBackground(image.bytes);
+  },
+  configuration: StepDefinitionConfiguration()
+    ..timeout = const Duration(minutes: 5),
+);


### PR DESCRIPTION
Resolves #111

## Synopsis

`MyProfile` не покрыт полностью тестами.


## Solution

Покрыть `MyProgile` тестами:

- [ ]  1. Тест на установление/обновление/удаления имя, статуса присутствия и обычного статуса.
- [ ]  2. Тест на ввод некорректного логина.
- [ ]  3. Тест на генерацию прямой ссылки, установление, обновление и переход по ней.
- [ ]  4. Тест на загрузку бэкграунда с устройства и удаление бэкграунда.
- [ ]  5. Тест на медиа: выбрать камеру, микрофон, устройство аудио вывода
- [ ]  6. Тест на включение/выключение загрузки изображений и проверить в чате.
- [ ]  7. Тест на разблокировку пользователей.
- [ ]  8. Тест на скачку приложения под платформы windows/macos,linux,ios,android.
- [ ]  9. Тест на включение/выключение звуковых уведомлений.	




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
