### PR TITLE
Throttle `GraphQlProvider.subscribe`s (#678)

### DIFF
--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -16,7 +16,6 @@
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
 import 'dart:async';
-import 'dart:math';
 
 import 'package:async/async.dart' show StreamGroup;
 import 'package:dio/dio.dart' as dio show DioException, Options, Response;
@@ -30,6 +29,7 @@ import '/domain/model/session.dart';
 import '/store/model/version.dart';
 import '/util/log.dart';
 import '/util/platform_utils.dart';
+import '/util/rate_limiter.dart';
 import 'exceptions.dart';
 import 'websocket/interface.dart'
     if (dart.library.io) 'websocket/io.dart'
@@ -125,6 +125,16 @@ class GraphQlClient {
   /// Indicator whether the [_wsLink] is connected.
   bool _wsConnected = false;
 
+  /// [RateLimiter] limiting the [subscribe] requests to the backend per second.
+  final RateLimiter _subscriptionLimiter = RateLimiter(
+    per: const Duration(milliseconds: 500),
+  );
+
+  /// [RateLimiter] limiting the [query] requests to the backend per second.
+  final RateLimiter _queryLimiter = RateLimiter(
+    per: const Duration(milliseconds: 500),
+  );
+
   /// Returns [GraphQLClient] with or without [token] header authorization.
   Future<GraphQLClient> get client async {
     if (_client != null && _currentToken == token) {
@@ -149,8 +159,9 @@ class GraphQlClient {
     Exception Function(Map<String, dynamic>)? handleException,
   ]) =>
       _middleware(() async {
-        QueryResult result =
-            await (await client).query(options).timeout(timeout);
+        final QueryResult result = await _queryLimiter.execute(
+          () async => await (await client).query(options).timeout(timeout),
+        );
         GraphQlProviderExceptions.fire(result, handleException);
         return result;
       });
@@ -232,71 +243,23 @@ class GraphQlClient {
   /// Disconnects the [client] and disposes the connection.
   void disconnect() {
     _disposeWebSocket();
+    _queryLimiter.clear();
+    _subscriptionLimiter.clear();
     _client = null;
   }
 
   /// Clears the cache attached to the [client].
   void clearCache() => _client?.cache.store.reset();
 
-  final List<Function> _queue = [];
-  Mutex? _subscribesMutex;
-  Timer? _subscribesTimer;
-  int _subscribes = 0;
-
-  FutureOr<T> _limited<T>(FutureOr<T> Function() callback) async {
-    // Start the [Timer] as soon as any operation is executed.
-    _subscribesTimer ??= Timer.periodic(const Duration(seconds: 1), (t) {
-      // Reduce the available slots by 5 every second.
-      _subscribes = max(0, _subscribes - 5);
-
-      print('[gql][$_subscribes] timer: second passed');
-
-      // If all the slots are available, then cancel the [Timer].
-      if (_subscribes <= 0) {
-        print('[gql][$_subscribes] timer: release mutex');
-        if (_subscribesMutex?.isLocked != false) {
-          _subscribesMutex?.release();
-          _subscribesMutex = null;
-        }
-
-        t.cancel();
-        _subscribesTimer?.cancel();
-        _subscribesTimer = null;
-      }
-    });
-
-    if (_subscribesMutex == null && _subscribes >= 5) {
-      print('[gql][$_subscribes] create mutex');
-      _subscribesMutex = Mutex();
-      await _subscribesMutex?.acquire();
-    }
-
-    ++_subscribes;
-    print('[gql][$_subscribes] ++, waiting');
-
-    // Wait for [_subscribesMutex] to become available, if not `null`.
-    await _subscribesMutex?.protect(() async {});
-
-    try {
-      final result = callback();
-      if (result is T) {
-        return result;
-      }
-
-      return await result;
-    } finally {
-      --_subscribes;
-      print('[gql][$_subscribes] -- done');
-    }
-  }
-
   /// Subscribes to a GraphQL subscription according to the [options] specified
   /// and returns a [Stream] which either emits received data or an error.
   ///
   /// Re-subscription is required on [ResubscriptionRequiredException] errors.
   Future<Stream<QueryResult>> _subscribe(SubscriptionOptions options) async {
-    final stream =
-        await _limited(() async => (await client).subscribe(options));
+    final stream = await _subscriptionLimiter.execute<Stream<QueryResult>>(
+      () async => (await client).subscribe(options),
+    );
+
     final connection = SubscriptionConnection(
       stream.expand((event) {
         Object? e = GraphQlProviderExceptions.parse(event);

--- a/lib/util/rate_limiter.dart
+++ b/lib/util/rate_limiter.dart
@@ -1,0 +1,115 @@
+// Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:mutex/mutex.dart';
+
+import '/util/backoff.dart';
+
+/// Utility limiting [Function] invokes to [requests] per the specified [per].
+class RateLimiter {
+  RateLimiter({
+    this.requests = 5,
+    this.per = const Duration(seconds: 1),
+  });
+
+  /// Requests allowed to be invoked in [per].
+  final int requests;
+
+  /// [Duration], per which the specified number of [requests] should be made.
+  final Duration per;
+
+  /// [Queue] of [Mutex]es locking the functions invoked.
+  @visibleForTesting
+  final Queue<Mutex> queue = Queue();
+
+  /// [Timer] unlocking the [queue] periodically.
+  Timer? _timer;
+
+  /// Iteration of this [RateLimiter], used to ignore queued functions, when
+  /// [clear] is invoked.
+  int _iteration = 0;
+
+  /// Executes the [function] limited to the [requests] per [per].
+  Future<T> execute<T>(FutureOr<T> Function() function) async {
+    // Current [_iteration] to ignore the invoke, if mismatched.
+    int iteration = _iteration;
+
+    // Start the [Timer] reducing the [_queue].
+    _timer ??= Timer.periodic(
+      per,
+      (_) {
+        // Remove unlocked [Mutex]es.
+        queue.removeWhere((e) => !e.isLocked);
+
+        if (queue.isEmpty) {
+          _timer?.cancel();
+          _timer = null;
+          return;
+        }
+
+        final taken = queue.take(requests);
+        for (var m in taken) {
+          m.release();
+        }
+      },
+    );
+
+    final Mutex mutex = Mutex();
+    queue.add(mutex);
+
+    if (queue.length > requests) {
+      await mutex.acquire();
+    }
+
+    await mutex.acquire();
+    try {
+      if (iteration != _iteration) {
+        throw OperationCanceledException();
+      }
+
+      if (function is T) {
+        return function();
+      }
+
+      return await function();
+    } finally {
+      if (mutex.isLocked) {
+        mutex.release();
+      }
+    }
+  }
+
+  /// Clears this [RateLimiter].
+  void clear() {
+    ++_iteration;
+
+    _timer?.cancel();
+    _timer = null;
+
+    for (var m in queue) {
+      if (m.isLocked) {
+        m.release();
+      }
+    }
+
+    queue.clear();
+  }
+}

--- a/test/unit/rate_limiter_test.dart
+++ b/test/unit/rate_limiter_test.dart
@@ -1,0 +1,143 @@
+// Copyright © 2022-2023 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:messenger/util/backoff.dart';
+import 'package:messenger/util/rate_limiter.dart';
+
+void main() async {
+  test('RateLimiter correctly limits its requests', () async {
+    const Duration per = Duration(milliseconds: 300);
+    const int requests = 5;
+
+    final RateLimiter limiter = RateLimiter(requests: requests, per: per);
+    expect(limiter.queue.length, 0);
+
+    final Set<int> finished = {};
+    final List<Future> futures = [];
+
+    for (var i = 0; i < requests * 5; ++i) {
+      futures.add(limiter.execute(() async => i)..then((v) => finished.add(v)));
+    }
+
+    DateTime startedAt = DateTime.now();
+
+    // Wait for [RateLimiter.execute]s to process.
+    await Future.wait(futures.take(requests));
+
+    expect(limiter.queue.length, requests * 5);
+    expect(finished.length, requests);
+    expect(finished, List.generate(requests, (i) => i));
+
+    // First bunch should be available almost immediately.
+    expect(
+      startedAt.difference(DateTime.now()) < const Duration(milliseconds: 16),
+      true,
+    );
+    startedAt = DateTime.now();
+
+    await Future.wait(futures.skip(requests).take(requests));
+    expect(finished.length, requests * 2);
+    expect(startedAt.difference(DateTime.now()) <= per, true);
+    startedAt = DateTime.now();
+
+    await Future.wait(futures.skip(requests * 2).take(requests));
+    expect(finished.length, requests * 3);
+    expect(startedAt.difference(DateTime.now()) <= per, true);
+    startedAt = DateTime.now();
+
+    await Future.wait(futures.skip(requests * 3).take(requests));
+    expect(finished.length, requests * 4);
+    expect(startedAt.difference(DateTime.now()) <= per, true);
+
+    await Future.wait(futures.skip(requests * 4).take(requests));
+    expect(finished.length, requests * 5);
+    startedAt = DateTime.now();
+
+    expect(limiter.queue.where((e) => e.isLocked).length, 0);
+
+    await Future.delayed(per);
+    expect(limiter.queue.length, 0);
+
+    // Next bunch should be executed immediately.
+    finished.clear();
+    futures.clear();
+    for (var i = 0; i < requests; ++i) {
+      futures.add(limiter.execute(() async => i)..then((v) => finished.add(v)));
+    }
+
+    startedAt = DateTime.now();
+
+    // Wait for [RateLimiter.execute]s to process.
+    await Future.wait(futures.take(requests));
+
+    expect(limiter.queue.length, requests);
+    expect(finished.length, requests);
+    expect(finished, List.generate(requests, (i) => i));
+
+    // First bunch should be available almost immediately.
+    expect(
+      startedAt.difference(DateTime.now()) < const Duration(milliseconds: 16),
+      true,
+    );
+
+    expect(limiter.queue.where((e) => e.isLocked).length, 0);
+
+    await Future.delayed(per);
+    expect(limiter.queue.length, 0);
+  });
+
+  test('RateLimiter correctly clears itself', () async {
+    const Duration per = Duration(milliseconds: 300);
+    const int requests = 5;
+
+    final RateLimiter limiter = RateLimiter(requests: requests, per: per);
+    expect(limiter.queue.length, 0);
+
+    int exceptions = 0;
+    final List<Future> futures = [];
+
+    for (var i = 0; i < requests * 2; ++i) {
+      futures.add(
+        limiter
+            .execute(() async => i)
+            .onError<OperationCanceledException>((_, __) => ++exceptions),
+      );
+    }
+
+    limiter.clear();
+
+    await Future.wait(futures);
+    expect(exceptions, requests * 2);
+
+    // Once again.
+    exceptions = 0;
+    futures.clear();
+    for (var i = 0; i < requests * 2; ++i) {
+      futures.add(
+        limiter
+            .execute(() async => i)
+            .onError<OperationCanceledException>((_, __) => ++exceptions),
+      );
+    }
+
+    limiter.clear();
+
+    await Future.wait(futures);
+    expect(exceptions, requests * 2);
+  });
+}


### PR DESCRIPTION
Resolves #678




## Synopsis

> При запуске приложения идёт подписка на тучу вещей: список контактов, список чатов, список звонков, каждый чат отдельно, все пользователи из диалогов, MyUser. Одновременно могут лететь по 30-50 подписок в один момент, это неприятное поведение.




## Solution

Добавить очередь из колбэков, которые будут выполняться по 5 штук раз в секунду.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
