### PR TITLE
Fix invalid `ChatCall.caller` name being displayed in `PopupCall`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,14 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Always display online status on desktop. ([#702], [#681])
 
+### Fixed
+
+- Web:
+    - Invalid caller name in popup calls. ([#711])
+
 [#681]: /../../issues/681
 [#702]: /../../pull/702
+[#711]: /../../pull/711
 
 
 

--- a/lib/util/web/web_utils.dart
+++ b/lib/util/web/web_utils.dart
@@ -85,6 +85,9 @@ class WebStoredCall {
               User(
                 UserId(data['call']['author']['id']),
                 UserNum(data['call']['author']['num']),
+                name: data['call']['author']['name'] == null
+                    ? null
+                    : UserName(data['call']['author']['name']),
               ),
               PreciseDateTime.parse(data['call']['at']),
               members: (data['call']['members'] as List<dynamic>)
@@ -146,6 +149,7 @@ class WebStoredCall {
               'author': {
                 'id': call!.author.id.val,
                 'num': call!.author.num.val,
+                'name': call!.author.name?.val,
               },
               'members': call!.members
                   .map((e) => {


### PR DESCRIPTION
## Synopsis

Звонки в вебе в отдельных окнах - имя звонящего пишется через `UserNum`.




## Solution

В `WebStoredCall` было пропущено имя.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
