### PR TITLE
Fix `Hive` races around `Box.close` (#598)

### DIFF
--- a/lib/provider/hive/base.dart
+++ b/lib/provider/hive/base.dart
@@ -98,12 +98,14 @@ abstract class HiveBaseProvider<T> extends DisposableInterface {
 
   /// Removes all entries from the [Box].
   @mustCallSuper
-  Future<void> clear() {
-    return _mutex.protect(() async {
+  Future<void> clear() async {
+    //return _mutex.protect(() async {
       if (_isReady && _box.isOpen) {
+        print('clear start');
         await box.clear();
+        print('clear end');
       }
-    });
+    //});
   }
 
   /// Closes the [Box].
@@ -114,7 +116,9 @@ abstract class HiveBaseProvider<T> extends DisposableInterface {
         _isReady = false;
 
         try {
+          print('close start');
           await _box.close();
+          print('close end');
         } on FileSystemException {
           // No-op.
         }
@@ -129,32 +133,38 @@ abstract class HiveBaseProvider<T> extends DisposableInterface {
   }
 
   /// Exception-safe wrapper for [BoxBase.put] saving the [key] - [value] pair.
-  Future<void> putSafe(dynamic key, T value) {
-    return _mutex.protect(() async {
+  Future<void> putSafe(dynamic key, T value) async {
+    //return _mutex.protect(() async {
       if (_isReady && _box.isOpen) {
+        print('putSafe start');
         await _box.put(key, value);
+        print('putSafe end');
       }
-    });
+    //});
   }
 
   /// Exception-safe wrapper for [Box.get] returning the value associated with
   /// the given [key], if any.
   T? getSafe(dynamic key, {T? defaultValue}) {
     if (_isReady && _box.isOpen) {
-      return box.get(key, defaultValue: defaultValue);
+      print('getSafe start');
+      var t = box.get(key, defaultValue: defaultValue);
+      print('getSafe end');
+      return t;
     }
     return null;
   }
 
   /// Exception-safe wrapper for [BoxBase.delete] deleting the given [key] from
   /// the [box].
-  Future<void> deleteSafe(dynamic key, {T? defaultValue}) {
-    return _mutex.protect(() async {
+  Future<void> deleteSafe(dynamic key, {T? defaultValue}) async {
+    //return _mutex.protect(() async {
       if (_isReady && _box.isOpen) {
+        print('deleteSafe start');
         await _box.delete(key);
+        print('deleteSafe end');
       }
-      return Future.value();
-    });
+    //});
   }
 }
 


### PR DESCRIPTION
Resolves #598




## Synopsis

Иногда `Hive.close` может вызваться перед `Hive.put`, который под капотом является асинхронной операцией, `await`ить которую не хочется. Отсюда может стрельнуть `box already closed` ошибка.




## Solution

Будут исследованы другие способы устранения данной ошибки.




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
