### PR TITLE
Redesign delete message modal (#580)

### DIFF
--- a/lib/ui/page/call/widget/participant/widget.dart
+++ b/lib/ui/page/call/widget/participant/widget.dart
@@ -144,7 +144,11 @@ class ParticipantWidget extends StatelessWidget {
                 width: double.infinity,
                 height: double.infinity,
                 color: style.colors.onBackgroundOpacity50,
-                child: const Center(child: CustomProgressIndicator.big()),
+                child: Center(
+                  child: CustomProgressIndicator.big(
+                    value: Config.disableInfiniteAnimations ? 0 : null,
+                  ),
+                ),
               );
             }
 

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -1136,19 +1136,15 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                                   variants: [
                                     if (!deletable || !isMonolog)
                                       ConfirmDialogVariant(
+                                        key: const Key('HideForMe'),
                                         onProceed: widget.onHide,
-                                        child: Text(
-                                          'label_delete_for_me'.l10n,
-                                          key: const Key('HideForMe'),
-                                        ),
+                                        label: 'label_delete_for_me'.l10n,
                                       ),
                                     if (deletable)
                                       ConfirmDialogVariant(
+                                        key: const Key('DeleteForAll'),
                                         onProceed: widget.onDelete,
-                                        child: Text(
-                                          'label_delete_for_everyone'.l10n,
-                                          key: const Key('DeleteForAll'),
-                                        ),
+                                        label: 'label_delete_for_everyone'.l10n,
                                       )
                                   ],
                                 );

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1729,19 +1729,15 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                                   variants: [
                                     if (!deletable || !isMonolog)
                                       ConfirmDialogVariant(
+                                        key: const Key('HideForMe'),
                                         onProceed: widget.onHide,
-                                        child: Text(
-                                          'label_delete_for_me'.l10n,
-                                          key: const Key('HideForMe'),
-                                        ),
+                                        label: 'label_delete_for_me'.l10n,
                                       ),
                                     if (deletable)
                                       ConfirmDialogVariant(
+                                        key: const Key('DeleteForAll'),
                                         onProceed: widget.onDelete,
-                                        child: Text(
-                                          key: const Key('DeleteForAll'),
-                                          'label_delete_for_everyone'.l10n,
-                                        ),
+                                        label: 'label_delete_for_everyone'.l10n,
                                       )
                                   ],
                                 );
@@ -1777,11 +1773,9 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                                   title: 'label_delete_message'.l10n,
                                   variants: [
                                     ConfirmDialogVariant(
+                                      key: const Key('DeleteForAll'),
                                       onProceed: widget.onDelete,
-                                      child: Text(
-                                        'label_delete_for_everyone'.l10n,
-                                        key: const Key('DeleteForAll'),
-                                      ),
+                                      label: 'label_delete_for_everyone'.l10n,
                                     )
                                   ],
                                 );

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -361,15 +361,15 @@ Widget _emails(BuildContext context, MyProfileController c) {
                             variants: [
                               ConfirmDialogVariant(
                                 onProceed: () {},
-                                child: Text('label_all'.l10n),
+                                label: 'label_all'.l10n,
                               ),
                               ConfirmDialogVariant(
                                 onProceed: () {},
-                                child: Text('label_my_contacts'.l10n),
+                                label: 'label_my_contacts'.l10n,
                               ),
                               ConfirmDialogVariant(
                                 onProceed: () {},
-                                child: Text('label_nobody'.l10n),
+                                label: 'label_nobody'.l10n,
                               ),
                             ],
                           );
@@ -500,15 +500,15 @@ Widget _phones(BuildContext context, MyProfileController c) {
                             variants: [
                               ConfirmDialogVariant(
                                 onProceed: () {},
-                                child: Text('label_all'.l10n),
+                                label: 'label_all'.l10n,
                               ),
                               ConfirmDialogVariant(
                                 onProceed: () {},
-                                child: Text('label_my_contacts'.l10n),
+                                label: 'label_my_contacts'.l10n,
                               ),
                               ConfirmDialogVariant(
                                 onProceed: () {},
-                                child: Text('label_nobody'.l10n),
+                                label: 'label_nobody'.l10n,
                               ),
                             ],
                           );

--- a/lib/ui/page/home/page/my_profile/widget/login.dart
+++ b/lib/ui/page/home/page/my_profile/widget/login.dart
@@ -159,15 +159,15 @@ class _UserLoginFieldState extends State<UserLoginField> {
                     variants: [
                       ConfirmDialogVariant(
                         onProceed: () {},
-                        child: Text('label_all'.l10n),
+                        label: 'label_all'.l10n,
                       ),
                       ConfirmDialogVariant(
                         onProceed: () {},
-                        child: Text('label_my_contacts'.l10n),
+                        label: 'label_my_contacts'.l10n,
                       ),
                       ConfirmDialogVariant(
                         onProceed: () {},
-                        child: Text('label_nobody'.l10n),
+                        label: 'label_nobody'.l10n,
                       ),
                     ],
                   );

--- a/lib/ui/page/home/widget/confirm_dialog.dart
+++ b/lib/ui/page/home/widget/confirm_dialog.dart
@@ -19,19 +19,22 @@ import 'package:flutter/material.dart';
 
 import '/l10n/l10n.dart';
 import '/themes.dart';
-import '/ui/page/home/widget/avatar.dart';
+import '/ui/page/login/widget/primary_button.dart';
 import '/ui/widget/modal_popup.dart';
-import '/ui/widget/outlined_rounded_button.dart';
+import 'rectangle_button.dart';
 
 /// Variant of a [ConfirmDialog].
 class ConfirmDialogVariant<T> {
-  const ConfirmDialogVariant({required this.child, this.onProceed});
+  const ConfirmDialogVariant({this.key, required this.label, this.onProceed});
+
+  /// [Key] of this [ConfirmDialogVariant].
+  final Key? key;
 
   /// Callback, called when this [ConfirmDialogVariant] is submitted.
   final T? Function()? onProceed;
 
-  /// [Widget] representing this [ConfirmDialogVariant].
-  final Widget child;
+  /// Label representing this [ConfirmDialogVariant].
+  final String label;
 }
 
 /// Dialog confirming a specific action from the provided [variants].
@@ -96,15 +99,15 @@ class ConfirmDialog extends StatefulWidget {
 /// State of a [ConfirmDialog] keeping the selected [ConfirmDialogVariant].
 class _ConfirmDialogState extends State<ConfirmDialog> {
   /// Currently selected [ConfirmDialogVariant].
-  late ConfirmDialogVariant _variant;
+  late ConfirmDialogVariant _selected;
 
   /// [ScrollController] to pass to a [Scrollbar].
-  final ScrollController scrollController = ScrollController();
+  final ScrollController _scrollController = ScrollController();
 
   @override
   void didUpdateWidget(ConfirmDialog oldWidget) {
-    if (!widget.variants.contains(_variant)) {
-      setState(() => _variant = widget.variants.first);
+    if (!widget.variants.contains(_selected)) {
+      setState(() => _selected = widget.variants.first);
     }
 
     super.didUpdateWidget(oldWidget);
@@ -112,56 +115,13 @@ class _ConfirmDialogState extends State<ConfirmDialog> {
 
   @override
   void initState() {
-    _variant = widget.variants[widget.initial];
+    _selected = widget.variants[widget.initial];
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
     final style = Theme.of(context).style;
-
-    // Builds a button representing the provided [ConfirmDialogVariant].
-    Widget button(ConfirmDialogVariant variant) {
-      return Padding(
-        padding: ModalPopup.padding(context),
-        child: Material(
-          type: MaterialType.card,
-          borderRadius: style.cardRadius,
-          color: _variant == variant
-              ? style.colors.primary
-              : style.cardColor.darken(0.05),
-          child: InkWell(
-            onTap: () => setState(() => _variant = variant),
-            hoverColor: _variant == variant
-                ? style.colors.primary
-                : style.cardHoveredColor,
-            borderRadius: style.cardRadius,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 8, 4),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: DefaultTextStyle.merge(
-                      style: _variant == variant
-                          ? style.fonts.big.regular.onPrimary
-                          : style.fonts.big.regular.onBackground,
-                      child: variant.child,
-                    ),
-                  ),
-                  IgnorePointer(
-                    child: Radio<ConfirmDialogVariant>(
-                      value: variant,
-                      groupValue: _variant,
-                      onChanged: null,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      );
-    }
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -189,12 +149,27 @@ class _ConfirmDialogState extends State<ConfirmDialog> {
         if (widget.variants.length > 1)
           Flexible(
             child: Scrollbar(
-              controller: scrollController,
+              controller: _scrollController,
               child: ListView.separated(
-                controller: scrollController,
+                controller: _scrollController,
                 physics: const ClampingScrollPhysics(),
                 shrinkWrap: true,
-                itemBuilder: (c, i) => button(widget.variants[i]),
+                itemBuilder: (c, i) {
+                  final ConfirmDialogVariant variant = widget.variants[i];
+
+                  return Padding(
+                    padding: ModalPopup.padding(context),
+                    child: RectangleButton(
+                      key: variant.key,
+                      selected: _selected == variant,
+                      onPressed: _selected == variant
+                          ? null
+                          : () => setState(() => _selected = variant),
+                      label: variant.label,
+                      radio: true,
+                    ),
+                  );
+                },
                 separatorBuilder: (c, i) => const SizedBox(height: 10),
                 itemCount: widget.variants.length,
               ),
@@ -204,17 +179,12 @@ class _ConfirmDialogState extends State<ConfirmDialog> {
           const SizedBox(height: 25),
         Padding(
           padding: ModalPopup.padding(context),
-          child: OutlinedRoundedButton(
+          child: PrimaryButton(
             key: const Key('Proceed'),
-            maxWidth: double.infinity,
-            title: Text(
-              widget.label ?? 'btn_proceed'.l10n,
-              style: style.fonts.normal.regular.onPrimary,
-            ),
+            title: widget.label ?? 'btn_proceed'.l10n,
             onPressed: () {
-              Navigator.of(context).pop(_variant.onProceed?.call());
+              Navigator.of(context).pop(_selected.onProceed?.call());
             },
-            color: style.colors.primary,
           ),
         ),
         const SizedBox(height: 12),

--- a/lib/ui/page/home/widget/rectangle_button.dart
+++ b/lib/ui/page/home/widget/rectangle_button.dart
@@ -20,6 +20,7 @@ import 'package:flutter/material.dart';
 import '/themes.dart';
 import '/ui/page/home/widget/avatar.dart';
 import '/ui/widget/animated_switcher.dart';
+import '/ui/widget/selected_dot.dart';
 
 /// Rectangular filled selectable button.
 class RectangleButton extends StatelessWidget {
@@ -29,6 +30,7 @@ class RectangleButton extends StatelessWidget {
     this.onPressed,
     required this.label,
     this.trailingColor,
+    this.radio = false,
   });
 
   /// Label of this [RectangleButton].
@@ -37,6 +39,9 @@ class RectangleButton extends StatelessWidget {
   /// Indicator whether this [RectangleButton] is selected, meaning an
   /// [Icons.check] should be displayed in a trailing.
   final bool selected;
+
+  /// Indicator whether this [RectangleButton] is radio button.
+  final bool radio;
 
   /// Callback, called when this [RectangleButton] is pressed.
   final void Function()? onPressed;
@@ -50,8 +55,9 @@ class RectangleButton extends StatelessWidget {
 
     return Material(
       borderRadius: BorderRadius.circular(10),
-      color:
-          selected ? style.colors.primary : style.colors.onPrimary.darken(0.05),
+      color: selected && !radio
+          ? style.colors.primary
+          : style.colors.onPrimary.darken(0.05),
       child: InkWell(
         borderRadius: BorderRadius.circular(10),
         onTap: selected ? null : onPressed,
@@ -64,7 +70,7 @@ class RectangleButton extends StatelessWidget {
                   label,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
-                  style: selected
+                  style: selected && !radio
                       ? style.fonts.normal.regular.onPrimary
                       : style.fonts.normal.regular.onBackground,
                 ),
@@ -78,15 +84,21 @@ class RectangleButton extends StatelessWidget {
                     duration: const Duration(milliseconds: 200),
                     child: selected
                         ? CircleAvatar(
-                            backgroundColor: style.colors.onPrimary,
+                            backgroundColor: radio
+                                ? style.colors.primary
+                                : style.colors.onPrimary,
                             radius: 12,
                             child: Icon(
                               Icons.check,
-                              color: style.colors.primary,
+                              color: radio
+                                  ? style.colors.onPrimary
+                                  : style.colors.primary,
                               size: 12,
                             ),
                           )
-                        : const SizedBox(),
+                        : radio
+                            ? const SelectedDot()
+                            : const SizedBox(),
                   ),
                 )
               else

--- a/lib/ui/widget/progress_indicator.dart
+++ b/lib/ui/widget/progress_indicator.dart
@@ -20,7 +20,6 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import '/config.dart';
 import '/themes.dart';
 import '/ui/page/call/widget/conditional_backdrop.dart';
 
@@ -94,7 +93,7 @@ class CustomProgressIndicator extends StatelessWidget {
         decoration: const BoxDecoration(shape: BoxShape.circle),
         padding: blur ? padding : EdgeInsets.zero,
         child: _CustomCircularProgressIndicator(
-          value: Config.disableInfiniteAnimations ? 0 : value,
+          value: value,
           color: primary
               ? style.colors.primary
               : style.colors.secondaryHighlightDarkest,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -150,10 +150,10 @@ flutter:
   fonts:
     - family: NotoSansDisplay
       fonts:
-        - asset: assets/fonts/NotoSansDisplay-Bold.ttf
-          weight: 700
         - asset: assets/fonts/NotoSansDisplay-Regular.ttf
           weight: 400
+        - asset: assets/fonts/NotoSansDisplay-Bold.ttf
+          weight: 700
 
 sentry:
   upload_native_symbols: true


### PR DESCRIPTION
Resolves #580




## Synopsis

Изменился дизайн модального окна удаления сообщения из чата.




## Solution

Измения будут перенесены из `new-design-preview`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
