### PR TITLE
Fix `OngoingCall` sending tracks before media has finished initializing

### DIFF
--- a/lib/ui/page/call/widget/video_view.dart
+++ b/lib/ui/page/call/widget/video_view.dart
@@ -190,7 +190,6 @@ class _RtcVideoViewState extends State<RtcVideoView> {
       mirror: widget.renderer.mirror,
       objectFit: VideoViewObjectFit.cover,
       enableContextMenu: widget.enableContextMenu,
-      autoRotate: widget.renderer.autoRotate,
     );
 
     // Wait for the size to be determined if necessary.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -978,10 +978,10 @@ packages:
     dependency: "direct main"
     description:
       name: medea_flutter_webrtc
-      sha256: "2b41dbe9bd690f868ff74425521b6b45dc28af879caa9662ec40999df1f8e798"
+      sha256: c5c6e772b76a9f6028aa608527c26c98d012441afe6f23a0bd0f7e84ce32a2c9
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.3-dev+rev.65596bcbac8d7aa997e4877697aaffec7dcf53f8"
+    version: "0.8.3-dev+rev.4622b6f7699e7205733cea57a6257fc40e2a94fa"
   medea_jason:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   intl: ^0.17.0
   js: ^0.6.5
   material_floating_search_bar: ^0.3.7
-  medea_flutter_webrtc: 0.8.3-dev+rev.65596bcbac8d7aa997e4877697aaffec7dcf53f8
+  medea_flutter_webrtc: 0.8.3-dev+rev.4622b6f7699e7205733cea57a6257fc40e2a94fa
   medea_jason: ^0.4.0
   media_kit: ^1.1.5
   media_kit_libs_android_video: ^1.3.2


### PR DESCRIPTION
## Synopsis

`OngoingCall` может отправлять треки ещё до окончания инициализации медиа, из-за чего стейт не синхронизируется и получается, что пользователи могут видеть расшарку, камеру итд без понимания того, что расшарка/видео идут.




## Solution

Происходит это, когда `joinRoom` происходит раньше, чем устанавливаются настройки треки. Решение: по умолчанию сразу после инициализации комнаты выставлять все настройки в `false`.




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
