### PR TITLE
Fix `AnimatedSwitcher`s throwing `Duplicate keys found` (#386)

### DIFF
--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -54,6 +54,7 @@ import '/routes.dart';
 import '/themes.dart';
 import '/ui/page/home/widget/animated_slider.dart';
 import '/ui/widget/animated_delayed_switcher.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
 import '/ui/widget/svg/svg.dart';
@@ -186,7 +187,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                             }
                           }
 
-                          return AnimatedSwitcher(
+                          return DefaultAnimatedSwitcher(
                             duration: 400.milliseconds,
                             child: child,
                           );
@@ -237,7 +238,10 @@ Widget desktopCall(CallController c, BuildContext context) {
             );
           }
 
-          return AnimatedSwitcher(duration: 200.milliseconds, child: child);
+          return DefaultAnimatedSwitcher(
+            duration: 200.milliseconds,
+            child: child,
+          );
         }),
 
         // Reconnection indicator.
@@ -322,7 +326,7 @@ Widget desktopCall(CallController c, BuildContext context) {
             130,
           );
 
-          return AnimatedSwitcher(
+          return DefaultAnimatedSwitcher(
             key: const Key('SecondaryTargetAnimatedSwitcher'),
             duration: 200.milliseconds,
             child: c.secondary.isEmpty && c.doughDraggedRenderer.value != null
@@ -523,7 +527,7 @@ Widget desktopCall(CallController c, BuildContext context) {
 
         // Display the more hint, if not dismissed.
         Obx(() {
-          return AnimatedSwitcher(
+          return DefaultAnimatedSwitcher(
             duration: 150.milliseconds,
             child: c.showDragAndDropButtonsHint && c.displayMore.value
                 ? Align(
@@ -564,7 +568,7 @@ Widget desktopCall(CallController c, BuildContext context) {
         IgnorePointer(
           child: Obx(() {
             bool preferTitle = c.state.value != OngoingCallState.active;
-            return AnimatedSwitcher(
+            return DefaultAnimatedSwitcher(
               duration: const Duration(milliseconds: 300),
               child: preferTitle &&
                       c.primary
@@ -600,7 +604,7 @@ Widget desktopCall(CallController c, BuildContext context) {
           final bool preferTitle =
               c.state.value != OngoingCallState.active && !isOutgoing;
 
-          return AnimatedSwitcher(
+          return DefaultAnimatedSwitcher(
             key: const Key('AnimatedSwitcherCallTitle'),
             duration: const Duration(milliseconds: 200),
             child: preferTitle
@@ -749,7 +753,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                   (c.focused.isEmpty &&
                       c.primary.length + c.secondary.length > 1));
 
-          return AnimatedSwitcher(
+          return DefaultAnimatedSwitcher(
             duration: 150.milliseconds,
             child: c.showDragAndDropVideosHint && mayDragVideo
                 ? Padding(
@@ -1706,7 +1710,7 @@ Widget _secondaryView(CallController c, BuildContext context) {
                     c.hoveredRenderer.value = null;
                     c.isCursorHidden.value = false;
                   },
-                  child: AnimatedSwitcher(
+                  child: DefaultAnimatedSwitcher(
                     duration: 200.milliseconds,
                     child: c.draggedRenderer.value == data.participant
                         ? Container()
@@ -1946,7 +1950,7 @@ Widget _secondaryView(CallController c, BuildContext context) {
                 width: width,
                 height: height,
                 child: Obx(() {
-                  return AnimatedSwitcher(
+                  return DefaultAnimatedSwitcher(
                     duration: 200.milliseconds,
                     child: c.primaryDrags.value != 0 &&
                             c.secondaryTargets.value != 0

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -187,7 +187,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                             }
                           }
 
-                          return DefaultAnimatedSwitcher(
+                          return SafeAnimatedSwitcher(
                             duration: 400.milliseconds,
                             child: child,
                           );
@@ -238,10 +238,7 @@ Widget desktopCall(CallController c, BuildContext context) {
             );
           }
 
-          return DefaultAnimatedSwitcher(
-            duration: 200.milliseconds,
-            child: child,
-          );
+          return SafeAnimatedSwitcher(duration: 200.milliseconds, child: child);
         }),
 
         // Reconnection indicator.
@@ -326,7 +323,7 @@ Widget desktopCall(CallController c, BuildContext context) {
             130,
           );
 
-          return DefaultAnimatedSwitcher(
+          return SafeAnimatedSwitcher(
             key: const Key('SecondaryTargetAnimatedSwitcher'),
             duration: 200.milliseconds,
             child: c.secondary.isEmpty && c.doughDraggedRenderer.value != null
@@ -527,7 +524,7 @@ Widget desktopCall(CallController c, BuildContext context) {
 
         // Display the more hint, if not dismissed.
         Obx(() {
-          return DefaultAnimatedSwitcher(
+          return SafeAnimatedSwitcher(
             duration: 150.milliseconds,
             child: c.showDragAndDropButtonsHint && c.displayMore.value
                 ? Align(
@@ -568,7 +565,7 @@ Widget desktopCall(CallController c, BuildContext context) {
         IgnorePointer(
           child: Obx(() {
             bool preferTitle = c.state.value != OngoingCallState.active;
-            return DefaultAnimatedSwitcher(
+            return SafeAnimatedSwitcher(
               duration: const Duration(milliseconds: 300),
               child: preferTitle &&
                       c.primary
@@ -604,7 +601,7 @@ Widget desktopCall(CallController c, BuildContext context) {
           final bool preferTitle =
               c.state.value != OngoingCallState.active && !isOutgoing;
 
-          return DefaultAnimatedSwitcher(
+          return SafeAnimatedSwitcher(
             key: const Key('AnimatedSwitcherCallTitle'),
             duration: const Duration(milliseconds: 200),
             child: preferTitle
@@ -753,7 +750,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                   (c.focused.isEmpty &&
                       c.primary.length + c.secondary.length > 1));
 
-          return DefaultAnimatedSwitcher(
+          return SafeAnimatedSwitcher(
             duration: 150.milliseconds,
             child: c.showDragAndDropVideosHint && mayDragVideo
                 ? Padding(
@@ -1710,7 +1707,7 @@ Widget _secondaryView(CallController c, BuildContext context) {
                     c.hoveredRenderer.value = null;
                     c.isCursorHidden.value = false;
                   },
-                  child: DefaultAnimatedSwitcher(
+                  child: SafeAnimatedSwitcher(
                     duration: 200.milliseconds,
                     child: c.draggedRenderer.value == data.participant
                         ? Container()
@@ -1950,7 +1947,7 @@ Widget _secondaryView(CallController c, BuildContext context) {
                 width: width,
                 height: height,
                 child: Obx(() {
-                  return DefaultAnimatedSwitcher(
+                  return SafeAnimatedSwitcher(
                     duration: 200.milliseconds,
                     child: c.primaryDrags.value != 0 &&
                             c.secondaryTargets.value != 0

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -46,6 +46,7 @@ import '/l10n/l10n.dart';
 import '/themes.dart';
 import '/ui/page/home/widget/animated_slider.dart';
 import '/ui/page/home/widget/gallery_popup.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
 import '/ui/widget/svg/svg.dart';
@@ -271,7 +272,10 @@ Widget mobileCall(CallController c, BuildContext context) {
                 );
               }
 
-              return AnimatedSwitcher(duration: 200.milliseconds, child: child);
+              return DefaultAnimatedSwitcher(
+                duration: 200.milliseconds,
+                child: child,
+              );
             }),
 
             if (isOutgoing)
@@ -332,7 +336,7 @@ Widget mobileCall(CallController c, BuildContext context) {
       // Dimmed container if any video is displayed while calling.
       Obx(() {
         return IgnorePointer(
-          child: AnimatedSwitcher(
+          child: DefaultAnimatedSwitcher(
             duration: const Duration(milliseconds: 300),
             child: (c.state.value != OngoingCallState.active &&
                     c.state.value != OngoingCallState.joining &&
@@ -544,7 +548,7 @@ Widget mobileCall(CallController c, BuildContext context) {
           ];
         }
 
-        return AnimatedSwitcher(
+        return DefaultAnimatedSwitcher(
           duration: const Duration(milliseconds: 400),
           child: c.state.value == OngoingCallState.active ||
                   c.state.value == OngoingCallState.joining

--- a/lib/ui/page/call/component/mobile.dart
+++ b/lib/ui/page/call/component/mobile.dart
@@ -272,7 +272,7 @@ Widget mobileCall(CallController c, BuildContext context) {
                 );
               }
 
-              return DefaultAnimatedSwitcher(
+              return SafeAnimatedSwitcher(
                 duration: 200.milliseconds,
                 child: child,
               );
@@ -336,7 +336,7 @@ Widget mobileCall(CallController c, BuildContext context) {
       // Dimmed container if any video is displayed while calling.
       Obx(() {
         return IgnorePointer(
-          child: DefaultAnimatedSwitcher(
+          child: SafeAnimatedSwitcher(
             duration: const Duration(milliseconds: 300),
             child: (c.state.value != OngoingCallState.active &&
                     c.state.value != OngoingCallState.joining &&
@@ -548,7 +548,7 @@ Widget mobileCall(CallController c, BuildContext context) {
           ];
         }
 
-        return DefaultAnimatedSwitcher(
+        return SafeAnimatedSwitcher(
           duration: const Duration(milliseconds: 400),
           child: c.state.value == OngoingCallState.active ||
                   c.state.value == OngoingCallState.joining

--- a/lib/ui/page/call/widget/participant/overlay.dart
+++ b/lib/ui/page/call/widget/participant/overlay.dart
@@ -231,7 +231,7 @@ class ParticipantOverlayWidget extends StatelessWidget {
               alignment: Alignment.bottomLeft,
               child: Padding(
                 padding: const EdgeInsets.only(bottom: 8, left: 8),
-                child: DefaultAnimatedSwitcher(
+                child: SafeAnimatedSwitcher(
                   duration: const Duration(milliseconds: 150),
                   child: child,
                 ),

--- a/lib/ui/page/call/widget/participant/overlay.dart
+++ b/lib/ui/page/call/widget/participant/overlay.dart
@@ -24,6 +24,7 @@ import '../conditional_backdrop.dart';
 import '/domain/model/ongoing_call.dart';
 import '/l10n/l10n.dart';
 import '/themes.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/svg/svg.dart';
 
 /// [Participant] overlay displaying its `muted` and `video status` icons.
@@ -230,15 +231,8 @@ class ParticipantOverlayWidget extends StatelessWidget {
               alignment: Alignment.bottomLeft,
               child: Padding(
                 padding: const EdgeInsets.only(bottom: 8, left: 8),
-                child: AnimatedSwitcher(
+                child: DefaultAnimatedSwitcher(
                   duration: const Duration(milliseconds: 150),
-                  layoutBuilder: (current, previous) => Stack(
-                    alignment: Alignment.center,
-                    children: [
-                      if (previous.isNotEmpty) previous.first,
-                      if (current != null) current,
-                    ],
-                  ),
                   child: child,
                 ),
               ),

--- a/lib/ui/page/call/widget/participant/widget.dart
+++ b/lib/ui/page/call/widget/participant/widget.dart
@@ -26,6 +26,7 @@ import '../video_view.dart';
 import '/config.dart';
 import '/domain/model/ongoing_call.dart';
 import '/themes.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/progress_indicator.dart';
 
 /// [Participant] visual representation.
@@ -88,18 +89,11 @@ class ParticipantWidget extends StatelessWidget {
       return Stack(
         children: [
           if (!hasVideo) ...background(),
-          AnimatedSwitcher(
+          DefaultAnimatedSwitcher(
             key: const Key('AnimatedSwitcher'),
             duration: animate
                 ? const Duration(milliseconds: 200)
                 : const Duration(seconds: 1),
-            layoutBuilder: (current, previous) => Stack(
-              alignment: Alignment.center,
-              children: [
-                if (previous.isNotEmpty) previous.first,
-                if (current != null) current,
-              ],
-            ),
             child: !hasVideo
                 ? Container()
                 : Center(
@@ -156,7 +150,10 @@ class ParticipantWidget extends StatelessWidget {
               );
             }
 
-            return AnimatedSwitcher(duration: 250.milliseconds, child: child);
+            return DefaultAnimatedSwitcher(
+              duration: 250.milliseconds,
+              child: child,
+            );
           }),
           Center(
             child: RaisedHand(participant.member.isHandRaised.value),

--- a/lib/ui/page/call/widget/participant/widget.dart
+++ b/lib/ui/page/call/widget/participant/widget.dart
@@ -89,7 +89,7 @@ class ParticipantWidget extends StatelessWidget {
       return Stack(
         children: [
           if (!hasVideo) ...background(),
-          DefaultAnimatedSwitcher(
+          SafeAnimatedSwitcher(
             key: const Key('AnimatedSwitcher'),
             duration: animate
                 ? const Duration(milliseconds: 200)
@@ -150,7 +150,7 @@ class ParticipantWidget extends StatelessWidget {
               );
             }
 
-            return DefaultAnimatedSwitcher(
+            return SafeAnimatedSwitcher(
               duration: 250.milliseconds,
               child: child,
             );

--- a/lib/ui/page/call/widget/video_view.dart
+++ b/lib/ui/page/call/widget/video_view.dart
@@ -23,6 +23,7 @@ import 'package:medea_jason/medea_jason.dart';
 
 import '/domain/model/ongoing_call.dart';
 import '/themes.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/svg/svg.dart';
 import '/util/platform_utils.dart';
@@ -281,7 +282,7 @@ class _RtcVideoViewState extends State<RtcVideoView> {
           alignment: Alignment.bottomCenter,
           children: [
             outlined(fit),
-            AnimatedSwitcher(
+            DefaultAnimatedSwitcher(
               duration: const Duration(milliseconds: 150),
               child: widget.muted || widget.label != null
                   ? Container(

--- a/lib/ui/page/call/widget/video_view.dart
+++ b/lib/ui/page/call/widget/video_view.dart
@@ -282,7 +282,7 @@ class _RtcVideoViewState extends State<RtcVideoView> {
           alignment: Alignment.bottomCenter,
           children: [
             outlined(fit),
-            DefaultAnimatedSwitcher(
+            SafeAnimatedSwitcher(
               duration: const Duration(milliseconds: 150),
               child: widget.muted || widget.label != null
                   ? Container(

--- a/lib/ui/page/home/page/chat/forward/view.dart
+++ b/lib/ui/page/home/page/chat/forward/view.dart
@@ -143,7 +143,7 @@ class ChatForwardView extends StatelessWidget {
                   ),
                 ),
                 IgnorePointer(
-                  child: DefaultAnimatedSwitcher(
+                  child: SafeAnimatedSwitcher(
                     duration: 200.milliseconds,
                     child: c.isDraggingFiles.value
                         ? Container(

--- a/lib/ui/page/home/page/chat/forward/view.dart
+++ b/lib/ui/page/home/page/chat/forward/view.dart
@@ -26,6 +26,7 @@ import '/domain/model/chat_item_quote_input.dart';
 import '/l10n/l10n.dart';
 import '/themes.dart';
 import '/ui/page/call/search/controller.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/page/call/widget/animated_delayed_scale.dart';
 import '/ui/page/call/widget/conditional_backdrop.dart';
 import '/ui/page/home/page/chat/message_field/view.dart';
@@ -142,7 +143,7 @@ class ChatForwardView extends StatelessWidget {
                   ),
                 ),
                 IgnorePointer(
-                  child: AnimatedSwitcher(
+                  child: DefaultAnimatedSwitcher(
                     duration: 200.milliseconds,
                     child: c.isDraggingFiles.value
                         ? Container(

--- a/lib/ui/page/home/page/chat/info/view.dart
+++ b/lib/ui/page/home/page/chat/info/view.dart
@@ -170,7 +170,7 @@ class ChatInfoView extends StatelessWidget {
                         shape: BoxShape.circle,
                       ),
                       child: Center(
-                        child: DefaultAnimatedSwitcher(
+                        child: SafeAnimatedSwitcher(
                           duration: 300.milliseconds,
                           child: c.inCall
                               ? const SvgImage.asset(

--- a/lib/ui/page/home/page/chat/info/view.dart
+++ b/lib/ui/page/home/page/chat/info/view.dart
@@ -33,6 +33,7 @@ import '/ui/page/home/widget/big_avatar.dart';
 import '/ui/page/home/widget/block.dart';
 import '/ui/page/home/widget/direct_link.dart';
 import '/ui/widget/animated_button.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/member_tile.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/svg/svg.dart';
@@ -169,7 +170,7 @@ class ChatInfoView extends StatelessWidget {
                         shape: BoxShape.circle,
                       ),
                       child: Center(
-                        child: AnimatedSwitcher(
+                        child: DefaultAnimatedSwitcher(
                           duration: 300.milliseconds,
                           child: c.inCall
                               ? const SvgImage.asset(

--- a/lib/ui/page/home/page/chat/message_field/view.dart
+++ b/lib/ui/page/home/page/chat/message_field/view.dart
@@ -499,7 +499,7 @@ class MessageFieldView extends StatelessWidget {
                     width: 56,
                     height: 56,
                     child: Center(
-                      child: DefaultAnimatedSwitcher(
+                      child: SafeAnimatedSwitcher(
                         duration: 300.milliseconds,
                         child: c.forwarding.value
                             ? const SvgImage.asset(

--- a/lib/ui/page/home/page/chat/message_field/view.dart
+++ b/lib/ui/page/home/page/chat/message_field/view.dart
@@ -41,6 +41,7 @@ import '/ui/page/home/widget/gallery_popup.dart';
 import '/ui/page/home/widget/init_callback.dart';
 import '/ui/page/home/widget/retry_image.dart';
 import '/ui/widget/animated_button.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/animations.dart';
 import '/ui/widget/svg/svg.dart';
 import '/ui/widget/text_field.dart';
@@ -498,7 +499,7 @@ class MessageFieldView extends StatelessWidget {
                     width: 56,
                     height: 56,
                     child: Center(
-                      child: AnimatedSwitcher(
+                      child: DefaultAnimatedSwitcher(
                         duration: 300.milliseconds,
                         child: c.forwarding.value
                             ? const SvgImage.asset(

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -285,7 +285,7 @@ class _ChatViewState extends State<ChatView>
                               AnimatedButton(
                                 key: const Key('ActiveCallButton'),
                                 onPressed: c.inCall ? c.dropCall : c.joinCall,
-                                child: DefaultAnimatedSwitcher(
+                                child: SafeAnimatedSwitcher(
                                   duration: 300.milliseconds,
                                   child: child,
                                 ),
@@ -489,7 +489,7 @@ class _ChatViewState extends State<ChatView>
                       return SizedBox(
                         width: 50,
                         height: 50,
-                        child: DefaultAnimatedSwitcher(
+                        child: SafeAnimatedSwitcher(
                           duration: 200.milliseconds,
                           child: c.canGoBack.isTrue
                               ? FloatingActionButton.small(
@@ -512,7 +512,7 @@ class _ChatViewState extends State<ChatView>
                   ),
                   IgnorePointer(
                     child: Obx(() {
-                      return DefaultAnimatedSwitcher(
+                      return SafeAnimatedSwitcher(
                         duration: 200.milliseconds,
                         child: c.isDraggingFiles.value
                             ? Container(

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -42,6 +42,7 @@ import '/ui/page/home/widget/highlighted_container.dart';
 import '/ui/page/home/widget/paddings.dart';
 import '/ui/page/home/widget/unblock_button.dart';
 import '/ui/widget/animated_button.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/menu_interceptor/menu_interceptor.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/svg/svg.dart';
@@ -284,15 +285,8 @@ class _ChatViewState extends State<ChatView>
                               AnimatedButton(
                                 key: const Key('ActiveCallButton'),
                                 onPressed: c.inCall ? c.dropCall : c.joinCall,
-                                child: AnimatedSwitcher(
+                                child: DefaultAnimatedSwitcher(
                                   duration: 300.milliseconds,
-                                  layoutBuilder: (current, previous) => Stack(
-                                    alignment: Alignment.center,
-                                    children: [
-                                      if (previous.isNotEmpty) previous.first,
-                                      if (current != null) current,
-                                    ],
-                                  ),
                                   child: child,
                                 ),
                               ),
@@ -495,7 +489,7 @@ class _ChatViewState extends State<ChatView>
                       return SizedBox(
                         width: 50,
                         height: 50,
-                        child: AnimatedSwitcher(
+                        child: DefaultAnimatedSwitcher(
                           duration: 200.milliseconds,
                           child: c.canGoBack.isTrue
                               ? FloatingActionButton.small(
@@ -518,7 +512,7 @@ class _ChatViewState extends State<ChatView>
                   ),
                   IgnorePointer(
                     child: Obx(() {
-                      return AnimatedSwitcher(
+                      return DefaultAnimatedSwitcher(
                         duration: 200.milliseconds,
                         child: c.isDraggingFiles.value
                             ? Container(

--- a/lib/ui/page/home/page/chat/widget/data_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/data_attachment.dart
@@ -194,7 +194,7 @@ class _DataAttachmentState extends State<DataAttachment> {
                 const SizedBox(width: 6),
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: DefaultAnimatedSwitcher(
+                  child: SafeAnimatedSwitcher(
                     key: Key('AttachmentStatus_${e.id}'),
                     duration: 250.milliseconds,
                     child: leading,

--- a/lib/ui/page/home/page/chat/widget/data_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/data_attachment.dart
@@ -23,6 +23,7 @@ import '/domain/model/attachment.dart';
 import '/domain/model/sending_status.dart';
 import '/l10n/l10n.dart';
 import '/themes.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/svg/svg.dart';
 import '/ui/widget/widget_button.dart';
 import '/ui/worker/cache.dart';
@@ -193,16 +194,9 @@ class _DataAttachmentState extends State<DataAttachment> {
                 const SizedBox(width: 6),
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: AnimatedSwitcher(
+                  child: DefaultAnimatedSwitcher(
                     key: Key('AttachmentStatus_${e.id}'),
                     duration: 250.milliseconds,
-                    layoutBuilder: (current, previous) => Stack(
-                      alignment: Alignment.center,
-                      children: [
-                        if (previous.isNotEmpty) previous.first,
-                        if (current != null) current,
-                      ],
-                    ),
                     child: leading,
                   ),
                 ),

--- a/lib/ui/page/home/page/chat/widget/message_info/view.dart
+++ b/lib/ui/page/home/page/chat/widget/message_info/view.dart
@@ -26,6 +26,7 @@ import '/themes.dart';
 import '/ui/page/home/page/chat/message_field/view.dart';
 import '/ui/page/home/widget/app_bar.dart';
 import '/ui/page/home/widget/contact_tile.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/modal_popup.dart';
 import '/ui/widget/svg/svg.dart';
 import '/ui/widget/text_field.dart';
@@ -151,7 +152,7 @@ class MessageInfo extends StatelessWidget {
                           ),
                         );
 
-                        return AnimatedSwitcher(
+                        return DefaultAnimatedSwitcher(
                           duration: 250.milliseconds,
                           child: c.search.isEmpty.value ? null : close,
                         );

--- a/lib/ui/page/home/page/chat/widget/message_info/view.dart
+++ b/lib/ui/page/home/page/chat/widget/message_info/view.dart
@@ -152,7 +152,7 @@ class MessageInfo extends StatelessWidget {
                           ),
                         );
 
-                        return DefaultAnimatedSwitcher(
+                        return SafeAnimatedSwitcher(
                           duration: 250.milliseconds,
                           child: c.search.isEmpty.value ? null : close,
                         );

--- a/lib/ui/page/home/page/chat/widget/video/video.dart
+++ b/lib/ui/page/home/page/chat/widget/video/video.dart
@@ -128,7 +128,7 @@ class _VideoViewState extends State<VideoView> {
   Widget build(BuildContext context) {
     final style = Theme.of(context).style;
 
-    return DefaultAnimatedSwitcher(
+    return SafeAnimatedSwitcher(
       duration: const Duration(milliseconds: 300),
       child: StreamBuilder(
           stream: _controller.player.stream.width,

--- a/lib/ui/page/home/page/chat/widget/video/video.dart
+++ b/lib/ui/page/home/page/chat/widget/video/video.dart
@@ -27,6 +27,7 @@ import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
 import '/themes.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/worker/cache.dart';
 import '/util/backoff.dart';
@@ -127,7 +128,7 @@ class _VideoViewState extends State<VideoView> {
   Widget build(BuildContext context) {
     final style = Theme.of(context).style;
 
-    return AnimatedSwitcher(
+    return DefaultAnimatedSwitcher(
       duration: const Duration(milliseconds: 300),
       child: StreamBuilder(
           stream: _controller.player.stream.width,

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -327,7 +327,7 @@ class UserView extends StatelessWidget {
                 child = const CustomProgressIndicator();
               }
 
-              return DefaultAnimatedSwitcher(
+              return SafeAnimatedSwitcher(
                 duration: 200.milliseconds,
                 child: child,
               );

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -32,6 +32,7 @@ import '/ui/page/home/widget/num.dart';
 import '/ui/page/home/widget/paddings.dart';
 import '/ui/page/home/widget/unblock_button.dart';
 import '/ui/widget/animated_button.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/svg/svg.dart';
 import '/ui/widget/text_field.dart';
@@ -326,7 +327,7 @@ class UserView extends StatelessWidget {
                 child = const CustomProgressIndicator();
               }
 
-              return AnimatedSwitcher(
+              return DefaultAnimatedSwitcher(
                 duration: 200.milliseconds,
                 child: child,
               );

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -165,7 +165,7 @@ class ChatsTabView extends StatelessWidget {
                       );
                     }
 
-                    return DefaultAnimatedSwitcher(
+                    return SafeAnimatedSwitcher(
                       duration: 250.milliseconds,
                       child: child,
                     );
@@ -233,7 +233,7 @@ class ChatsTabView extends StatelessWidget {
                             child: child,
                           );
                         },
-                        child: DefaultAnimatedSwitcher(
+                        child: SafeAnimatedSwitcher(
                           duration: 250.milliseconds,
                           child: c.searching.value
                               ? Icon(
@@ -301,7 +301,7 @@ class ChatsTabView extends StatelessWidget {
                                 height: double.infinity,
                                 child: SizedBox(
                                   width: 21.77,
-                                  child: DefaultAnimatedSwitcher(
+                                  child: SafeAnimatedSwitcher(
                                     duration: 250.milliseconds,
                                     child: child,
                                   ),
@@ -917,7 +917,7 @@ class ChatsTabView extends StatelessWidget {
                   }
 
                   return ContextMenuInterceptor(
-                    child: DefaultAnimatedSwitcher(
+                    child: SafeAnimatedSwitcher(
                       duration: const Duration(milliseconds: 250),
                       child: child,
                     ),
@@ -1000,7 +1000,7 @@ class ChatsTabView extends StatelessWidget {
                 child = const SizedBox();
               }
 
-              return DefaultAnimatedSwitcher(
+              return SafeAnimatedSwitcher(
                 duration: 200.milliseconds,
                 child: child,
               );

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -38,6 +38,7 @@ import '/ui/page/home/widget/safe_scrollbar.dart';
 import '/ui/page/home/widget/shadowed_rounded_button.dart';
 import '/ui/widget/animated_button.dart';
 import '/ui/widget/animated_delayed_switcher.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
 import '/ui/widget/menu_interceptor/menu_interceptor.dart';
@@ -164,7 +165,7 @@ class ChatsTabView extends StatelessWidget {
                       );
                     }
 
-                    return AnimatedSwitcher(
+                    return DefaultAnimatedSwitcher(
                       duration: 250.milliseconds,
                       child: child,
                     );
@@ -232,7 +233,7 @@ class ChatsTabView extends StatelessWidget {
                             child: child,
                           );
                         },
-                        child: AnimatedSwitcher(
+                        child: DefaultAnimatedSwitcher(
                           duration: 250.milliseconds,
                           child: c.searching.value
                               ? Icon(
@@ -300,7 +301,7 @@ class ChatsTabView extends StatelessWidget {
                                 height: double.infinity,
                                 child: SizedBox(
                                   width: 21.77,
-                                  child: AnimatedSwitcher(
+                                  child: DefaultAnimatedSwitcher(
                                     duration: 250.milliseconds,
                                     child: child,
                                   ),
@@ -916,7 +917,7 @@ class ChatsTabView extends StatelessWidget {
                   }
 
                   return ContextMenuInterceptor(
-                    child: AnimatedSwitcher(
+                    child: DefaultAnimatedSwitcher(
                       duration: const Duration(milliseconds: 250),
                       child: child,
                     ),
@@ -999,7 +1000,10 @@ class ChatsTabView extends StatelessWidget {
                 child = const SizedBox();
               }
 
-              return AnimatedSwitcher(duration: 200.milliseconds, child: child);
+              return DefaultAnimatedSwitcher(
+                duration: 200.milliseconds,
+                child: child,
+              );
             }),
           ],
         );

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -790,7 +790,7 @@ class RecentChatTile extends StatelessWidget {
 
       return Padding(
         padding: const EdgeInsets.only(left: 5),
-        child: DefaultAnimatedSwitcher(
+        child: SafeAnimatedSwitcher(
           duration: 300.milliseconds,
           child: PeriodicBuilder(
             period: Config.disableInfiniteAnimations

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -38,6 +38,7 @@ import '/ui/page/home/widget/animated_typing.dart';
 import '/ui/page/home/widget/avatar.dart';
 import '/ui/page/home/widget/chat_tile.dart';
 import '/ui/page/home/widget/retry_image.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/svg/svg.dart';
 import '/util/message_popup.dart';
@@ -789,7 +790,7 @@ class RecentChatTile extends StatelessWidget {
 
       return Padding(
         padding: const EdgeInsets.only(left: 5),
-        child: AnimatedSwitcher(
+        child: DefaultAnimatedSwitcher(
           duration: 300.milliseconds,
           child: PeriodicBuilder(
             period: Config.disableInfiniteAnimations

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -132,7 +132,7 @@ class ContactsTabView extends StatelessWidget {
                 );
               }
 
-              return DefaultAnimatedSwitcher(
+              return SafeAnimatedSwitcher(
                 duration: 250.milliseconds,
                 child: child,
               );
@@ -182,7 +182,7 @@ class ContactsTabView extends StatelessWidget {
                           width: 29.69 + 12 + 18,
                           height: double.infinity,
                           child: Center(
-                            child: DefaultAnimatedSwitcher(
+                            child: SafeAnimatedSwitcher(
                               duration: 250.milliseconds,
                               child: child,
                             ),
@@ -279,7 +279,7 @@ class ContactsTabView extends StatelessWidget {
                       child: child,
                     );
                   },
-                  child: DefaultAnimatedSwitcher(
+                  child: SafeAnimatedSwitcher(
                     duration: 250.milliseconds,
                     child: c.search.value != null
                         ? Icon(
@@ -575,7 +575,7 @@ class ContactsTabView extends StatelessWidget {
                   );
                 }),
                 ContextMenuInterceptor(
-                  child: DefaultAnimatedSwitcher(
+                  child: SafeAnimatedSwitcher(
                     duration: const Duration(milliseconds: 250),
                     child: child,
                   ),

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -39,6 +39,7 @@ import '/ui/page/home/widget/safe_scrollbar.dart';
 import '/ui/page/home/widget/shadowed_rounded_button.dart';
 import '/ui/widget/animated_button.dart';
 import '/ui/widget/animated_delayed_switcher.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
 import '/ui/widget/menu_interceptor/menu_interceptor.dart';
@@ -131,7 +132,10 @@ class ContactsTabView extends StatelessWidget {
                 );
               }
 
-              return AnimatedSwitcher(duration: 250.milliseconds, child: child);
+              return DefaultAnimatedSwitcher(
+                duration: 250.milliseconds,
+                child: child,
+              );
             }),
             actions: [
               Obx(() {
@@ -178,7 +182,7 @@ class ContactsTabView extends StatelessWidget {
                           width: 29.69 + 12 + 18,
                           height: double.infinity,
                           child: Center(
-                            child: AnimatedSwitcher(
+                            child: DefaultAnimatedSwitcher(
                               duration: 250.milliseconds,
                               child: child,
                             ),
@@ -275,7 +279,7 @@ class ContactsTabView extends StatelessWidget {
                       child: child,
                     );
                   },
-                  child: AnimatedSwitcher(
+                  child: DefaultAnimatedSwitcher(
                     duration: 250.milliseconds,
                     child: c.search.value != null
                         ? Icon(
@@ -571,15 +575,8 @@ class ContactsTabView extends StatelessWidget {
                   );
                 }),
                 ContextMenuInterceptor(
-                  child: AnimatedSwitcher(
+                  child: DefaultAnimatedSwitcher(
                     duration: const Duration(milliseconds: 250),
-                    layoutBuilder: (current, previous) => Stack(
-                      alignment: Alignment.center,
-                      children: [
-                        if (previous.isNotEmpty) previous.first,
-                        if (current != null) current,
-                      ],
-                    ),
                     child: child,
                   ),
                 ),

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -269,7 +269,7 @@ class _HomeViewState extends State<HomeView> {
                                       );
                                     }
 
-                                    return DefaultAnimatedSwitcher(
+                                    return SafeAnimatedSwitcher(
                                       key: c.chatsKey,
                                       duration: 200.milliseconds,
                                       child: child,
@@ -434,7 +434,7 @@ class _HomeViewState extends State<HomeView> {
                 ),
               ),
               Positioned.fill(
-                child: DefaultAnimatedSwitcher(
+                child: SafeAnimatedSwitcher(
                   duration: 250.milliseconds,
                   child: image,
                 ),

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -28,6 +28,7 @@ import '/routes.dart';
 import '/themes.dart';
 import '/ui/page/call/widget/conditional_backdrop.dart';
 import '/ui/page/call/widget/scaler.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
 import '/ui/widget/progress_indicator.dart';
@@ -268,18 +269,9 @@ class _HomeViewState extends State<HomeView> {
                                       );
                                     }
 
-                                    return AnimatedSwitcher(
+                                    return DefaultAnimatedSwitcher(
                                       key: c.chatsKey,
                                       duration: 200.milliseconds,
-                                      layoutBuilder: (current, previous) =>
-                                          Stack(
-                                        alignment: Alignment.center,
-                                        children: [
-                                          if (previous.isNotEmpty)
-                                            previous.first,
-                                          if (current != null) current,
-                                        ],
-                                      ),
                                       child: child,
                                     );
                                   }),
@@ -442,16 +434,8 @@ class _HomeViewState extends State<HomeView> {
                 ),
               ),
               Positioned.fill(
-                child: AnimatedSwitcher(
+                child: DefaultAnimatedSwitcher(
                   duration: 250.milliseconds,
-                  layoutBuilder: (child, previous) {
-                    return Stack(
-                      alignment: Alignment.center,
-                      children: [...previous, if (child != null) child]
-                          .map((e) => Positioned.fill(child: e))
-                          .toList(),
-                    );
-                  },
                   child: image,
                 ),
               ),

--- a/lib/ui/page/home/widget/big_avatar.dart
+++ b/lib/ui/page/home/widget/big_avatar.dart
@@ -107,7 +107,7 @@ class _BigAvatarWidgetState extends State<BigAvatarWidget> {
           children: [
             _avatar(context),
             Positioned.fill(
-              child: DefaultAnimatedSwitcher(
+              child: SafeAnimatedSwitcher(
                 duration: 200.milliseconds,
                 child: widget.loading
                     ? Container(

--- a/lib/ui/page/home/widget/big_avatar.dart
+++ b/lib/ui/page/home/widget/big_avatar.dart
@@ -25,6 +25,7 @@ import '/domain/repository/chat.dart';
 import '/domain/repository/user.dart';
 import '/l10n/l10n.dart';
 import '/themes.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/widget_button.dart';
 import 'avatar.dart';
@@ -106,7 +107,7 @@ class _BigAvatarWidgetState extends State<BigAvatarWidget> {
           children: [
             _avatar(context),
             Positioned.fill(
-              child: AnimatedSwitcher(
+              child: DefaultAnimatedSwitcher(
                 duration: 200.milliseconds,
                 child: widget.loading
                     ? Container(

--- a/lib/ui/page/home/widget/rectangle_button.dart
+++ b/lib/ui/page/home/widget/rectangle_button.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 
 import '/themes.dart';
 import '/ui/page/home/widget/avatar.dart';
+import '/ui/widget/animated_switcher.dart';
 
 /// Rectangular filled selectable button.
 class RectangleButton extends StatelessWidget {
@@ -73,7 +74,7 @@ class RectangleButton extends StatelessWidget {
                 SizedBox(
                   width: 20,
                   height: 20,
-                  child: AnimatedSwitcher(
+                  child: DefaultAnimatedSwitcher(
                     duration: const Duration(milliseconds: 200),
                     child: selected
                         ? CircleAvatar(
@@ -95,7 +96,7 @@ class RectangleButton extends StatelessWidget {
                   child: CircleAvatar(
                     backgroundColor: trailingColor,
                     radius: 12,
-                    child: AnimatedSwitcher(
+                    child: DefaultAnimatedSwitcher(
                       duration: const Duration(milliseconds: 200),
                       child: selected
                           ? Icon(

--- a/lib/ui/page/home/widget/rectangle_button.dart
+++ b/lib/ui/page/home/widget/rectangle_button.dart
@@ -74,7 +74,7 @@ class RectangleButton extends StatelessWidget {
                 SizedBox(
                   width: 20,
                   height: 20,
-                  child: DefaultAnimatedSwitcher(
+                  child: SafeAnimatedSwitcher(
                     duration: const Duration(milliseconds: 200),
                     child: selected
                         ? CircleAvatar(
@@ -96,7 +96,7 @@ class RectangleButton extends StatelessWidget {
                   child: CircleAvatar(
                     backgroundColor: trailingColor,
                     radius: 12,
-                    child: DefaultAnimatedSwitcher(
+                    child: SafeAnimatedSwitcher(
                       duration: const Duration(milliseconds: 200),
                       child: selected
                           ? Icon(

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -319,7 +319,7 @@ class _RetryImageState extends State<RetryImage> {
       return Stack(
         alignment: Alignment.center,
         children: [
-          DefaultAnimatedSwitcher(
+          SafeAnimatedSwitcher(
             duration: const Duration(milliseconds: 150),
             child: _fallback == null
                 ? SizedBox(width: 200, height: widget.height)
@@ -345,7 +345,7 @@ class _RetryImageState extends State<RetryImage> {
           ),
           Positioned.fill(
             child: Center(
-              child: DefaultAnimatedSwitcher(
+              child: SafeAnimatedSwitcher(
                 duration: const Duration(milliseconds: 150),
                 child:
                     KeyedSubtree(key: Key('Image_${widget.url}'), child: child),
@@ -358,7 +358,7 @@ class _RetryImageState extends State<RetryImage> {
 
     return KeyedSubtree(
       key: Key('Image_${widget.url}'),
-      child: DefaultAnimatedSwitcher(
+      child: SafeAnimatedSwitcher(
         duration: const Duration(milliseconds: 150),
         child: child,
       ),

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -25,6 +25,7 @@ import 'package:flutter/material.dart';
 import '/domain/model/attachment.dart';
 import '/domain/model/file.dart';
 import '/themes.dart';
+import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/svg/svg.dart';
 import '/ui/widget/widget_button.dart';
@@ -318,7 +319,7 @@ class _RetryImageState extends State<RetryImage> {
       return Stack(
         alignment: Alignment.center,
         children: [
-          AnimatedSwitcher(
+          DefaultAnimatedSwitcher(
             duration: const Duration(milliseconds: 150),
             child: _fallback == null
                 ? SizedBox(width: 200, height: widget.height)
@@ -344,7 +345,7 @@ class _RetryImageState extends State<RetryImage> {
           ),
           Positioned.fill(
             child: Center(
-              child: AnimatedSwitcher(
+              child: DefaultAnimatedSwitcher(
                 duration: const Duration(milliseconds: 150),
                 child:
                     KeyedSubtree(key: Key('Image_${widget.url}'), child: child),
@@ -357,7 +358,7 @@ class _RetryImageState extends State<RetryImage> {
 
     return KeyedSubtree(
       key: Key('Image_${widget.url}'),
-      child: AnimatedSwitcher(
+      child: DefaultAnimatedSwitcher(
         duration: const Duration(milliseconds: 150),
         child: child,
       ),

--- a/lib/ui/widget/animated_switcher.dart
+++ b/lib/ui/widget/animated_switcher.dart
@@ -1,0 +1,48 @@
+// Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'package:flutter/material.dart';
+
+/// [AnimatedSwitcher] with exception-safe layout builder.
+///
+/// Intended to be used instead of the [AnimatedSwitcher].
+class DefaultAnimatedSwitcher extends StatelessWidget {
+  const DefaultAnimatedSwitcher({
+    super.key,
+    required this.duration,
+    this.child,
+  });
+
+  /// [Duration] of the switching animation.
+  final Duration duration;
+
+  /// Current [Widget] to display.
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) => AnimatedSwitcher(
+        duration: duration,
+        layoutBuilder: (current, previous) => Stack(
+          alignment: Alignment.center,
+          children: [
+            if (previous.isNotEmpty) previous.first,
+            if (current != null) current,
+          ],
+        ),
+        child: child,
+      );
+}

--- a/lib/ui/widget/animated_switcher.dart
+++ b/lib/ui/widget/animated_switcher.dart
@@ -20,8 +20,8 @@ import 'package:flutter/material.dart';
 /// [AnimatedSwitcher] with exception-safe layout builder.
 ///
 /// Intended to be used instead of the [AnimatedSwitcher].
-class DefaultAnimatedSwitcher extends StatelessWidget {
-  const DefaultAnimatedSwitcher({
+class SafeAnimatedSwitcher extends StatelessWidget {
+  const SafeAnimatedSwitcher({
     super.key,
     required this.duration,
     this.child,
@@ -34,15 +34,17 @@ class DefaultAnimatedSwitcher extends StatelessWidget {
   final Widget? child;
 
   @override
-  Widget build(BuildContext context) => AnimatedSwitcher(
-        duration: duration,
-        layoutBuilder: (current, previous) => Stack(
-          alignment: Alignment.center,
-          children: [
-            if (previous.isNotEmpty) previous.first,
-            if (current != null) current,
-          ],
-        ),
-        child: child,
-      );
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: duration,
+      layoutBuilder: (current, previous) => Stack(
+        alignment: Alignment.center,
+        children: [
+          if (previous.isNotEmpty) previous.first,
+          if (current != null) current,
+        ],
+      ),
+      child: child,
+    );
+  }
 }

--- a/lib/ui/widget/member_tile.dart
+++ b/lib/ui/widget/member_tile.dart
@@ -23,6 +23,7 @@ import '/themes.dart';
 import '/ui/page/home/widget/contact_tile.dart';
 import '/util/message_popup.dart';
 import 'animated_button.dart';
+import 'animated_switcher.dart';
 import 'svg/svg.dart';
 
 /// Styled [ContactTile] representing the provided [RxUser] as a member of some
@@ -70,7 +71,7 @@ class MemberTile extends StatelessWidget {
       trailing: [
         if (inCall != null) ...[
           const SizedBox(width: 8),
-          AnimatedSwitcher(
+          DefaultAnimatedSwitcher(
             duration: const Duration(milliseconds: 300),
             child: Material(
               key: Key(inCall == true ? 'InCall' : 'NotInCall'),

--- a/lib/ui/widget/member_tile.dart
+++ b/lib/ui/widget/member_tile.dart
@@ -71,7 +71,7 @@ class MemberTile extends StatelessWidget {
       trailing: [
         if (inCall != null) ...[
           const SizedBox(width: 8),
-          DefaultAnimatedSwitcher(
+          SafeAnimatedSwitcher(
             duration: const Duration(milliseconds: 300),
             child: Material(
               key: Key(inCall == true ? 'InCall' : 'NotInCall'),

--- a/lib/ui/widget/selected_dot.dart
+++ b/lib/ui/widget/selected_dot.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 
 import '/themes.dart';
 import '/ui/page/home/widget/avatar.dart';
+import 'animated_switcher.dart';
 
 /// Animated [CircleAvatar] representing a selection circle.
 class SelectedDot extends StatelessWidget {
@@ -53,7 +54,7 @@ class SelectedDot extends StatelessWidget {
 
     return SizedBox(
       width: 30,
-      child: AnimatedSwitcher(
+      child: DefaultAnimatedSwitcher(
         duration: const Duration(milliseconds: 200),
         child: selected
             ? CircleAvatar(

--- a/lib/ui/widget/selected_dot.dart
+++ b/lib/ui/widget/selected_dot.dart
@@ -54,7 +54,7 @@ class SelectedDot extends StatelessWidget {
 
     return SizedBox(
       width: 30,
-      child: DefaultAnimatedSwitcher(
+      child: SafeAnimatedSwitcher(
         duration: const Duration(milliseconds: 200),
         child: selected
             ? CircleAvatar(

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -27,6 +27,7 @@ import '/util/message_popup.dart';
 import '/util/platform_utils.dart';
 import 'allow_overflow.dart';
 import 'animated_button.dart';
+import 'animated_switcher.dart';
 import 'animations.dart';
 import 'svg/svg.dart';
 
@@ -393,7 +394,7 @@ class ReactiveTextField extends StatelessWidget {
               duration: 200.milliseconds,
               child: Align(
                 alignment: Alignment.centerLeft,
-                child: AnimatedSwitcher(
+                child: DefaultAnimatedSwitcher(
                   duration: 200.milliseconds,
                   child: state.error.value == null
                       ? subtitle != null

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -394,7 +394,7 @@ class ReactiveTextField extends StatelessWidget {
               duration: 200.milliseconds,
               child: Align(
                 alignment: Alignment.centerLeft,
-                child: DefaultAnimatedSwitcher(
+                child: SafeAnimatedSwitcher(
                   duration: 200.milliseconds,
                   child: state.error.value == null
                       ? subtitle != null


### PR DESCRIPTION
Resolves #386




## Synopsis

Во всём приложении много мест, где `AnimatedSwitcher` что-то ломает.




## Solution

`AnimatedSwitcher`ы будут исправлены.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
