### PR TITLE
Fix `renewSession` in `PopupCall`s sometimes overlap, causing `MyUser` to lose authorization (#728)

### DIFF
--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -73,7 +73,7 @@ class AuthService extends GetxService {
   final Duration _refreshTaskInterval = const Duration(minutes: 1);
 
   /// Minimal allowed [_session] TTL.
-  final Duration _accessTokenMinTtl = const Duration(minutes: 2);
+  final Duration _accessTokenMinTtl = const Duration(minutes: 3);
 
   /// Guard used to track [renewSession] completion.
   final Mutex _tokenGuard = Mutex();


### PR DESCRIPTION
Part of #728




## Synopsis

Иногда при активном popup звонке пользователя может разлогинить, так как в одном из окон используется протухший `RefreshToken`.




## Solution

Будет увеличено время ожидания обновления токена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
