### PR TITLE
Replace `ubuntu:latest` with `debian:bullseye` for Linux build CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,17 +140,6 @@ jobs:
           channel: stable
           cache: true
 
-      - run: sudo apt-get update -y
-        if: ${{ matrix.platform == 'linux' }}
-      - run: sudo apt-get install -y
-                          ninja-build
-                          libunwind-dev
-                          libgtk-3-dev
-                          libpulse-dev
-                          libmpv-dev
-                          mpv
-        if: ${{ matrix.platform == 'linux' }}
-
       - name: Configure FCM (Firebase Cloud Messaging)
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/service_account.json
@@ -172,7 +161,7 @@ jobs:
         if: ${{ matrix.platform == 'web' }}
 
       - run: flutter config --enable-${{ matrix.platform }}-desktop
-        if: ${{ contains('linux macos windows', matrix.platform) }}
+        if: ${{ contains('macos windows', matrix.platform) }}
 
       - name: Parse semver versions from Git tag
         id: semver
@@ -221,14 +210,12 @@ jobs:
           filename: ${{ github.workspace }}/artifacts/${{ steps.app.outputs.group1 }}-${{ matrix.platform }}.zip
           directory: ${{ (matrix.platform == 'ios'
                           && 'build/ios/iphoneos/dist')
-                      || (matrix.platform == 'linux'
-                          && 'build/linux/x64/release/bundle')
                       || (matrix.platform == 'macos'
                           && 'build/macos/Build/Products/Release/dist')
                       || (matrix.platform == 'windows'
                           && 'build/windows/runner/Release')
                       ||     'build/web'}}
-        if: ${{ contains('ios linux macos web windows', matrix.platform) }}
+        if: ${{ contains('ios macos web windows', matrix.platform) }}
 
       - name: Generate SHA256 checksums
         run: ${{ (runner.os == 'Windows'
@@ -261,6 +248,7 @@ jobs:
           # Unshallow the repository in order for `PubspecBuilder` and its
           # `git describe` to work.
           fetch-depth: 0
+      - run: git config --global --add safe.directory '*'
 
       - run: apt-get update -y
       - run: apt-get install -y
@@ -279,14 +267,11 @@ jobs:
                      clang
                      zip
 
-      - run: git config --global --add safe.directory '*'
-
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
-
       - run: flutter config --enable-linux-desktop
 
       - name: Parse semver versions from Git tag
@@ -314,11 +299,10 @@ jobs:
           regex: '^${{ github.repository_owner }}/(.+)$'
 
       - run: mkdir artifacts/
-
       - uses: thedoctor0/zip-release@0.7.1
         with:
           filename: ${{ github.workspace }}/artifacts/${{ steps.app.outputs.group1 }}-linux.zip
-          directory: 'build/linux/x64/release/bundle'
+          directory: build/linux/x64/release/bundle
 
       - name: Generate SHA256 checksums
         run: ${{ 'ls -1 | xargs -I {} sh -c "sha256sum {} > {}.sha256sum"' }}
@@ -331,6 +315,7 @@ jobs:
         with:
           name: build-linux-${{ github.run_number }}
           path: artifacts/
+          if-no-files-found: error
           retention-days: 1
 
   dartdoc:
@@ -356,9 +341,7 @@ jobs:
              || startsWith(github.ref, 'refs/tags/v') }}
 
   docker:
-    needs:
-      - build
-      - build-linux
+    needs: ["build", "build-linux"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
           # Unshallow the repository in order for `PubspecBuilder` and its
           # `git describe` to work.
           fetch-depth: 0
+
       - run: apt-get update -y
       - run: apt-get install -y
                      ninja-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,6 @@ jobs:
           # Unshallow the repository in order for `PubspecBuilder` and its
           # `git describe` to work.
           fetch-depth: 0
-      - run: git config --global --add safe.directory '*'
 
       - run: apt-get update -y
       - run: apt-get install -y
@@ -266,6 +265,8 @@ jobs:
                      cmake
                      clang
                      zip
+
+      - run: git config --global --add safe.directory '*'
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     needs:
       - build
+      - build-linux
       - copyright
       - dartanalyze
       - dartdoc
@@ -121,7 +122,6 @@ jobs:
           - apk
           - appbundle
           - ios
-          - linux
           - macos
           - web
           - windows
@@ -250,6 +250,88 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-linux:
+    name: build (linux)
+    runs-on: ubuntu-latest
+    # Pin glibc to 2.31 version for better compatibility.
+    container: debian:bullseye
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Unshallow the repository in order for `PubspecBuilder` and its
+          # `git describe` to work.
+          fetch-depth: 0
+      - run: apt-get update -y
+      - run: apt-get install -y
+                     ninja-build
+                     libunwind-dev
+                     libgtk-3-dev
+                     libpulse-dev
+                     libmpv-dev
+                     mpv
+                     jq
+                     curl
+                     git
+                     make
+                     procps
+                     cmake
+                     clang
+                     zip
+
+      - run: git config --global --add safe.directory '*'
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VER }}
+          channel: stable
+          cache: true
+
+      - run: flutter config --enable-linux-desktop
+
+      - name: Parse semver versions from Git tag
+        id: semver
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.ref }}
+          regex: '^refs/tags/v(((([0-9]+)\.[0-9]+)\.[0-9]+)(-.+)?)$'
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - run: make flutter.pub
+
+      - run: make flutter.build platform=linux
+                  dart-env='SOCAPP_HTTP_URL=${{ secrets.BACKEND_URL }}
+                            SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }}
+                            SOCAPP_WS_URL=${{ secrets.BACKEND_WS }}
+                            SOCAPP_WS_PORT=${{ secrets.BACKEND_PORT }}
+                            SOCAPP_USER_AGENT_VERSION=${{ steps.semver.outputs.group1 }}'
+
+      - name: Parse application name from Git repository name
+        id: app
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.repository }}
+          regex: '^${{ github.repository_owner }}/(.+)$'
+
+      - run: mkdir artifacts/
+
+      - uses: thedoctor0/zip-release@0.7.1
+        with:
+          filename: ${{ github.workspace }}/artifacts/${{ steps.app.outputs.group1 }}-linux.zip
+          directory: 'build/linux/x64/release/bundle'
+
+      - name: Generate SHA256 checksums
+        run: ${{ 'ls -1 | xargs -I {} sh -c "sha256sum {} > {}.sha256sum"' }}
+        working-directory: artifacts/
+      - name: Show generated SHA256 checksums
+        run: ${{ 'cat *.sha256sum' }}
+        working-directory: artifacts/
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build-linux-${{ github.run_number }}
+          path: artifacts/
+          retention-days: 1
+
   dartdoc:
     runs-on: ubuntu-latest
     steps:
@@ -273,7 +355,9 @@ jobs:
              || startsWith(github.ref, 'refs/tags/v') }}
 
   docker:
-    needs: ["build"]
+    needs:
+      - build
+      - build-linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -633,6 +717,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs:
       - build
+      - build-linux
       - copyright
       - dartanalyze
       - dartdoc


### PR DESCRIPTION
## Synopsis

CI build Linux under `ubuntu:latest` runner, however, seems like it uses kernel dependencies a bit too high for common Linux distributions.

E.g. currently built executable requires:

```
./libdesktop_drop_plugin.so: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by ./libdesktop_drop_plugin.so)
```

And `GLIBCXX_3.4.32` seems to be missing from more or less old Linux distros (e.g., Ubuntu 22.04, or even 23 still misses this version). Upgrading the `libstdc++` seems to be annoying for Linux users.




## Solution

This PR uses `debian` container for Linux building, introducing a new `build-linux` job (cuz GitHub doesn't allow to run different containers based on matrices).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
