### PR TITLE
`CustomAppBar.title` jumpes when entering search on `Chat`s tab (#550)

### DIFF
--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -232,19 +232,22 @@ class ChatsTabView extends StatelessWidget {
                             child: child,
                           );
                         },
-                        child: AnimatedSwitcher(
-                          duration: 250.milliseconds,
-                          child: c.searching.value
-                              ? Icon(
-                                  key: const Key('ArrowBack'),
-                                  Icons.arrow_back_ios_new,
-                                  size: 20,
-                                  color: style.colors.primary,
-                                )
-                              : const SvgImage.asset(
-                                  'assets/icons/search.svg',
-                                  width: 17.77,
-                                ),
+                        child: SizedBox(
+                          width: 20,
+                          child: AnimatedSwitcher(
+                            duration: 250.milliseconds,
+                            child: c.searching.value
+                                ? Icon(
+                                    key: const Key('ArrowBack'),
+                                    Icons.arrow_back_ios_new,
+                                    size: 20,
+                                    color: style.colors.primary,
+                                  )
+                                : const SvgImage.asset(
+                                    'assets/icons/search.svg',
+                                    width: 17.77,
+                                  ),
+                          ),
                         ),
                       );
                     }),
@@ -271,84 +274,85 @@ class ChatsTabView extends StatelessWidget {
                         }
                       }
 
-                      return Row(
-                        children: [
-                          if (child != null)
-                            AnimatedButton(
-                              key: c.searching.value
-                                  ? const Key('CloseSearchButton')
-                                  : null,
-                              onPressed: () {
-                                if (c.searching.value) {
-                                  if (c.search.value?.search.isEmpty.value ==
-                                      false) {
-                                    c.search.value?.search.clear();
-                                    c.search.value?.query.value = '';
-                                    c.search.value?.search.focus.requestFocus();
-                                  }
-                                } else if (c.selecting.value) {
-                                  c.toggleSelecting();
-                                } else {
-                                  if (c.groupCreating.value) {
-                                    c.closeGroupCreating();
-                                  }
-                                }
-                              },
-                              child: Container(
-                                padding:
-                                    const EdgeInsets.only(left: 12, right: 18),
+                      if (child != null) {
+                        return AnimatedButton(
+                          key: c.searching.value
+                              ? const Key('CloseSearchButton')
+                              : null,
+                          onPressed: () {
+                            if (c.searching.value) {
+                              if (c.search.value?.search.isEmpty.value ==
+                                  false) {
+                                c.search.value?.search.clear();
+                                c.search.value?.query.value = '';
+                                c.search.value?.search.focus.requestFocus();
+                              }
+                            } else if (c.selecting.value) {
+                              c.toggleSelecting();
+                            } else {
+                              if (c.groupCreating.value) {
+                                c.closeGroupCreating();
+                              }
+                            }
+                          },
+                          child: Container(
+                            padding: const EdgeInsets.only(left: 12, right: 18),
+                            height: double.infinity,
+                            child: SizedBox(
+                              width: 21.77,
+                              child: AnimatedSwitcher(
+                                duration: 250.milliseconds,
+                                child: child,
+                              ),
+                            ),
+                          ),
+                        );
+                      }
+
+                      return AnimatedOpacity(
+                        duration: 250.milliseconds,
+                        opacity: c.searching.value ||
+                                c.groupCreating.value ||
+                                c.selecting.value
+                            ? 0
+                            : 1,
+                        child: ContextMenuRegion(
+                          key: const Key('ChatsMenu'),
+                          selector: c.moreKey,
+                          alignment: Alignment.topRight,
+                          enablePrimaryTap: true,
+                          enableSecondaryTap: false,
+                          enableLongTap: false,
+                          margin: const EdgeInsets.only(bottom: 4, right: 0),
+                          actions: [
+                            ContextMenuButton(
+                              label: 'btn_create_group'.l10n,
+                              onPressed: c.startGroupCreating,
+                            ),
+                            ContextMenuButton(
+                              key: const Key('SelectChatsButton'),
+                              label: 'btn_select_and_delete'.l10n,
+                              onPressed: c.toggleSelecting,
+                            ),
+                          ],
+                          child: AnimatedButton(
+                            decorator: (child) {
+                              return Container(
+                                key: c.moreKey,
+                                padding: const EdgeInsets.only(
+                                  left: 12,
+                                  right: 18,
+                                ),
                                 height: double.infinity,
-                                child: SizedBox(
-                                  width: 21.77,
-                                  child: AnimatedSwitcher(
-                                    duration: 250.milliseconds,
-                                    child: child,
-                                  ),
-                                ),
-                              ),
+                                child: child,
+                              );
+                            },
+                            child: Icon(
+                              Icons.more_vert,
+                              color: style.colors.primary,
                             ),
-                          if (!c.searching.value &&
-                              !c.groupCreating.value &&
-                              !c.selecting.value)
-                            ContextMenuRegion(
-                              key: const Key('ChatsMenu'),
-                              selector: c.moreKey,
-                              alignment: Alignment.topRight,
-                              enablePrimaryTap: true,
-                              enableSecondaryTap: false,
-                              enableLongTap: false,
-                              margin:
-                                  const EdgeInsets.only(bottom: 4, right: 0),
-                              actions: [
-                                ContextMenuButton(
-                                  label: 'btn_create_group'.l10n,
-                                  onPressed: c.startGroupCreating,
-                                ),
-                                ContextMenuButton(
-                                  key: const Key('SelectChatsButton'),
-                                  label: 'btn_select_and_delete'.l10n,
-                                  onPressed: c.toggleSelecting,
-                                ),
-                              ],
-                              child: AnimatedButton(
-                                decorator: (child) {
-                                  return Container(
-                                    key: c.moreKey,
-                                    padding: const EdgeInsets.only(
-                                      left: 12,
-                                      right: 18,
-                                    ),
-                                    height: double.infinity,
-                                    child: child,
-                                  );
-                                },
-                                child: Icon(
-                                  Icons.more_vert,
-                                  color: style.colors.primary,
-                                ),
-                              ),
-                            ),
-                        ],
+                          ),
+                        ),
                       );
                     }),
                   ],


### PR DESCRIPTION
Resolves #550




## Synopsis

При входе в поиск в шапке вкладки чатов прыгает чуть вправо надпись "Чаты".




## Solution

Проблема будет исправлена.




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
