### PR TITLE
Don't use `onActivityChanged` for `keepOnline` determination on desktop (#681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.1.0-alpha.12] · 2023-??-??
+[0.1.0-alpha.12]: /../../tree/v0.1.0-alpha.11
+
+[Diff](/../../compare/v0.1.0-alpha.11...v0.1.0-alpha.12) | [Milestone](/../../milestone/13)
+
+### Changed
+
+- UI:
+    - Always display online status on desktop. ([#702], [#681])
+
+[#681]: /../../issues/681
+[#702]: /../../pull/702
+
+
+
 ## [0.1.0-alpha.11] · 2023-11-02
 [0.1.0-alpha.11]: /../../tree/v0.1.0-alpha.11
 

--- a/lib/store/my_user.dart
+++ b/lib/store/my_user.dart
@@ -91,9 +91,9 @@ class MyUserRepository implements AbstractMyUserRepository {
   /// [GraphQlProvider.keepOnline] subscription keeping the [MyUser] online.
   StreamSubscription? _keepOnlineSubscription;
 
-  /// Subscription to the [PlatformUtils.onActivityChanged] initializing and
+  /// Subscription to the [PlatformUtils.onFocusChanged] initializing and
   /// canceling the [_keepOnlineSubscription].
-  StreamSubscription? _onActivityChanged;
+  StreamSubscription? _onFocusChanged;
 
   /// [CancelToken] for cancelling the [_fetchBlocklist].
   final CancelToken _cancelToken = CancelToken();
@@ -118,20 +118,22 @@ class MyUserRepository implements AbstractMyUserRepository {
     _initRemoteSubscription();
     _initBlacklistSubscription();
 
-    if (await PlatformUtils.isActive) {
+    if (PlatformUtils.isDesktop || await PlatformUtils.isFocused) {
       _initKeepOnlineSubscription();
     }
 
-    _onActivityChanged = PlatformUtils.onActivityChanged.listen((active) {
-      if (active) {
-        if (_keepOnlineSubscription == null) {
-          _initKeepOnlineSubscription();
+    if (!PlatformUtils.isDesktop) {
+      _onFocusChanged = PlatformUtils.onFocusChanged.listen((focused) {
+        if (focused) {
+          if (_keepOnlineSubscription == null) {
+            _initKeepOnlineSubscription();
+          }
+        } else {
+          _keepOnlineSubscription?.cancel();
+          _keepOnlineSubscription = null;
         }
-      } else {
-        _keepOnlineSubscription?.cancel();
-        _keepOnlineSubscription = null;
-      }
-    });
+      });
+    }
 
     if (!_blocklistLocal.isEmpty) {
       final List<RxUser?> users =
@@ -165,7 +167,7 @@ class MyUserRepository implements AbstractMyUserRepository {
     _blocklistSubscription?.cancel();
     _remoteSubscription?.close(immediate: true);
     _keepOnlineSubscription?.cancel();
-    _onActivityChanged?.cancel();
+    _onFocusChanged?.cancel();
     _cancelToken.cancel();
   }
 


### PR DESCRIPTION
Resolves #681




## Synopsis

> На данный момент используется понятие "активности" = приложение в фокусе и/или есть активность (движения курсора, тыки клавиатуры). Обсудили в https://github.com/team113/messenger/issues/680: предложено отказаться временно от такого решения




## Solution

1. Убрать `onActivityChanged` с десктопов вовсе.
2. Использовать `onFocusChanged` на мобилках.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
