### PR TITLE
Fix save button behavior (#575)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,14 @@ All user visible changes to this project will be documented in this file. This p
         - Redesigned typography tab. ([#663], [#615])
     - Chat page:
         - Display message field while loading. ([#662], [#634])
-    - Profile page:
-        - Refactored Login filed behavior. ([#672], [#575])
 - Web:
     - Updated loading animation. ([#662], [#634])
+
+### Fixed
+
+- UI:
+    - Profile page:
+        - Save button displaying when login field is empty. ([#672], [#575])
 
 [#615]: /../../issues/615
 [#634]: /../../issues/634

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All user visible changes to this project will be documented in this file. This p
     - Profile page:
         - Refactored Login filed behavior. ([#672], [#575])
 - Web:
-    - Updated loading animation. ([#672], [#634])
+    - Updated loading animation. ([#662], [#634])
 
 [#615]: /../../issues/615
 [#634]: /../../issues/634

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,17 @@ All user visible changes to this project will be documented in this file. This p
         - Redesigned typography tab. ([#663], [#615])
     - Chat page:
         - Display message field while loading. ([#662], [#634])
+    - Profile page:
+        - Refactored Login filed behavior. ([#672], [#575])
 - Web:
-    - Updated loading animation. ([#662], [#634])
+    - Updated loading animation. ([#672], [#634])
 
 [#615]: /../../issues/615
 [#634]: /../../issues/634
+[#575]: /../../issues/575
 [#662]: /../../pull/662
 [#663]: /../../pull/663
+[#672]: /../../pull/672
 
 
 

--- a/lib/ui/page/home/page/my_profile/widget/login.dart
+++ b/lib/ui/page/home/page/my_profile/widget/login.dart
@@ -123,6 +123,7 @@ class _UserLoginFieldState extends State<UserLoginField> {
             ),
       label: 'label_login'.l10n,
       hint: widget.login == null ? 'label_login_hint'.l10n : widget.login!.val,
+      canBeEmpty: false,
       subtitle: RichText(
         text: TextSpan(
           children: [

--- a/lib/ui/page/home/page/my_profile/widget/login.dart
+++ b/lib/ui/page/home/page/my_profile/widget/login.dart
@@ -123,7 +123,7 @@ class _UserLoginFieldState extends State<UserLoginField> {
             ),
       label: 'label_login'.l10n,
       hint: widget.login == null ? 'label_login_hint'.l10n : widget.login!.val,
-      canBeEmpty: false,
+      clearable: false,
       subtitle: RichText(
         text: TextSpan(
           children: [

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -61,7 +61,7 @@ class ReactiveTextField extends StatelessWidget {
     this.treatErrorAsStatus = true,
     this.type,
     this.subtitle,
-    this.canBeEmpty = true,
+    this.clearable = true,
   });
 
   /// Reactive state of this [ReactiveTextField].
@@ -153,8 +153,8 @@ class ReactiveTextField extends StatelessWidget {
   /// Maximum number of characters allowed in this [TextField].
   final int? maxLength;
 
-  /// Indicator whether this [ReactiveTextField] can be empty
-  final bool canBeEmpty;
+  /// Indicator whether this [ReactiveTextField] should display
+  final bool clearable;
 
   @override
   Widget build(BuildContext context) {
@@ -194,7 +194,9 @@ class ReactiveTextField extends StatelessWidget {
 
         return AnimatedButton(
           onPressed: state.approvable && state.changed.value
-              ? state.submit
+              ? state.isEmpty.value && !clearable
+                  ? null
+                  : state.submit
               : onSuffixPressed,
           decorator: (child) {
             if (!hasSuffix) {
@@ -239,11 +241,14 @@ class ReactiveTextField extends StatelessWidget {
                                         color: style.colors.danger,
                                       ),
                                     )
-                                  : state.isEmpty.value && !canBeEmpty
-                                      ? const SizedBox(width: 1, height: 0)
-                                      : (state.approvable &&
-                                              state.changed.value)
-                                          ? AllowOverflow(
+                                  : (state.approvable && state.changed.value)
+                                      ? state.isEmpty.value && !clearable
+                                          ? const SizedBox(
+                                              key: Key('Empty'),
+                                              width: 1,
+                                              height: 0,
+                                            )
+                                          : AllowOverflow(
                                               key: const ValueKey('Approve'),
                                               child: Text(
                                                 'btn_save'.l10n,
@@ -251,13 +256,13 @@ class ReactiveTextField extends StatelessWidget {
                                                     .primary,
                                               ),
                                             )
-                                          : SizedBox(
-                                              key: const ValueKey('Icon'),
-                                              width: 24,
-                                              child: suffix != null
-                                                  ? Icon(suffix)
-                                                  : trailing,
-                                            ),
+                                      : SizedBox(
+                                          key: const ValueKey('Icon'),
+                                          width: 24,
+                                          child: suffix != null
+                                              ? Icon(suffix)
+                                              : trailing,
+                                        ),
                     ),
                   )
                 : const SizedBox(width: 1, height: 0),

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -61,6 +61,7 @@ class ReactiveTextField extends StatelessWidget {
     this.treatErrorAsStatus = true,
     this.type,
     this.subtitle,
+    this.canBeEmpty = true,
   });
 
   /// Reactive state of this [ReactiveTextField].
@@ -152,6 +153,9 @@ class ReactiveTextField extends StatelessWidget {
   /// Maximum number of characters allowed in this [TextField].
   final int? maxLength;
 
+  /// Indicator whether this [ReactiveTextField] can be empty
+  final bool canBeEmpty;
+
   @override
   Widget build(BuildContext context) {
     EdgeInsets? contentPadding = padding;
@@ -235,22 +239,25 @@ class ReactiveTextField extends StatelessWidget {
                                         color: style.colors.danger,
                                       ),
                                     )
-                                  : (state.approvable && state.changed.value && !state.isEmpty.value)
-                                      ? AllowOverflow(
-                                          key: const ValueKey('Approve'),
-                                          child: Text(
-                                            'btn_save'.l10n,
-                                            style: style
-                                                .fonts.small.regular.primary,
-                                          ),
-                                        )
-                                      : SizedBox(
-                                          key: const ValueKey('Icon'),
-                                          width: 24,
-                                          child: suffix != null
-                                              ? Icon(suffix)
-                                              : trailing,
-                                        ),
+                                  : state.isEmpty.value && !canBeEmpty
+                                      ? const SizedBox(width: 1, height: 0)
+                                      : (state.approvable &&
+                                              state.changed.value)
+                                          ? AllowOverflow(
+                                              key: const ValueKey('Approve'),
+                                              child: Text(
+                                                'btn_save'.l10n,
+                                                style: style.fonts.small.regular
+                                                    .primary,
+                                              ),
+                                            )
+                                          : SizedBox(
+                                              key: const ValueKey('Icon'),
+                                              width: 24,
+                                              child: suffix != null
+                                                  ? Icon(suffix)
+                                                  : trailing,
+                                            ),
                     ),
                   )
                 : const SizedBox(width: 1, height: 0),

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -235,7 +235,7 @@ class ReactiveTextField extends StatelessWidget {
                                         color: style.colors.danger,
                                       ),
                                     )
-                                  : (state.approvable && state.changed.value)
+                                  : (state.approvable && state.changed.value && !state.isEmpty.value)
                                       ? AllowOverflow(
                                           key: const ValueKey('Approve'),
                                           child: Text(

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -153,7 +153,8 @@ class ReactiveTextField extends StatelessWidget {
   /// Maximum number of characters allowed in this [TextField].
   final int? maxLength;
 
-  /// Indicator whether this [ReactiveTextField] should display
+  /// Indicator whether this [ReactiveTextField] should display a save button,
+  /// when being empty, if [state] is approvable.
   final bool clearable;
 
   @override


### PR DESCRIPTION
Resolves #575 

## Synopsis
Скрывать кнопку сохранить, когда в строке логина будет пусто

## Solution

Добавить индикатор, который указывает, что поле может быть пустым, и дополнительное условие в тернарном операторе




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
