### PR TITLE
Fix chat events race

### DIFF
--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -184,6 +184,8 @@ class ChatRepository extends DisposableInterface
 
     status.value = RxStatus.loading();
 
+    // Popup shouldn't listen to recent chats remote updates, as it's happening
+    // inside single [Chat].
     if (!WebUtils.isPopup) {
       _initDraftSubscription();
       _initRemoteSubscription();
@@ -1232,6 +1234,10 @@ class ChatRepository extends DisposableInterface
 
     HiveRxChat hiveChat = _add(chat, pagination: pagination);
 
+    // TODO: https://github.com/team113/messenger/issues/27
+    // Don't write to [Hive] from popup, as [Hive] doesn't support isolate
+    // synchronization, thus writes from multiple applications may lead to
+    // missing events.
     if (!WebUtils.isPopup) {
       final HiveChat? saved = await _chatLocal.get(chat.value.id);
 

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -1232,13 +1232,15 @@ class ChatRepository extends DisposableInterface
 
     HiveRxChat hiveChat = _add(chat, pagination: pagination);
 
-    final HiveChat? saved = await _chatLocal.get(chat.value.id);
+    if (!WebUtils.isPopup) {
+      final HiveChat? saved = await _chatLocal.get(chat.value.id);
 
-    // [Chat.firstItem] is maintained locally only for [Pagination] reasons.
-    chat.value.firstItem ??= saved?.value.firstItem;
+      // [Chat.firstItem] is maintained locally only for [Pagination] reasons.
+      chat.value.firstItem ??= saved?.value.firstItem;
 
-    if (saved == null || saved.ver < chat.ver) {
-      await _chatLocal.put(chat);
+      if (saved == null || saved.ver < chat.ver) {
+        await _chatLocal.put(chat);
+      }
     }
 
     return hiveChat;

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -60,6 +60,7 @@ import '/store/user.dart';
 import '/util/new_type.dart';
 import '/util/obs/obs.dart';
 import '/util/stream_utils.dart';
+import '/util/web/web_utils.dart';
 import 'chat_rx.dart';
 import 'event/chat.dart';
 import 'event/favorite_chat.dart';
@@ -180,12 +181,14 @@ class ChatRepository extends DisposableInterface
 
     status.value = RxStatus.loading();
 
-    _initDraftSubscription();
-    _initRemoteSubscription();
-    _initFavoriteSubscription();
+    if (!WebUtils.isPopup) {
+      _initDraftSubscription();
+      _initRemoteSubscription();
+      _initFavoriteSubscription();
 
-    // TODO: Should display last known list of [Chat]s, until remote responds.
-    _initPagination();
+      // TODO: Should display last known list of [Chat]s, until remote responds.
+      _initPagination();
+    }
   }
 
   @override

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -53,6 +53,7 @@ import '/util/new_type.dart';
 import '/util/obs/obs.dart';
 import '/util/platform_utils.dart';
 import '/util/stream_utils.dart';
+import '/util/web/web_utils.dart';
 import 'chat.dart';
 import 'event/chat.dart';
 import 'pagination/graphql.dart';
@@ -1355,7 +1356,7 @@ class HiveRxChat extends RxChat {
           }
         }
 
-        if (putChat) {
+        if (putChat && !WebUtils.isPopup) {
           await _chatRepository.put(chatEntity);
         }
         break;

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -53,7 +53,6 @@ import '/util/new_type.dart';
 import '/util/obs/obs.dart';
 import '/util/platform_utils.dart';
 import '/util/stream_utils.dart';
-import '/util/web/web_utils.dart';
 import 'chat.dart';
 import 'event/chat.dart';
 import 'pagination/graphql.dart';
@@ -1366,7 +1365,7 @@ class HiveRxChat extends RxChat {
           }
         }
 
-        if (putChat && !WebUtils.isPopup) {
+        if (putChat) {
           await _chatRepository.put(chatEntity);
         }
         break;


### PR DESCRIPTION
## Synopsis

Когда звонок открыт в попапе, новые сообщения в чате могут не рисоваться.




## Solution

Баг будет исправлен.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
