### PR TITLE
Fix `Restore` button displayed with incorrect position on mobile (#758)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Fixed
 
-- Mobile:
-    - Restore button has incorrect position. ([#763, #758])
+- UI:
+    - Chats tab:
+        - Restore button displaying under mobile navigation bar. ([#763, #758])
+    - Contacts tab:
+        - Restore button displaying under mobile navigation bar. ([#763, #758])
 
 [#758]: /../../issues/758
 [#763]: /../../pull/763
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.1.0-alpha.12] · 2024-??-??
+[0.1.0-alpha.12]: /../../tree/v0.1.0-alpha.12
+
+[Diff](/../../compare/v0.1.0-alpha.11.1...v0.1.0-alpha.12) | [Milestone](/../../milestone/14)
+
+### Fixed
+
+- Mobile:
+    - Restore button has incorrect position. ([#763, #758])
+
+[#758]: /../../issues/758
+[#763]: /../../pull/763
+
+
+
 ## [0.1.0-alpha.11.1] · 2023-12-22
 [0.1.0-alpha.11.1]: /../../tree/v0.1.0-alpha.11.1
 

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -1016,7 +1016,7 @@ class ChatsTabView extends StatelessWidget {
                             10 + 10,
                             0,
                             10 + 10,
-                            72 + MediaQuery.of(context).viewPadding.bottom,
+                            72 + router.context!.mediaQueryViewPadding.bottom,
                           ),
                           child: WidgetButton(
                             key: const Key('Restore'),

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -641,7 +641,7 @@ class ContactsTabView extends StatelessWidget {
                       10 + 10,
                       0,
                       10 + 10,
-                      72 + MediaQuery.of(context).viewPadding.bottom,
+                      72 + router.context!.mediaQueryViewPadding.bottom,
                     ),
                     child: WidgetButton(
                       key: const Key('Restore'),


### PR DESCRIPTION
Resolves #758




## Synopsis

На мобильном устройстве кнопка отмены удаления съезжает вниз за границы видимой области списка чатов/контактов.




## Solution

Проблема будет решена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
