### PR TITLE
Prevent AvatarWidget from rendering gradient when RetryImage is fetched (#435)

### DIFF
--- a/lib/ui/page/home/widget/avatar.dart
+++ b/lib/ui/page/home/widget/avatar.dart
@@ -386,76 +386,88 @@ class AvatarWidget extends StatelessWidget {
                   ? avatar?.medium
                   : avatar?.small;
 
-      return Badge(
-        largeSize: badgeSize * 1.16,
-        isLabelVisible: isOnline,
-        alignment: Alignment.bottomRight,
-        backgroundColor: style.colors.onPrimary,
-        padding: EdgeInsets.all(badgeSize / 12),
-        offset: maxWidth >= 40 ? const Offset(-2.5, -2.5) : const Offset(0, 0),
-        label: SizedBox(
-          width: badgeSize,
-          height: badgeSize,
-          child: Container(
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color:
-                  isAway ? style.colors.warning : style.colors.acceptAuxiliary,
+      final Widget defaultAvatar = Container(
+        margin: const EdgeInsets.all(0.5),
+        constraints: BoxConstraints(
+          minHeight: minHeight,
+          minWidth: minWidth,
+          maxWidth: maxWidth,
+          maxHeight: maxHeight,
+        ),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [gradient.lighten(), gradient],
+          ),
+          shape: BoxShape.circle,
+        ),
+        child: Center(
+          child: label ??
+              SelectionContainer.disabled(
+                child: Text(
+                  (title ?? '??').initials(),
+                  style: style.fonts.normal.bold.onPrimary.copyWith(
+                    fontSize: style.fonts.normal.bold.onPrimary.fontSize! *
+                        (maxWidth / 40.0),
+                  ),
+
+                  // Disable the accessibility size settings for this [Text].
+                  textScaler: const TextScaler.linear(1),
+                ),
+              ),
+        ),
+      );
+
+      return ConstrainedBox(
+        constraints: BoxConstraints(
+          minWidth: minWidth,
+          minHeight: minHeight,
+          maxWidth: maxWidth,
+          maxHeight: maxHeight,
+        ),
+        child: Badge(
+          largeSize: badgeSize * 1.16,
+          isLabelVisible: isOnline,
+          alignment: Alignment.bottomRight,
+          backgroundColor: style.colors.onPrimary,
+          padding: EdgeInsets.all(badgeSize / 12),
+          offset:
+              maxWidth >= 40 ? const Offset(-2.5, -2.5) : const Offset(0, 0),
+          label: SizedBox(
+            width: badgeSize,
+            height: badgeSize,
+            child: Container(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: isAway
+                    ? style.colors.warning
+                    : style.colors.acceptAuxiliary,
+              ),
             ),
           ),
-        ),
-        child: Stack(
-          children: [
-            Container(
-              margin: const EdgeInsets.all(0.5),
-              constraints: BoxConstraints(
-                minHeight: minHeight,
-                minWidth: minWidth,
-                maxWidth: maxWidth,
-                maxHeight: maxHeight,
-              ),
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [gradient.lighten(), gradient],
-                ),
-                shape: BoxShape.circle,
-              ),
-              child: Center(
-                child: label ??
-                    SelectionContainer.disabled(
-                      child: Text(
-                        (title ?? '??').initials(),
-                        style: style.fonts.normal.bold.onPrimary.copyWith(
-                          fontSize:
-                              style.fonts.normal.bold.onPrimary.fontSize! *
-                                  (maxWidth / 40.0),
+          child: Stack(
+            children: [
+              if (avatar == null) defaultAvatar,
+              if (avatar != null || child != null)
+                Positioned.fill(
+                  child: ClipOval(
+                    child: child ??
+                        RetryImage(
+                          image!.url,
+                          checksum: image.checksum,
+                          thumbhash: image.thumbhash,
+                          fit: BoxFit.cover,
+                          height: double.infinity,
+                          width: double.infinity,
+                          displayProgress: false,
+                          onForbidden: onForbidden,
+                          backgroundBuilder: () => defaultAvatar,
                         ),
-
-                        // Disable the accessibility size settings for this [Text].
-                        textScaler: const TextScaler.linear(1),
-                      ),
-                    ),
-              ),
-            ),
-            if (avatar != null || child != null)
-              Positioned.fill(
-                child: ClipOval(
-                  child: child ??
-                      RetryImage(
-                        image!.url,
-                        checksum: image.checksum,
-                        thumbhash: image.thumbhash,
-                        fit: BoxFit.cover,
-                        height: double.infinity,
-                        width: double.infinity,
-                        displayProgress: false,
-                        onForbidden: onForbidden,
-                      ),
+                  ),
                 ),
-              ),
-          ],
+            ],
+          ),
         ),
       );
     });

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -55,6 +55,7 @@ class RetryImage extends StatefulWidget {
     this.cancelable = false,
     this.autoLoad = true,
     this.displayProgress = true,
+    this.backgroundBuilder,
   });
 
   /// Constructs a [RetryImage] from the provided [attachment] loading the
@@ -151,6 +152,9 @@ class RetryImage extends StatefulWidget {
 
   /// Indicator whether the image fetching progress should be displayed.
   final bool displayProgress;
+
+  /// Optional background constructor that is shown under the loader
+  final Widget Function()? backgroundBuilder;
 
   @override
   State<RetryImage> createState() => _RetryImageState();
@@ -281,40 +285,46 @@ class _RetryImageState extends State<RetryImage> {
           height: widget.height,
           constraints: const BoxConstraints(minWidth: 200),
           alignment: Alignment.center,
-          child: Container(
-            constraints: const BoxConstraints(
-              maxHeight: 46,
-              maxWidth: 46,
-              minWidth: 10,
-              minHeight: 10,
-            ),
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                if (!_canceled && widget.displayProgress)
-                  CustomProgressIndicator.primary(
-                    value: _progress == 0 ? null : _progress.clamp(0, 1),
-                  ),
-                if (widget.cancelable)
-                  Center(
-                    child: _canceled
-                        ? Container(
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              boxShadow: [
-                                BoxShadow(
-                                  color: style.colors.onBackgroundOpacity20,
-                                  blurRadius: 8,
-                                  blurStyle: BlurStyle.outer.workaround,
+          child: Stack(
+            children: [
+              if (widget.backgroundBuilder != null)
+                widget.backgroundBuilder!.call(),
+              Container(
+                constraints: const BoxConstraints(
+                  maxHeight: 46,
+                  maxWidth: 46,
+                  minWidth: 10,
+                  minHeight: 10,
+                ),
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    if (!_canceled && widget.displayProgress)
+                      CustomProgressIndicator.primary(
+                        value: _progress == 0 ? null : _progress.clamp(0, 1),
+                      ),
+                    if (widget.cancelable)
+                      Center(
+                        child: _canceled
+                            ? Container(
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: style.colors.onBackgroundOpacity20,
+                                      blurRadius: 8,
+                                      blurStyle: BlurStyle.outer.workaround,
+                                    ),
+                                  ],
                                 ),
-                              ],
-                            ),
-                            child: const SvgIcon(SvgIcons.download),
-                          )
-                        : const SvgIcon(SvgIcons.closePrimary),
-                  ),
-              ],
-            ),
+                                child: const SvgIcon(SvgIcons.download),
+                              )
+                            : const SvgIcon(SvgIcons.closePrimary),
+                      ),
+                  ],
+                ),
+              ),
+            ],
           ),
         ),
       );


### PR DESCRIPTION
Resolves #435




## Synopsis

<Give a brief overview of the problem>
Необходимо было исключить рендер дефолтного аватара при наличии пользовательского аватара




## Solution

Проблему постоянного рендера решил добавлением условия для рендера дефолтного аватара, а для сохранения визуального эффекта добавил необязательный `backgroundBuilder` метод в `RetryImage` виджет, который отрисует фон за `CustomProgressIndicator` виджетом




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
