### PR TITLE
`MessageFieldMore` appearance animation (#641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ All user visible changes to this project will be documented in this file. This p
 [#202]: /../../pull/202
 [#525]: /../../issues/525
 [#628]: /../../pull/628
-[#628]: /../../pull/657
-[#628]: /../../pull/641
+[#641]: /../../pull/641
+[#657]: /../../pull/657
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,26 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Added
 
+- Push notifications. ([#202], [#201])
+
+### Changed
+
 - UI:
     - Chat page:
-        - More panel appearance animation. ([#657], [#641])
-- Push notifications. ([#202], [#201])
+        - Attachments panel smoothly appearing and disappearing. ([#657], [#641])
 
 ### Fixed
 
 - UI:
     - Chats tab:
         - Wide image attachments having blurry previews. ([#628], [#525])
+- Web:
+    - Back button not working on Android. ([#548])
 
 [#201]: /../../issues/201
 [#202]: /../../pull/202
 [#525]: /../../issues/525
+[#548]: /../../issues/548
 [#628]: /../../pull/628
 [#641]: /../../pull/641
 [#657]: /../../pull/657

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Added
 
+- UI:
+    - Chat page:
+        - More panel appearance animation. ([#657], [#641])
 - Push notifications. ([#202], [#201])
 
 ### Fixed
@@ -25,6 +28,8 @@ All user visible changes to this project will be documented in this file. This p
 [#202]: /../../pull/202
 [#525]: /../../issues/525
 [#628]: /../../pull/628
+[#628]: /../../pull/657
+[#628]: /../../pull/641
 
 
 

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -538,7 +538,7 @@ class CallController extends GetxController {
     Size size = router.context!.mediaQuerySize;
 
     HardwareKeyboard.instance.addHandler(_onKey);
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.add(_onBack, ifNotYetIntercepted: true);
     }
 
@@ -807,7 +807,7 @@ class CallController extends GetxController {
     }
 
     HardwareKeyboard.instance.removeHandler(_onKey);
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.remove(_onBack);
     }
 

--- a/lib/ui/page/call/participant/controller.dart
+++ b/lib/ui/page/call/participant/controller.dart
@@ -105,7 +105,7 @@ class ParticipantController extends GetxController {
 
   @override
   void onInit() {
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.add(_onBack, ifNotYetIntercepted: true);
     }
 
@@ -149,7 +149,7 @@ class ParticipantController extends GetxController {
     _stateWorker?.dispose();
     _chatWorker?.dispose();
 
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.remove(_onBack);
     }
 

--- a/lib/ui/page/home/page/chat/message_field/component/more.dart
+++ b/lib/ui/page/home/page/chat/message_field/component/more.dart
@@ -199,8 +199,10 @@ class _MessageFieldMoreState extends State<MessageFieldMore>
   Future<void> dismiss() async {
     _worker?.dispose();
     _worker = null;
+
     await _controller.reverse();
     widget.onDismissed?.call();
+
     if (widget.c.moreOpened.isTrue) {
       widget.c.toggleMore();
     }

--- a/lib/ui/page/home/page/chat/message_field/component/more.dart
+++ b/lib/ui/page/home/page/chat/message_field/component/more.dart
@@ -27,18 +27,65 @@ import '/util/platform_utils.dart';
 /// Visual representation of the [MessageFieldController.panel].
 ///
 /// Intended to be drawn in the overlay.
-class MessageFieldMore extends StatelessWidget {
-  const MessageFieldMore(this.c, {super.key});
+class MessageFieldMore extends StatefulWidget {
+  const MessageFieldMore(this.c, {super.key, this.onDismissed});
 
   /// [MessageFieldController] this [MessageFieldMore] is bound to.
   final MessageFieldController c;
+
+  /// Callback, called when animation of this [MessageFieldMore] is
+  /// [AnimationStatus.dismissed].
+  final void Function()? onDismissed;
+
+  @override
+  State<MessageFieldMore> createState() => _MessageFieldMoreState();
+}
+
+/// State of a [MessageFieldMore] maintaining the [_controller].
+class _MessageFieldMoreState extends State<MessageFieldMore>
+    with TickerProviderStateMixin {
+  /// Controller animating [FadeTransition].
+  late AnimationController _controller;
+
+  /// Animation of [FadeTransition].
+  late Animation<double> _animation;
+
+  /// [Worker] reacting on the [MessageFieldController.moreOpened] changes
+  /// [dismiss]ing this [MessageFieldMore]
+  Worker? _worker;
+
+  @override
+  void initState() {
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 150),
+      vsync: this,
+    )..forward();
+
+    _animation = CurvedAnimation(parent: _controller, curve: Curves.easeIn);
+
+    _worker = ever(widget.c.moreOpened, (opened) {
+      if (!opened) {
+        dismiss();
+      }
+    });
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _worker?.dispose();
+    _worker = null;
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final style = Theme.of(context).style;
 
     return LayoutBuilder(builder: (context, constraints) {
-      final Rect? rect = c.fieldKey.globalPaintBounds;
+      final Rect? rect = widget.c.fieldKey.globalPaintBounds;
 
       final double left = rect?.left ?? 0;
       final double right =
@@ -48,23 +95,23 @@ class MessageFieldMore extends StatelessWidget {
           : (constraints.maxHeight - rect.bottom + rect.height);
 
       final List<Widget> widgets = [];
-      for (int i = 0; i < c.panel.length; ++i) {
-        final e = c.panel.elementAt(i);
+      for (int i = 0; i < widget.c.panel.length; ++i) {
+        final e = widget.c.panel.elementAt(i);
 
         widgets.add(
           Obx(() {
-            final bool contains = c.buttons.contains(e);
+            final bool contains = widget.c.buttons.contains(e);
 
             return ChatMoreWidget(
               e,
               pinned: contains,
-              onPressed: c.toggleMore,
-              onPin: contains || c.canPin.value
+              onPressed: dismiss,
+              onPin: contains || widget.c.canPin.value
                   ? () {
-                      if (c.buttons.contains(e)) {
-                        c.buttons.remove(e);
+                      if (widget.c.buttons.contains(e)) {
+                        widget.c.buttons.remove(e);
                       } else {
-                        c.buttons.add(e);
+                        widget.c.buttons.add(e);
                       }
                     }
                   : null,
@@ -78,70 +125,84 @@ class MessageFieldMore extends StatelessWidget {
         children: widgets,
       );
 
-      return Stack(
-        fit: StackFit.expand,
-        children: [
-          Align(
-            alignment: Alignment.topLeft,
-            child: Listener(
-              onPointerDown: (_) => c.toggleMore(),
-              child: Container(
-                width: rect?.left ?? constraints.maxWidth,
-                height: constraints.maxHeight,
-                color: style.colors.transparent,
-              ),
-            ),
-          ),
-          Align(
-            alignment: Alignment.topLeft,
-            child: Listener(
-              onPointerDown: (_) => c.toggleMore(),
-              child: Container(
-                margin: EdgeInsets.only(
-                  left: (rect?.left ?? constraints.maxWidth) + 50,
+      return FadeTransition(
+        opacity: _animation,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Align(
+              alignment: Alignment.topLeft,
+              child: Listener(
+                onPointerDown: (_) => dismiss(),
+                child: Container(
+                  width: rect?.left ?? constraints.maxWidth,
+                  height: constraints.maxHeight,
+                  color: style.colors.transparent,
                 ),
-                width: constraints.maxWidth -
-                    (rect?.left ?? constraints.maxWidth) -
-                    50,
-                height: constraints.maxHeight,
-                color: style.colors.transparent,
               ),
             ),
-          ),
-          Align(
-            alignment: Alignment.topLeft,
-            child: Listener(
-              onPointerDown: (_) => c.toggleMore(),
-              child: Container(
-                margin:
-                    EdgeInsets.only(left: (rect?.left ?? constraints.maxWidth)),
-                width: 50,
-                height: rect?.top ?? 0,
-                color: style.colors.transparent,
-              ),
-            ),
-          ),
-          Positioned(
-            left: left,
-            right: context.isNarrow ? right : null,
-            bottom: bottom + 10,
-            child: Container(
-              decoration: BoxDecoration(
-                color: style.colors.onPrimary,
-                borderRadius: style.cardRadius,
-                boxShadow: [
-                  CustomBoxShadow(
-                    blurRadius: 8,
-                    color: style.colors.onBackgroundOpacity13,
+            Align(
+              alignment: Alignment.topLeft,
+              child: Listener(
+                onPointerDown: (_) => dismiss(),
+                child: Container(
+                  margin: EdgeInsets.only(
+                    left: (rect?.left ?? constraints.maxWidth) + 50,
                   ),
-                ],
+                  width: constraints.maxWidth -
+                      (rect?.left ?? constraints.maxWidth) -
+                      50,
+                  height: constraints.maxHeight,
+                  color: style.colors.transparent,
+                ),
               ),
-              child:
-                  context.isNarrow ? actions : IntrinsicWidth(child: actions),
             ),
-          ),
-        ],
+            Align(
+              alignment: Alignment.topLeft,
+              child: Listener(
+                onPointerDown: (_) => dismiss(),
+                child: Container(
+                  margin: EdgeInsets.only(
+                      left: (rect?.left ?? constraints.maxWidth)),
+                  width: 50,
+                  height: rect?.top ?? 0,
+                  color: style.colors.transparent,
+                ),
+              ),
+            ),
+            Positioned(
+              left: left,
+              right: context.isNarrow ? right : null,
+              bottom: bottom + 10,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: style.colors.onPrimary,
+                  borderRadius: style.cardRadius,
+                  boxShadow: [
+                    CustomBoxShadow(
+                      blurRadius: 8,
+                      color: style.colors.onBackgroundOpacity13,
+                    ),
+                  ],
+                ),
+                child:
+                    context.isNarrow ? actions : IntrinsicWidth(child: actions),
+              ),
+            ),
+          ],
+        ),
       );
     });
+  }
+
+  /// Dismisses this [MessageFieldMore] with animation.
+  Future<void> dismiss() async {
+    _worker?.dispose();
+    _worker = null;
+    await _controller.reverse();
+    widget.onDismissed?.call();
+    if(widget.c.moreOpened.isTrue) {
+      widget.c.toggleMore();
+    }
   }
 }

--- a/lib/ui/page/home/page/chat/message_field/component/more.dart
+++ b/lib/ui/page/home/page/chat/message_field/component/more.dart
@@ -47,7 +47,7 @@ class _MessageFieldMoreState extends State<MessageFieldMore>
   /// Controller animating [FadeTransition].
   late AnimationController _controller;
 
-  /// Animation of [FadeTransition].
+  /// Animation of [FadeTransition] and [SlideTransition].
   late Animation<double> _animation;
 
   /// [Worker] reacting on the [MessageFieldController.moreOpened] changes
@@ -57,11 +57,11 @@ class _MessageFieldMoreState extends State<MessageFieldMore>
   @override
   void initState() {
     _controller = AnimationController(
-      duration: const Duration(milliseconds: 150),
+      duration: const Duration(milliseconds: 200),
       vsync: this,
     )..forward();
 
-    _animation = CurvedAnimation(parent: _controller, curve: Curves.easeIn);
+    _animation = CurvedAnimation(parent: _controller, curve: Curves.ease);
 
     _worker = ever(widget.c.moreOpened, (opened) {
       if (!opened) {
@@ -125,72 +125,83 @@ class _MessageFieldMoreState extends State<MessageFieldMore>
         children: widgets,
       );
 
-      return FadeTransition(
-        opacity: _animation,
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            Align(
-              alignment: Alignment.topLeft,
-              child: Listener(
-                onPointerDown: (_) => dismiss(),
-                child: Container(
-                  width: rect?.left ?? constraints.maxWidth,
-                  height: constraints.maxHeight,
-                  color: style.colors.transparent,
-                ),
-              ),
-            ),
-            Align(
-              alignment: Alignment.topLeft,
-              child: Listener(
-                onPointerDown: (_) => dismiss(),
-                child: Container(
-                  margin: EdgeInsets.only(
-                    left: (rect?.left ?? constraints.maxWidth) + 50,
-                  ),
-                  width: constraints.maxWidth -
-                      (rect?.left ?? constraints.maxWidth) -
-                      50,
-                  height: constraints.maxHeight,
-                  color: style.colors.transparent,
-                ),
-              ),
-            ),
-            Align(
-              alignment: Alignment.topLeft,
-              child: Listener(
-                onPointerDown: (_) => dismiss(),
-                child: Container(
-                  margin: EdgeInsets.only(
-                      left: (rect?.left ?? constraints.maxWidth)),
-                  width: 50,
-                  height: rect?.top ?? 0,
-                  color: style.colors.transparent,
-                ),
-              ),
-            ),
-            Positioned(
-              left: left,
-              right: context.isNarrow ? right : null,
-              bottom: bottom + 10,
+      return Stack(
+        fit: StackFit.expand,
+        children: [
+          Align(
+            alignment: Alignment.topLeft,
+            child: Listener(
+              onPointerDown: (_) => dismiss(),
               child: Container(
-                decoration: BoxDecoration(
-                  color: style.colors.onPrimary,
-                  borderRadius: style.cardRadius,
-                  boxShadow: [
-                    CustomBoxShadow(
-                      blurRadius: 8,
-                      color: style.colors.onBackgroundOpacity13,
-                    ),
-                  ],
-                ),
-                child:
-                    context.isNarrow ? actions : IntrinsicWidth(child: actions),
+                width: rect?.left ?? constraints.maxWidth,
+                height: constraints.maxHeight,
+                color: style.colors.transparent,
               ),
             ),
-          ],
-        ),
+          ),
+          Align(
+            alignment: Alignment.topLeft,
+            child: Listener(
+              onPointerDown: (_) => dismiss(),
+              child: Container(
+                margin: EdgeInsets.only(
+                  left: (rect?.left ?? constraints.maxWidth) + 50,
+                ),
+                width: constraints.maxWidth -
+                    (rect?.left ?? constraints.maxWidth) -
+                    50,
+                height: constraints.maxHeight,
+                color: style.colors.transparent,
+              ),
+            ),
+          ),
+          Align(
+            alignment: Alignment.topLeft,
+            child: Listener(
+              onPointerDown: (_) => dismiss(),
+              child: Container(
+                margin:
+                    EdgeInsets.only(left: (rect?.left ?? constraints.maxWidth)),
+                width: 50,
+                height: rect?.top ?? 0,
+                color: style.colors.transparent,
+              ),
+            ),
+          ),
+          Positioned(
+            left: left,
+            right: context.isNarrow ? right : null,
+            bottom: 0,
+            child: SlideTransition(
+              position: Tween(
+                begin: context.isMobile ? const Offset(0, 1) : Offset.zero,
+                end: Offset.zero,
+              ).animate(_animation),
+              child: FadeTransition(
+                opacity: Tween(
+                  begin: context.isMobile ? 1.0 : 0.0,
+                  end: 1.0,
+                ).animate(_animation),
+                child: Container(
+                  margin: EdgeInsets.only(bottom: bottom + 10),
+                  decoration: BoxDecoration(
+                    color: style.colors.onPrimary,
+                    borderRadius: style.cardRadius,
+                    boxShadow: [
+                      CustomBoxShadow(
+                        blurRadius: 8,
+                        color: style.colors.onBackgroundOpacity13,
+                      ),
+                    ],
+                  ),
+                  child: context.isNarrow
+                      ? actions
+                      : IntrinsicWidth(child: actions),
+                ),
+              ),
+            ),
+          ),
+        ],
       );
     });
   }

--- a/lib/ui/page/home/page/chat/message_field/component/more.dart
+++ b/lib/ui/page/home/page/chat/message_field/component/more.dart
@@ -201,7 +201,7 @@ class _MessageFieldMoreState extends State<MessageFieldMore>
     _worker = null;
     await _controller.reverse();
     widget.onDismissed?.call();
-    if(widget.c.moreOpened.isTrue) {
+    if (widget.c.moreOpened.isTrue) {
       widget.c.toggleMore();
     }
   }

--- a/lib/ui/page/home/page/chat/message_field/controller.dart
+++ b/lib/ui/page/home/page/chat/message_field/controller.dart
@@ -285,10 +285,13 @@ class MessageFieldController extends GetxController {
   void toggleMore() {
     if (moreOpened.isFalse) {
       _moreEntry = OverlayEntry(
-        builder: (_) => MessageFieldMore(this, onDismissed: () {
-          _moreEntry?.remove();
-          _moreEntry = null;
-        }),
+        builder: (_) => MessageFieldMore(
+          this,
+          onDismissed: () {
+            _moreEntry?.remove();
+            _moreEntry = null;
+          },
+        ),
       );
       router.overlay!.insert(_moreEntry!);
     }

--- a/lib/ui/page/home/page/chat/message_field/controller.dart
+++ b/lib/ui/page/home/page/chat/message_field/controller.dart
@@ -194,18 +194,22 @@ class MessageFieldController extends GetxController {
   /// [AbstractSettingsRepository], used to get the [buttons] value.
   final AbstractSettingsRepository _settingsRepository;
 
-  /// Worker reacting on the [replied] changes.
+  /// [Worker] reacting on the [replied] changes.
   Worker? _repliesWorker;
 
-  /// Worker reacting on the [attachments] changes.
+  /// [Worker] reacting on the [attachments] changes.
   Worker? _attachmentsWorker;
 
-  /// Worker reacting on the [edited] changes.
+  /// [Worker] reacting on the [edited] changes.
   Worker? _editedWorker;
 
-  /// Worker capturing any [buttons] changes to update the
+  /// [Worker] capturing any [buttons] changes to update the
   /// [ApplicationSettings.pinnedActions] value.
   Worker? _buttonsWorker;
+
+  /// [Worker] reacting on the [RouterState.routes] changes hiding the
+  /// [_moreEntry].
+  Worker? _routesWorker;
 
   /// [OverlayEntry] of the [MessageFieldMore].
   OverlayEntry? _moreEntry;
@@ -240,6 +244,14 @@ class MessageFieldController extends GetxController {
       );
     });
 
+    String route = router.route;
+    _routesWorker = ever(router.routes, (routes) {
+      if (router.route != route) {
+        _moreEntry?.remove();
+        _moreEntry = null;
+      }
+    });
+
     super.onInit();
   }
 
@@ -250,6 +262,7 @@ class MessageFieldController extends GetxController {
     _attachmentsWorker?.dispose();
     _editedWorker?.dispose();
     _buttonsWorker?.dispose();
+    _routesWorker?.dispose();
 
     if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.remove(_onBack);

--- a/lib/ui/page/home/page/chat/message_field/controller.dart
+++ b/lib/ui/page/home/page/chat/message_field/controller.dart
@@ -215,7 +215,7 @@ class MessageFieldController extends GetxController {
 
   @override
   void onInit() {
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.add(_onBack, ifNotYetIntercepted: true);
     }
 
@@ -250,6 +250,11 @@ class MessageFieldController extends GetxController {
     _attachmentsWorker?.dispose();
     _editedWorker?.dispose();
     _buttonsWorker?.dispose();
+
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
+      BackButtonInterceptor.remove(_onBack);
+    }
+
     super.onClose();
   }
 
@@ -265,11 +270,13 @@ class MessageFieldController extends GetxController {
 
   /// Toggles the [moreOpened] and populates the [_moreEntry].
   void toggleMore() {
-    if (moreOpened.isTrue) {
-      _moreEntry?.remove();
-      _moreEntry = null;
-    } else {
-      _moreEntry = (OverlayEntry(builder: (_) => MessageFieldMore(this)));
+    if (moreOpened.isFalse) {
+      _moreEntry = OverlayEntry(
+        builder: (_) => MessageFieldMore(this, onDismissed: () {
+          _moreEntry?.remove();
+          _moreEntry = null;
+        }),
+      );
       router.overlay!.insert(_moreEntry!);
     }
 

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -174,7 +174,7 @@ class ChatsTabController extends GetxController {
     chats = RxList<RxChat>(_chatService.paginated.values.toList());
 
     HardwareKeyboard.instance.addHandler(_escapeListener);
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.add(_onBack, ifNotYetIntercepted: true);
     }
 
@@ -262,7 +262,7 @@ class ChatsTabController extends GetxController {
     HardwareKeyboard.instance.removeHandler(_escapeListener);
     scrollController.removeListener(_scrollListener);
 
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.remove(_onBack);
     }
 

--- a/lib/ui/page/home/tab/contacts/controller.dart
+++ b/lib/ui/page/home/tab/contacts/controller.dart
@@ -144,7 +144,7 @@ class ContactsTabController extends GetxController {
     _initUsersUpdates();
 
     HardwareKeyboard.instance.addHandler(_escapeListener);
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.add(_onBack, ifNotYetIntercepted: true);
     }
 
@@ -163,7 +163,7 @@ class ContactsTabController extends GetxController {
     _userWorkers.forEach((_, v) => v.dispose());
 
     HardwareKeyboard.instance.removeHandler(_escapeListener);
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.remove(_onBack);
     }
 

--- a/lib/ui/page/home/widget/gallery_popup.dart
+++ b/lib/ui/page/home/widget/gallery_popup.dart
@@ -326,7 +326,7 @@ class _GalleryPopupState extends State<GalleryPopup>
 
     Future.delayed(Duration.zero, _displayControls);
 
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.add(_onBack);
     }
 
@@ -342,7 +342,7 @@ class _GalleryPopupState extends State<GalleryPopup>
       _exitFullscreen();
     }
 
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.remove(_onBack);
     }
 

--- a/lib/ui/widget/context_menu/mobile.dart
+++ b/lib/ui/widget/context_menu/mobile.dart
@@ -216,7 +216,7 @@ class _AnimatedMenuState extends State<_AnimatedMenu>
 
   @override
   void initState() {
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.add(_onBack, ifNotYetIntercepted: true);
     }
 
@@ -252,7 +252,7 @@ class _AnimatedMenuState extends State<_AnimatedMenu>
 
   @override
   void dispose() {
-    if (PlatformUtils.isMobile) {
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       BackButtonInterceptor.remove(_onBack);
     }
     _fading.dispose();


### PR DESCRIPTION
Resolves #641
Resolves #548




## Synopsis

`MessageFieldMore` появляется резко и без анимации.




## Solution

Анимация будет добавлена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
