### PR TITLE
Fix ContextMenu called twice longpressing on element (#508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,18 @@ All user visible changes to this project will be documented in this file. This p
 
 - Mobile:
     - Back camera being mirrored. ([#301], [#70])
+- UI:
+    - Chats tab:
+        - Context menu appearing twice when long pressing dots. ([#599], [#508])
 
 [#70]: /../../issues/70
 [#301]: /../../pull/301
 [#370]: /../../issues/370
 [#423]: /../../pull/423
+[#508]: /../../issues/508
 [#587]: /../../pull/587
 [#597]: /../../pull/597
+[#599]: /../../pull/599
 
 
 

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -316,6 +316,7 @@ class ChatsTabView extends StatelessWidget {
                               alignment: Alignment.topRight,
                               enablePrimaryTap: true,
                               enableSecondaryTap: false,
+                              enableLongTap: false,
                               margin:
                                   const EdgeInsets.only(bottom: 4, right: 0),
                               actions: [

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -190,6 +190,7 @@ class ContactsTabView extends StatelessWidget {
                         key: const Key('ContactsMenu'),
                         alignment: Alignment.topRight,
                         enablePrimaryTap: true,
+                        enableLongTap: false,
                         enableSecondaryTap: false,
                         selector: c.moreKey,
                         margin: const EdgeInsets.only(bottom: 4, right: 0),

--- a/lib/ui/page/home/tab/menu/view.dart
+++ b/lib/ui/page/home/tab/menu/view.dart
@@ -52,6 +52,7 @@ class MenuTabView extends StatelessWidget {
               alignment: Alignment.topLeft,
               margin: const EdgeInsets.only(top: 7, right: 32),
               enablePrimaryTap: true,
+              enableLongTap: false,
               actions: [
                 ContextMenuButton(
                   label: 'label_presence_present'.l10n,

--- a/lib/ui/widget/context_menu/region.dart
+++ b/lib/ui/widget/context_menu/region.dart
@@ -218,11 +218,20 @@ class _ContextMenuRegionState extends State<ContextMenuRegion> {
   Future<void> _show(BuildContext context, Offset position) async {
     final style = Theme.of(context).style;
 
-    if (widget.actions.isEmpty) {
+    if (_displayed || widget.actions.isEmpty) {
       return;
     }
 
     HapticFeedback.lightImpact();
+
+    _displayed = true;
+    if (widget.indicateOpenedMenu) {
+      _darkened = true;
+    }
+
+    if (mounted) {
+      setState(() {});
+    }
 
     if (widget.selector != null) {
       await Selector.show<ContextMenuItem>(
@@ -262,16 +271,15 @@ class _ContextMenuRegionState extends State<ContextMenuRegion> {
         buttonKey: widget.selector,
         alignment: Alignment(-widget.alignment.x, -widget.alignment.y),
       );
-    } else {
-      _displayed = true;
-      if (widget.indicateOpenedMenu) {
-        _darkened = true;
-      }
 
+      _displayed = false;
+      if (widget.indicateOpenedMenu) {
+        _darkened = false;
+      }
       if (mounted) {
         setState(() {});
       }
-
+    } else {
       _entry = OverlayEntry(builder: (_) {
         return Listener(
           onPointerUp: (d) {


### PR DESCRIPTION
Resolves #508 




## Synopsis

В трех местах контекстное меню вызывается два раза при долгом нажатии




## Solution

Добавил enableLongTap : false




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
