### PR TITLE
Fix `ChatForward`s missing half read status

### DIFF
--- a/lib/ui/page/home/page/chat/forward/controller.dart
+++ b/lib/ui/page/home/page/chat/forward/controller.dart
@@ -68,7 +68,7 @@ class ChatForwardController extends GetxController {
 
   /// Callback, called when a [ChatForwardView] this controller is bound to
   /// should be popped from the [Navigator].
-  final void Function()? pop;
+  final void Function([dynamic])? pop;
 
   /// [ScrollController] to pass to a [Scrollbar].
   final ScrollController scrollController = ScrollController();
@@ -178,7 +178,7 @@ class ChatForwardController extends GetxController {
           ];
 
           await Future.wait(futures);
-          pop?.call();
+          pop?.call(true);
           onSent?.call();
         } on ForwardChatItemsException catch (e) {
           MessagePopup.error(e);

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -253,30 +253,13 @@ class _ChatViewState extends State<ChatView>
                       leading: const [StyledBackButton()],
                       actions: [
                         Obx(() {
-                          if (c.chat?.blocked == true) {
-                            return const SizedBox.shrink();
-                          }
-
+                          final bool blocked = c.chat?.blocked == true;
                           final bool inCall = c.chat?.inCall.value ?? false;
 
                           final List<Widget> children;
 
-                          if (c.selecting.value) {
-                            children = [
-                              AnimatedButton(
-                                key: const Key('CloseButton'),
-                                decorator: (c) => Container(
-                                  padding:
-                                      const EdgeInsets.fromLTRB(12, 0, 2, 0),
-                                  height: double.infinity,
-                                  child: c,
-                                ),
-                                onPressed: c.selecting.value
-                                    ? c.selecting.toggle
-                                    : null,
-                                child: const SvgIcon(SvgIcons.closePrimary),
-                              ),
-                            ];
+                          if (blocked) {
+                            children = [];
                           } else if (c.chat!.chat.value.ongoingCall == null) {
                             children = [
                               if (c.callPosition == null ||
@@ -361,178 +344,218 @@ class _ChatViewState extends State<ChatView>
 
                                 final Widget child;
 
-                                child = ContextMenuRegion(
-                                  key: c.moreKey,
-                                  selector: c.moreKey,
-                                  alignment: Alignment.topRight,
-                                  enablePrimaryTap: true,
-                                  margin: const EdgeInsets.only(
-                                    bottom: 4,
-                                    right: 10,
-                                  ),
-                                  actions: [
-                                    if (c.callPosition ==
-                                        CallButtonsPosition.contextMenu) ...[
-                                      ContextMenuButton(
-                                        label: 'btn_audio_call'.l10n,
-                                        onPressed:
-                                            inCall ? null : () => c.call(false),
-                                        trailing: SvgIcon(
-                                          inCall
-                                              ? SvgIcons.makeAudioCallDisabled
-                                              : SvgIcons.makeAudioCall,
-                                        ),
-                                        inverted: const SvgIcon(
-                                          SvgIcons.makeAudioCallWhite,
-                                        ),
+                                if (c.selecting.value) {
+                                  child = AnimatedButton(
+                                    onPressed: c.selecting.toggle,
+                                    child: Container(
+                                      padding: const EdgeInsets.only(left: 10),
+                                      key: c.moreKey,
+                                      height: double.infinity,
+                                      child: const Padding(
+                                        padding:
+                                            EdgeInsets.fromLTRB(10, 0, 21, 0),
+                                        child: SvgIcon(SvgIcons.closePrimary),
                                       ),
-                                      ContextMenuButton(
-                                        label: 'btn_video_call'.l10n,
-                                        onPressed:
-                                            inCall ? null : () => c.call(true),
-                                        trailing: SvgIcon(
-                                          inCall
-                                              ? SvgIcons.makeVideoCallDisabled
-                                              : SvgIcons.makeVideoCall,
-                                        ),
-                                        inverted: const SvgIcon(
-                                          SvgIcons.makeVideoCallWhite,
-                                        ),
-                                      ),
-                                    ],
-                                    if (dialog)
-                                      ContextMenuButton(
-                                        key: Key(
-                                          contact
-                                              ? 'DeleteFromContactsButton'
-                                              : 'AddToContactsButton',
-                                        ),
-                                        label: contact
-                                            ? 'btn_delete_from_contacts'.l10n
-                                            : 'btn_add_to_contacts'.l10n,
-                                        trailing: SvgIcon(
-                                          contact
-                                              ? SvgIcons.deleteContact
-                                              : SvgIcons.addContact,
-                                        ),
-                                        inverted: SvgIcon(
-                                          contact
-                                              ? SvgIcons.deleteContactWhite
-                                              : SvgIcons.addContactWhite,
-                                        ),
-                                        onPressed: contact
-                                            ? () =>
-                                                _removeFromContacts(c, context)
-                                            : c.addToContacts,
-                                      ),
-                                    ContextMenuButton(
-                                      key: Key(
-                                        favorite
-                                            ? 'UnfavoriteChatButton'
-                                            : 'FavoriteChatButton',
-                                      ),
-                                      label: favorite
-                                          ? 'btn_delete_from_favorites'.l10n
-                                          : 'btn_add_to_favorites'.l10n,
-                                      trailing: SvgIcon(
-                                        favorite
-                                            ? SvgIcons.favoriteSmall
-                                            : SvgIcons.unfavoriteSmall,
-                                      ),
-                                      inverted: SvgIcon(
-                                        favorite
-                                            ? SvgIcons.favoriteSmallWhite
-                                            : SvgIcons.unfavoriteSmallWhite,
-                                      ),
-                                      onPressed: favorite
-                                          ? c.unfavoriteChat
-                                          : c.favoriteChat,
                                     ),
-                                    if (!isLocal) ...[
-                                      if (!monolog)
+                                  );
+                                } else {
+                                  child = ContextMenuRegion(
+                                    key: c.moreKey,
+                                    selector: c.moreKey,
+                                    alignment: Alignment.topRight,
+                                    enablePrimaryTap: true,
+                                    margin: const EdgeInsets.only(
+                                      bottom: 4,
+                                      right: 10,
+                                    ),
+                                    actions: [
+                                      if (c.callPosition ==
+                                          CallButtonsPosition.contextMenu) ...[
+                                        ContextMenuButton(
+                                          label: 'btn_audio_call'.l10n,
+                                          onPressed: blocked || inCall
+                                              ? null
+                                              : () => c.call(false),
+                                          trailing: SvgIcon(
+                                            blocked || inCall
+                                                ? SvgIcons.makeAudioCallDisabled
+                                                : SvgIcons.makeAudioCall,
+                                          ),
+                                          inverted: const SvgIcon(
+                                            SvgIcons.makeAudioCallWhite,
+                                          ),
+                                        ),
+                                        ContextMenuButton(
+                                          label: 'btn_video_call'.l10n,
+                                          onPressed: blocked || inCall
+                                              ? null
+                                              : () => c.call(true),
+                                          trailing: SvgIcon(
+                                            blocked || inCall
+                                                ? SvgIcons.makeVideoCallDisabled
+                                                : SvgIcons.makeVideoCall,
+                                          ),
+                                          inverted: const SvgIcon(
+                                            SvgIcons.makeVideoCallWhite,
+                                          ),
+                                        ),
+                                      ],
+                                      if (dialog)
                                         ContextMenuButton(
                                           key: Key(
-                                            muted
-                                                ? 'UnmuteChatButton'
-                                                : 'MuteChatButton',
+                                            contact
+                                                ? 'DeleteFromContactsButton'
+                                                : 'AddToContactsButton',
                                           ),
-                                          label: muted
-                                              ? PlatformUtils.isMobile
-                                                  ? 'btn_unmute'.l10n
-                                                  : 'btn_unmute_chat'.l10n
-                                              : PlatformUtils.isMobile
-                                                  ? 'btn_mute'.l10n
-                                                  : 'btn_mute_chat'.l10n,
+                                          label: contact
+                                              ? 'btn_delete_from_contacts'.l10n
+                                              : 'btn_add_to_contacts'.l10n,
                                           trailing: SvgIcon(
-                                            muted
-                                                ? SvgIcons.unmuteSmall
-                                                : SvgIcons.muteSmall,
+                                            contact
+                                                ? SvgIcons.deleteContact
+                                                : SvgIcons.addContact,
                                           ),
                                           inverted: SvgIcon(
-                                            muted
-                                                ? SvgIcons.unmuteSmallWhite
-                                                : SvgIcons.muteSmallWhite,
+                                            contact
+                                                ? SvgIcons.deleteContactWhite
+                                                : SvgIcons.addContactWhite,
                                           ),
-                                          onPressed:
-                                              muted ? c.unmuteChat : c.muteChat,
+                                          onPressed: contact
+                                              ? () => _removeFromContacts(
+                                                    c,
+                                                    context,
+                                                  )
+                                              : c.addToContacts,
                                         ),
                                       ContextMenuButton(
-                                        key: const Key('ClearHistoryButton'),
-                                        label: 'btn_clear_history'.l10n,
+                                        key: Key(
+                                          favorite
+                                              ? 'UnfavoriteChatButton'
+                                              : 'FavoriteChatButton',
+                                        ),
+                                        label: favorite
+                                            ? 'btn_delete_from_favorites'.l10n
+                                            : 'btn_add_to_favorites'.l10n,
+                                        trailing: SvgIcon(
+                                          favorite
+                                              ? SvgIcons.favoriteSmall
+                                              : SvgIcons.unfavoriteSmall,
+                                        ),
+                                        inverted: SvgIcon(
+                                          favorite
+                                              ? SvgIcons.favoriteSmallWhite
+                                              : SvgIcons.unfavoriteSmallWhite,
+                                        ),
+                                        onPressed: favorite
+                                            ? c.unfavoriteChat
+                                            : c.favoriteChat,
+                                      ),
+                                      if (!isLocal) ...[
+                                        if (!monolog)
+                                          ContextMenuButton(
+                                            key: Key(
+                                              muted
+                                                  ? 'UnmuteChatButton'
+                                                  : 'MuteChatButton',
+                                            ),
+                                            label: muted
+                                                ? PlatformUtils.isMobile
+                                                    ? 'btn_unmute'.l10n
+                                                    : 'btn_unmute_chat'.l10n
+                                                : PlatformUtils.isMobile
+                                                    ? 'btn_mute'.l10n
+                                                    : 'btn_mute_chat'.l10n,
+                                            trailing: SvgIcon(
+                                              muted
+                                                  ? SvgIcons.unmuteSmall
+                                                  : SvgIcons.muteSmall,
+                                            ),
+                                            inverted: SvgIcon(
+                                              muted
+                                                  ? SvgIcons.unmuteSmallWhite
+                                                  : SvgIcons.muteSmallWhite,
+                                            ),
+                                            onPressed: muted
+                                                ? c.unmuteChat
+                                                : c.muteChat,
+                                          ),
+                                        ContextMenuButton(
+                                          key: const Key('ClearHistoryButton'),
+                                          label: 'btn_clear_history'.l10n,
+                                          trailing: const SvgIcon(
+                                            SvgIcons.cleanHistory,
+                                          ),
+                                          inverted: const SvgIcon(
+                                            SvgIcons.cleanHistoryWhite,
+                                          ),
+                                          onPressed: () =>
+                                              _clearChat(c, context),
+                                        ),
+                                      ],
+                                      if (!monolog && !dialog)
+                                        ContextMenuButton(
+                                          key: const Key('LeaveGroupButton'),
+                                          label: 'btn_leave_group'.l10n,
+                                          trailing: const SvgIcon(
+                                            SvgIcons.leaveGroup,
+                                          ),
+                                          inverted: const SvgIcon(
+                                            SvgIcons.leaveGroupWhite,
+                                          ),
+                                          onPressed: () =>
+                                              _leaveGroup(c, context),
+                                        ),
+                                      if (!isLocal || monolog)
+                                        ContextMenuButton(
+                                          key: const Key('HideChatButton'),
+                                          label: 'btn_delete_chat'.l10n,
+                                          trailing:
+                                              const SvgIcon(SvgIcons.delete19),
+                                          inverted: const SvgIcon(
+                                            SvgIcons.delete19White,
+                                          ),
+                                          onPressed: () =>
+                                              _hideChat(c, context),
+                                        ),
+                                      if (dialog)
+                                        ContextMenuButton(
+                                          key: Key(
+                                            blocked ? 'Unblock' : 'Block',
+                                          ),
+                                          label: blocked
+                                              ? 'btn_unblock'.l10n
+                                              : 'btn_block'.l10n,
+                                          trailing:
+                                              const SvgIcon(SvgIcons.block),
+                                          inverted: const SvgIcon(
+                                            SvgIcons.blockWhite,
+                                          ),
+                                          onPressed: blocked
+                                              ? c.unblock
+                                              : () => _blockUser(c, context),
+                                        ),
+                                      ContextMenuButton(
+                                        label: 'btn_select_messages'.l10n,
+                                        onPressed: c.selecting.toggle,
                                         trailing: const SvgIcon(
-                                          SvgIcons.cleanHistory,
+                                          SvgIcons.select,
                                         ),
                                         inverted: const SvgIcon(
-                                          SvgIcons.cleanHistoryWhite,
+                                          SvgIcons.selectWhite,
                                         ),
-                                        onPressed: () => _clearChat(c, context),
                                       ),
                                     ],
-                                    if (!monolog && !dialog)
-                                      ContextMenuButton(
-                                        key: const Key('LeaveGroupButton'),
-                                        label: 'btn_leave_group'.l10n,
-                                        trailing: const SvgIcon(
-                                          SvgIcons.leaveGroup,
-                                        ),
-                                        inverted: const SvgIcon(
-                                          SvgIcons.leaveGroupWhite,
-                                        ),
-                                        onPressed: () =>
-                                            _leaveGroup(c, context),
+                                    child: Container(
+                                      key: const Key('MoreButton'),
+                                      padding: const EdgeInsets.only(
+                                        left: 20,
+                                        right: 21,
                                       ),
-                                    if (!isLocal || monolog)
-                                      ContextMenuButton(
-                                        key: const Key('HideChatButton'),
-                                        label: 'btn_delete_chat'.l10n,
-                                        trailing:
-                                            const SvgIcon(SvgIcons.delete19),
-                                        inverted: const SvgIcon(
-                                          SvgIcons.delete19White,
-                                        ),
-                                        onPressed: () => _hideChat(c, context),
-                                      ),
-                                    if (dialog)
-                                      ContextMenuButton(
-                                        key: const Key('Block'),
-                                        label: 'btn_block'.l10n,
-                                        trailing: const SvgIcon(SvgIcons.block),
-                                        inverted: const SvgIcon(
-                                          SvgIcons.blockWhite,
-                                        ),
-                                        onPressed: () => _blockUser(c, context),
-                                      ),
-                                  ],
-                                  child: Container(
-                                    key: const Key('MoreButton'),
-                                    padding: const EdgeInsets.only(
-                                      left: 20,
-                                      right: 21,
+                                      height: double.infinity,
+                                      child: const SvgIcon(SvgIcons.more),
                                     ),
-                                    height: double.infinity,
-                                    child: const SvgIcon(SvgIcons.more),
-                                  ),
-                                );
+                                  );
+                                }
 
                                 return AnimatedButton(
                                   child: SafeAnimatedSwitcher(
@@ -985,7 +1008,10 @@ class _ChatViewState extends State<ChatView>
                   onDownload: c.downloadMedia,
                   onDownloadAs: c.downloadMediaAs,
                   onSave: (a) => c.saveToGallery(a, e.value),
-                  onSelect: c.selecting.toggle,
+                  onSelect: () {
+                    c.selecting.toggle();
+                    c.selected.add(element);
+                  },
                 ),
               ),
             );
@@ -1117,7 +1143,10 @@ class _ChatViewState extends State<ChatView>
                     await Future.delayed(Duration.zero);
                   },
                   onSelecting: (s) => c.isSelecting.value = s,
-                  onSelect: c.selecting.toggle,
+                  onSelect: () {
+                    c.selecting.toggle();
+                    c.selected.add(element);
+                  },
                 ),
               ),
             );

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -225,6 +225,16 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
     }
   }
 
+  /// Indicates whether this [ChatItem] was read only partially.
+  bool get _isHalfRead {
+    final Chat? chat = widget.chat.value;
+    if (chat == null) {
+      return false;
+    }
+
+    return chat.isHalfRead(widget.forwards.first.value, widget.me);
+  }
+
   /// Indicates whether these [ChatForwardWidget.forwards] were forwarded by the
   /// authenticated [MyUser].
   bool get _fromMe => widget.authorId == widget.me;
@@ -358,6 +368,7 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                                 at: _at,
                                 status: SendingStatus.sent,
                                 read: _isRead,
+                                halfRead: _isHalfRead,
                                 delivered: widget.chat.value?.lastDelivery
                                         .isBefore(_at) ==
                                     false,
@@ -837,6 +848,8 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
 
   /// Returns rounded rectangle of a [child] representing a message box.
   Widget _rounded(BuildContext context, Widget Function(bool) builder) {
+    final style = Theme.of(context).style;
+
     final ChatItem? item = widget.note.value?.value;
 
     final bool isSent =
@@ -874,15 +887,26 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                 final RxUser? data =
                     snapshot.data ?? (member is RxUser? ? member : null);
 
-                if (data != null) {
-                  return AvatarWidget.fromRxUser(
-                    data,
-                    radius: AvatarRadius.smaller,
-                  );
-                }
-                return AvatarWidget.fromUser(
-                  user,
-                  radius: AvatarRadius.smaller,
+                return Tooltip(
+                  message: data?.user.value.name?.val ??
+                      data?.user.value.num.toString() ??
+                      user?.name?.val ??
+                      user?.num.toString(),
+                  verticalOffset: 15,
+                  padding: const EdgeInsets.fromLTRB(7, 3, 7, 3),
+                  decoration: BoxDecoration(
+                    color: style.colors.secondaryOpacity40,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: data != null
+                      ? AvatarWidget.fromRxUser(
+                          data,
+                          radius: AvatarRadius.smaller,
+                        )
+                      : AvatarWidget.fromUser(
+                          user,
+                          radius: AvatarRadius.smaller,
+                        ),
                 );
               },
             ),
@@ -912,7 +936,7 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
           builder(menu),
           if (avatars.isNotEmpty)
             Transform.translate(
-              offset: const Offset(-12, -4),
+              offset: const Offset(-12, 0),
               child: WidgetButton(
                 onPressed: () => MessageInfo.show(
                   context,
@@ -938,6 +962,7 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
       isDelivered:
           isSent && widget.chat.value?.lastDelivery.isBefore(_at) == false,
       isRead: isSent && _isRead,
+      isHalfRead: _isHalfRead,
       isError: widget.forwards.first.value.status.value == SendingStatus.error,
       isSending:
           widget.forwards.first.value.status.value == SendingStatus.sending,

--- a/lib/ui/widget/svg/svgs.dart
+++ b/lib/ui/widget/svg/svgs.dart
@@ -1434,6 +1434,18 @@ class SvgIcons {
     height: 19,
   );
 
+  static const SvgData unblock = SvgData(
+    'assets/icons/unblock.svg',
+    width: 19,
+    height: 19,
+  );
+
+  static const SvgData unblockWhite = SvgData(
+    'assets/icons/unblock_white.svg',
+    width: 19,
+    height: 19,
+  );
+
   static const SvgData cleanHistory = SvgData(
     'assets/icons/clean_history.svg',
     width: 17.21,

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -623,14 +623,14 @@ extension MobileExtensionOnContext on BuildContext {
 /// Extension adding an ability to pop the current [ModalRoute].
 extension PopExtensionOnContext on BuildContext {
   /// Pops the [ModalRoute] from this [BuildContext], if any is active.
-  void popModal() {
+  void popModal([dynamic result]) {
     if (mounted) {
       final NavigatorState navigator = Navigator.of(this);
       final ModalRoute? modal = ModalRoute.of(this);
 
       if (modal?.isActive == true) {
         if (modal?.isCurrent == true) {
-          navigator.pop();
+          navigator.pop(result);
         } else {
           navigator.removeRoute(modal!);
         }


### PR DESCRIPTION
## Synopsis

`ChatForward`s don't display half read status.




## Solution

This PR adds the missing code.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
