### PR TITLE
Disable `textScaleFactor` (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All user visible changes to this project will be documented in this file. This p
         - Redesigned typography tab. ([#663], [#615])
     - Chat page:
         - Display message field while loading. ([#662], [#634])
+    - Disabled larger fonts accessibility setting temporary. ([#679])
 - Web:
     - Updated loading animation. ([#662], [#634])
 
@@ -34,6 +35,7 @@ All user visible changes to this project will be documented in this file. This p
 [#662]: /../../pull/662
 [#663]: /../../pull/663
 [#672]: /../../pull/672
+[#679]: /../../pull/679
 
 
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -270,15 +270,18 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GetMaterialApp.router(
-      routerDelegate: router.delegate,
-      routeInformationParser: router.parser,
-      routeInformationProvider: router.provider,
-      navigatorObservers: [SentryNavigatorObserver()],
-      onGenerateTitle: (context) => 'Gapopa',
-      theme: Themes.light(),
-      themeMode: ThemeMode.light,
-      debugShowCheckedModeBanner: false,
+    return MediaQuery(
+      data: MediaQuery.of(context).copyWith(textScaleFactor: 1),
+      child: GetMaterialApp.router(
+        routerDelegate: router.delegate,
+        routeInformationParser: router.parser,
+        routeInformationProvider: router.provider,
+        navigatorObservers: [SentryNavigatorObserver()],
+        onGenerateTitle: (context) => 'Gapopa',
+        theme: Themes.light(),
+        themeMode: ThemeMode.light,
+        debugShowCheckedModeBanner: false,
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -150,10 +150,10 @@ flutter:
   fonts:
     - family: NotoSansDisplay
       fonts:
-        - asset: assets/fonts/NotoSansDisplay-Bold.ttf
-          weight: 700
         - asset: assets/fonts/NotoSansDisplay-Regular.ttf
           weight: 400
+        - asset: assets/fonts/NotoSansDisplay-Bold.ttf
+          weight: 700
 
 sentry:
   upload_native_symbols: true


### PR DESCRIPTION
Part of #411




## Synopsis

Если в настройках системы указать увеличенные шрифты, во многих местах приложение начинает выглядить некоректно.




## Solution

Увеличение шртфтов будет отключено.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
