### PR TITLE
Use `ImageFile.height` when displaying `ImageAttachment`s (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All user visible changes to this project will be documented in this file. This p
         - Redesigned typography tab. ([#663], [#615])
     - Chat page:
         - Display message field while loading. ([#662], [#634])
-        - Updated minimal image height to 100 pixels. ([#688], [#653])
+        - Display small images smaller. ([#688], [#653])
     - Disabled larger fonts accessibility setting temporary. ([#679])
     - Home page:
         - Redesigned introduction modal. ([#668], [#633])
@@ -33,9 +33,9 @@ All user visible changes to this project will be documented in this file. This p
     - Profile page:
         - Save button displaying when login field is empty. ([#672], [#575])
 
+[#575]: /../../issues/575
 [#615]: /../../issues/615
 [#634]: /../../issues/634
-[#575]: /../../issues/575
 [#633]: /../../issues/633
 [#653]: /../../issues/653
 [#662]: /../../pull/662

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All user visible changes to this project will be documented in this file. This p
         - Redesigned typography tab. ([#663], [#615])
     - Chat page:
         - Display message field while loading. ([#662], [#634])
+        - Updated minimal image height to 100 pixels. ([#688], [#653])
     - Disabled larger fonts accessibility setting temporary. ([#679])
     - Home page:
         - Redesigned introduction modal. ([#668], [#633])
@@ -36,11 +37,13 @@ All user visible changes to this project will be documented in this file. This p
 [#634]: /../../issues/634
 [#575]: /../../issues/575
 [#633]: /../../issues/633
+[#653]: /../../issues/653
 [#662]: /../../pull/662
 [#663]: /../../pull/663
 [#668]: /../../pull/668
 [#672]: /../../pull/672
 [#679]: /../../pull/679
+[#688]: /../../pull/688
 
 
 

--- a/lib/domain/model/native_file.dart
+++ b/lib/domain/model/native_file.dart
@@ -209,12 +209,15 @@ class NativeFile {
       //
       // Throws an error, if decoding fails.
       if (isImage && bytes.value != null) {
-        final decoded = await instantiateImageCodec(bytes.value!);
-        final frame = await decoded.getNextFrame();
-        dimensions.value = Size(
-          frame.image.width.toDouble(),
-          frame.image.height.toDouble(),
-        );
+        // TODO: Validate SVGs and retrieve its width and height.
+        if (!isSvg) {
+          final decoded = await instantiateImageCodec(bytes.value!);
+          final frame = await decoded.getNextFrame();
+          dimensions.value = Size(
+            frame.image.width.toDouble(),
+            frame.image.height.toDouble(),
+          );
+        }
       }
 
       return bytes.value;

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -225,7 +225,6 @@ class ChatItemWidget extends StatefulWidget {
       attachment = MediaAttachment(
         key: key,
         attachment: e,
-        height: 300,
         width: filled ? double.infinity : null,
         autoLoad: autoLoad,
         onError: onError,

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -15,6 +15,7 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -131,8 +132,12 @@ class _MediaAttachmentState extends State<MediaAttachment> {
         child = RetryImage.attachment(
           attachment as ImageAttachment,
           fit: widget.fit ?? (ratio > 3 ? BoxFit.contain : BoxFit.cover),
-          width: widget.width,
-          height: widget.height,
+          width: widget.width ?? max(100, file.width?.toDouble() ?? 550),
+          height: widget.height ??
+              max(
+                100,
+                min(file.height?.toDouble() ?? 300, 300),
+              ),
           onForbidden: widget.onError,
           cancelable: true,
           autoLoad: widget.autoLoad,

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -133,6 +133,7 @@ class _MediaAttachmentState extends State<MediaAttachment> {
           attachment as ImageAttachment,
           fit: widget.fit ?? (ratio > 3 ? BoxFit.contain : BoxFit.cover),
           width: widget.width,
+          minWidth: 75,
           height: widget.height ??
               max(
                 100,

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -132,7 +132,7 @@ class _MediaAttachmentState extends State<MediaAttachment> {
         child = RetryImage.attachment(
           attachment as ImageAttachment,
           fit: widget.fit ?? (ratio > 3 ? BoxFit.contain : BoxFit.cover),
-          width: widget.width ?? max(100, file.width?.toDouble() ?? 550),
+          width: widget.width,
           height: widget.height ??
               max(
                 100,

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -48,6 +48,7 @@ class RetryImage extends StatefulWidget {
     this.fit,
     this.height,
     this.width,
+    this.minWidth,
     this.borderRadius,
     this.onForbidden,
     this.filter,
@@ -63,6 +64,7 @@ class RetryImage extends StatefulWidget {
     BoxFit? fit,
     double? height,
     double? width,
+    double? minWidth,
     BorderRadius? borderRadius,
     Future<void> Function()? onForbidden,
     ImageFilter? filter,
@@ -88,6 +90,7 @@ class RetryImage extends StatefulWidget {
       fit: fit,
       height: height,
       width: width,
+      minWidth: minWidth,
       borderRadius: borderRadius,
       onForbidden: onForbidden,
       filter: filter,
@@ -121,6 +124,9 @@ class RetryImage extends StatefulWidget {
 
   /// Width of this [RetryImage].
   final double? width;
+
+  /// Minimal width of this [RetryImage].
+  final double? minWidth;
 
   /// [ImageFilter] to apply to this [RetryImage].
   final ImageFilter? filter;
@@ -213,7 +219,7 @@ class _RetryImageState extends State<RetryImage> {
   Widget build(BuildContext context) {
     final style = Theme.of(context).style;
 
-    final Widget child;
+    Widget child;
 
     if (_image != null) {
       Widget image;
@@ -311,7 +317,7 @@ class _RetryImageState extends State<RetryImage> {
     }
 
     if (widget.fallbackUrl != null && _image == null) {
-      return Stack(
+      child = Stack(
         alignment: Alignment.center,
         children: [
           SafeAnimatedSwitcher(
@@ -351,11 +357,14 @@ class _RetryImageState extends State<RetryImage> {
       );
     }
 
-    return KeyedSubtree(
-      key: Key('Image_${widget.url}'),
-      child: SafeAnimatedSwitcher(
-        duration: const Duration(milliseconds: 150),
-        child: child,
+    return ConstrainedBox(
+      constraints: BoxConstraints(minWidth: widget.minWidth ?? 0),
+      child: KeyedSubtree(
+        key: Key('Image_${widget.url}'),
+        child: SafeAnimatedSwitcher(
+          duration: const Duration(milliseconds: 150),
+          child: child,
+        ),
       ),
     );
   }


### PR DESCRIPTION
Resolves #653




## Synopsis

Картинки с высотой меньше 300 пикселей выглядят несуразно.




## Solution

Минимальная высота картинки будет уменьшена до 100 пикселей




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
