### PR TITLE
Add `url` parameter to `sentry.upload` Makefile command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -943,3 +943,4 @@ jobs:
                   org=${{ secrets.SENTRY_ORG }}
                   token=${{ secrets.SENTRY_TOKEN }}
                   release=${{ steps.semver.outputs.group1 }}
+                  url=${{ secrets.SENTRY_URL }}

--- a/Makefile
+++ b/Makefile
@@ -836,6 +836,7 @@ endif
 #	                   [org=($(SENTRY_ORG)|<org>)]
 #	                   [token=($(SENTRY_AUTH_TOKEN)|<token>)]
 #	                   [release=($(SENTRY_RELEASE)|<release>)]
+#	                   [url=($(SENTRY_URL)|<url>)]
 
 sentry-project=$(strip $(or $(SENTRY_PROJECT),\
 	$(shell grep 'SENTRY_PROJECT=' .env | cut -d'=' -f2)))
@@ -846,12 +847,15 @@ sentry-token=$(strip $(or $(SENTRY_AUTH_TOKEN),\
 sentry-release=$(strip $(or $(SENTRY_RELEASE),\
 	$(shell grep 'SENTRY_RELEASE=' .env | cut -d'=' -f2),\
 	$(shell grep -m1 'ref = ' lib/pubspec.g.dart | cut -d"'" -f2)))
+sentry-url=$(or $(url),$(strip $(or $(SENTRY_URL),\
+	$(shell grep 'SENTRY_URL=' .env | cut -d'=' -f2))))
 
 sentry.upload:
 	SENTRY_PROJECT=$(or $(project),$(sentry-project)) \
 	SENTRY_ORG=$(or $(org),$(sentry-org)) \
 	SENTRY_AUTH_TOKEN=$(or $(token),$(sentry-token)) \
 	SENTRY_RELEASE=$(NAME)@$(or $(release),$(sentry-release)) \
+	$(if $(call eq,$(sentry-url),),,SENTRY_URL=$(sentry-url)) \
 	dart run sentry_dart_plugin
 
 

--- a/Makefile
+++ b/Makefile
@@ -847,8 +847,8 @@ sentry-token=$(strip $(or $(SENTRY_AUTH_TOKEN),\
 sentry-release=$(strip $(or $(SENTRY_RELEASE),\
 	$(shell grep 'SENTRY_RELEASE=' .env | cut -d'=' -f2),\
 	$(shell grep -m1 'ref = ' lib/pubspec.g.dart | cut -d"'" -f2)))
-sentry-url=$(or $(url),$(strip $(or $(SENTRY_URL),\
-	$(shell grep 'SENTRY_URL=' .env | cut -d'=' -f2))))
+sentry-url=$(strip $(or $(url),$(SENTRY_URL),\
+	$(shell grep 'SENTRY_URL=' .env | cut -d'=' -f2)))
 
 sentry.upload:
 	SENTRY_PROJECT=$(or $(project),$(sentry-project)) \


### PR DESCRIPTION
Related to #746




## Synopsis

Sentry URL is not configurable currently.




## Solution

This PR adds `url` parameter to `sentry.upload` command to make it possible to specify Sentry URL for symbols uploading.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
