### PR TITLE
Fix `Safari` invoking `getUserMedia` onto `undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All user visible changes to this project will be documented in this file. This p
         - Downloaded avatar missing its extension on desktop. ([#756, #726])
     - Chat page:
         - Read partially message status missing in forwards. ([#776])
+- Web:
+    - Media devices not showing up on profile page in Safari. ([#779])
 
 [#582]: /../../issues/582
 [#718]: /../../issues/718
@@ -40,6 +42,7 @@ All user visible changes to this project will be documented in this file. This p
 [#758]: /../../issues/758
 [#763]: /../../pull/763
 [#776]: /../../pull/776
+[#779]: /../../pull/779
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All user visible changes to this project will be documented in this file. This p
     - Chat page:
         - Read partially message status missing in forwards. ([#776])
 - Web:
-    - Media devices not showing up on profile page in Safari. ([#779])
+    - Media devices not showing up on profile page in Safari. ([#780])
 
 [#582]: /../../issues/582
 [#718]: /../../issues/718
@@ -42,7 +42,7 @@ All user visible changes to this project will be documented in this file. This p
 [#758]: /../../issues/758
 [#763]: /../../pull/763
 [#776]: /../../pull/776
-[#779]: /../../pull/779
+[#780]: /../../pull/780
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -307,6 +307,7 @@ err_invalid_crop_points = Invalid crop points
 err_invalid_registration_token = Invalid registration token
 err_unknown_registration_token = Unknown registration token
 err_login_occupied = This login is already taken.
+err_media_devices_are_null = Cannot retrieve `MediaStream` with `video` constraints due to `window.navigator.mediaDevices` being `null`. Seems like your browser\'s configuration doesn\'t allow media devices to be retrieved. Tune up the settings, or ensure the devices are available.
 err_message_was_read = Message was read
 err_monolog = Can't perfom this action in a monolog
 err_network = Connection to the server refused

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -308,6 +308,7 @@ err_invalid_crop_points = Неверные точки обрезки
 err_invalid_registration_token = Некорректный регистрационный токен
 err_unknown_registration_token = Неизвестный регистрационный токен
 err_login_occupied = Данный логин уже занят.
+err_media_devices_are_null = Невозможно получить `MediaStream` с `video` парамтеро, т.к. `window.navigator.mediaDevices` является `null`. Вероятно, конфигурация Вашего браузера не позволяет получить медиа устройства. Подкорректируйте настройки и убедитесь в доступности медиа устройств.
 err_message_was_read = Сообщение было прочитано
 err_monolog = Невозможно выполнить данное действие в монологе
 err_network = Ошибка подключения к серверу

--- a/lib/ui/page/call/settings/view.dart
+++ b/lib/ui/page/call/settings/view.dart
@@ -31,6 +31,7 @@ import '/ui/widget/modal_popup.dart';
 import '/ui/widget/text_field.dart';
 import '/ui/widget/widget_button.dart';
 import '/util/platform_utils.dart';
+import '/util/web/web_utils.dart';
 import 'controller.dart';
 
 /// View of the call overlay settings.
@@ -137,39 +138,47 @@ class CallSettingsView extends StatelessWidget {
                       ),
                     ),
                   ),
-                  const SizedBox(height: 16),
-                  Padding(
-                    padding: padding,
-                    child: WidgetButton(
-                      onPressed: () async {
-                        await OutputSwitchView.show(
-                          context,
-                          onChanged: (device) => c.setOutputDevice(device),
-                          output: c.output.value,
-                        );
 
-                        if (c.devices.output().isEmpty) {
-                          await c.enumerateDevices();
-                        }
-                      },
-                      child: IgnorePointer(
-                        child: Obx(() {
-                          return ReactiveTextField(
-                            label: 'label_media_output'.l10n,
-                            state: TextFieldState(
-                              text: (c.devices.output().firstWhereOrNull((e) =>
-                                              e.deviceId() == c.output.value) ??
-                                          c.devices.output().firstOrNull)
-                                      ?.label() ??
-                                  'label_media_no_device_available'.l10n,
-                              editable: false,
-                            ),
-                            style: style.fonts.normal.regular.primary,
+                  // TODO: Remove, when Safari supports output devices without
+                  //       tweaking the developer options:
+                  //       https://bugs.webkit.org/show_bug.cgi?id=216641
+                  if (!WebUtils.isSafari || c.devices.output().isNotEmpty) ...[
+                    const SizedBox(height: 16),
+                    Padding(
+                      padding: padding,
+                      child: WidgetButton(
+                        onPressed: () async {
+                          await OutputSwitchView.show(
+                            context,
+                            onChanged: (device) => c.setOutputDevice(device),
+                            output: c.output.value,
                           );
-                        }),
+
+                          if (c.devices.output().isEmpty) {
+                            await c.enumerateDevices();
+                          }
+                        },
+                        child: IgnorePointer(
+                          child: Obx(() {
+                            return ReactiveTextField(
+                              label: 'label_media_output'.l10n,
+                              state: TextFieldState(
+                                text: (c.devices.output().firstWhereOrNull(
+                                                (e) =>
+                                                    e.deviceId() ==
+                                                    c.output.value) ??
+                                            c.devices.output().firstOrNull)
+                                        ?.label() ??
+                                    'label_media_no_device_available'.l10n,
+                                editable: false,
+                              ),
+                              style: style.fonts.normal.regular.primary,
+                            );
+                          }),
+                        ),
                       ),
                     ),
-                  ),
+                  ],
                   const SizedBox(height: 16),
                   ModalPopupHeader(text: 'label_calls'.l10n, close: false),
                   Padding(

--- a/lib/ui/page/home/page/my_profile/camera_switch/view.dart
+++ b/lib/ui/page/home/page/my_profile/camera_switch/view.dart
@@ -105,6 +105,19 @@ class CameraSwitchView extends StatelessWidget {
                     ),
                     const SizedBox(height: 25),
                     Obx(() {
+                      if (c.error.value == null) {
+                        return const SizedBox();
+                      }
+
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: Text(
+                          c.error.value!,
+                          style: style.fonts.normal.regular.danger,
+                        ),
+                      );
+                    }),
+                    Obx(() {
                       return ListView.separated(
                         shrinkWrap: true,
                         padding: ModalPopup.padding(context),

--- a/lib/ui/page/home/page/my_profile/microphone_switch/controller.dart
+++ b/lib/ui/page/home/page/my_profile/microphone_switch/controller.dart
@@ -23,6 +23,7 @@ import 'package:medea_jason/medea_jason.dart';
 import '/domain/model/media_settings.dart';
 import '/domain/model/ongoing_call.dart';
 import '/domain/repository/settings.dart';
+import '/l10n/l10n.dart';
 import '/util/media_utils.dart';
 import '/util/web/web_utils.dart';
 
@@ -42,6 +43,9 @@ class MicrophoneSwitchController extends GetxController {
   /// List of [MediaDeviceDetails] of all the available devices.
   final RxList<MediaDeviceDetails> devices = RxList<MediaDeviceDetails>([]);
 
+    /// Error message to display, if any.
+  final RxnString error = RxnString();
+
   /// [StreamSubscription] for the [MediaUtils.onDeviceChange] stream updating
   /// the [devices].
   StreamSubscription? _devicesSubscription;
@@ -52,9 +56,16 @@ class MicrophoneSwitchController extends GetxController {
       (e) => devices.value = e.audio().toList(),
     );
 
-    await WebUtils.microphonePermission();
-    devices.value =
-        await MediaUtils.enumerateDevices(MediaDeviceKind.audioInput);
+    try {
+      await WebUtils.microphonePermission();
+      devices.value =
+          await MediaUtils.enumerateDevices(MediaDeviceKind.audioInput);
+    } on UnsupportedError {
+      error.value = 'err_media_devices_are_null'.l10n;
+    } catch (e) {
+      error.value = e.toString();
+      rethrow;
+    }
 
     super.onInit();
   }

--- a/lib/ui/page/home/page/my_profile/microphone_switch/view.dart
+++ b/lib/ui/page/home/page/my_profile/microphone_switch/view.dart
@@ -22,6 +22,7 @@ import 'package:medea_jason/medea_jason.dart';
 
 import '/domain/model/media_settings.dart';
 import '/l10n/l10n.dart';
+import '/themes.dart';
 import '/ui/page/home/widget/rectangle_button.dart';
 import '/ui/widget/modal_popup.dart';
 import 'controller.dart';
@@ -52,6 +53,8 @@ class MicrophoneSwitchView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final style = Theme.of(context).style;
+
     return GetBuilder(
       init: MicrophoneSwitchController(Get.find(), mic: mic),
       builder: (MicrophoneSwitchController c) {
@@ -68,6 +71,19 @@ class MicrophoneSwitchView extends StatelessWidget {
                   shrinkWrap: true,
                   children: [
                     const SizedBox(height: 13),
+                    Obx(() {
+                      if (c.error.value == null) {
+                        return const SizedBox();
+                      }
+
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: Text(
+                          c.error.value!,
+                          style: style.fonts.normal.regular.danger,
+                        ),
+                      );
+                    }),
                     Obx(() {
                       return ListView.separated(
                         shrinkWrap: true,

--- a/lib/ui/page/home/page/my_profile/output_switch/controller.dart
+++ b/lib/ui/page/home/page/my_profile/output_switch/controller.dart
@@ -23,6 +23,7 @@ import 'package:medea_jason/medea_jason.dart';
 import '/domain/model/media_settings.dart';
 import '/domain/model/ongoing_call.dart';
 import '/domain/repository/settings.dart';
+import '/l10n/l10n.dart';
 import '/util/media_utils.dart';
 import '/util/web/web_utils.dart';
 
@@ -42,6 +43,9 @@ class OutputSwitchController extends GetxController {
   /// ID of the initially selected audio output device.
   RxnString output;
 
+  /// Error message to display, if any.
+  final RxnString error = RxnString();
+
   /// [StreamSubscription] for the [MediaUtils.onDeviceChange] stream updating
   /// the [devices].
   StreamSubscription? _devicesSubscription;
@@ -52,11 +56,18 @@ class OutputSwitchController extends GetxController {
       (e) => devices.value = e.output().toList(),
     );
 
-    // Output devices are permitted to be use when requesting a microphone
-    // permission.
-    await WebUtils.microphonePermission();
-    devices.value =
-        await MediaUtils.enumerateDevices(MediaDeviceKind.audioOutput);
+    try {
+      // Output devices are permitted to be use when requesting a microphone
+      // permission.
+      await WebUtils.microphonePermission();
+      devices.value =
+          await MediaUtils.enumerateDevices(MediaDeviceKind.audioOutput);
+    } on UnsupportedError {
+      error.value = 'err_media_devices_are_null'.l10n;
+    } catch (e) {
+      error.value = e.toString();
+      rethrow;
+    }
 
     super.onInit();
   }

--- a/lib/ui/page/home/page/my_profile/output_switch/view.dart
+++ b/lib/ui/page/home/page/my_profile/output_switch/view.dart
@@ -22,6 +22,7 @@ import 'package:medea_jason/medea_jason.dart';
 
 import '/domain/model/media_settings.dart';
 import '/l10n/l10n.dart';
+import '/themes.dart';
 import '/ui/page/home/widget/rectangle_button.dart';
 import '/ui/widget/modal_popup.dart';
 import 'controller.dart';
@@ -52,6 +53,8 @@ class OutputSwitchView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final style = Theme.of(context).style;
+
     return GetBuilder(
       init: OutputSwitchController(Get.find(), output: output),
       builder: (OutputSwitchController c) {
@@ -68,6 +71,19 @@ class OutputSwitchView extends StatelessWidget {
                   shrinkWrap: true,
                   children: [
                     const SizedBox(height: 13),
+                    Obx(() {
+                      if (c.error.value == null) {
+                        return const SizedBox();
+                      }
+
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: Text(
+                          c.error.value!,
+                          style: style.fonts.normal.regular.danger,
+                        ),
+                      );
+                    }),
                     Obx(() {
                       return ListView.separated(
                         shrinkWrap: true,

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -19,6 +19,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:messenger/util/web/web_utils.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import '/api/backend/schema.dart' show Presence;
@@ -766,30 +767,36 @@ Widget _media(BuildContext context, MyProfileController c) {
           );
         }),
       ),
-      const SizedBox(height: 16),
-      Paddings.dense(
-        Obx(() {
-          return FieldButton(
-            text: (c.devices.output().firstWhereOrNull((e) =>
-                            e.deviceId() == c.media.value?.outputDevice) ??
-                        c.devices.output().firstOrNull)
-                    ?.label() ??
-                'label_media_no_device_available'.l10n,
-            hint: 'label_media_output'.l10n,
-            onPressed: () async {
-              await OutputSwitchView.show(
-                context,
-                output: c.media.value?.outputDevice,
-              );
 
-              if (c.devices.output().isEmpty) {
-                c.devices.value = await MediaUtils.enumerateDevices();
-              }
-            },
-            style: style.fonts.normal.regular.primary,
-          );
-        }),
-      ),
+      // TODO: Remove, when Safari supports output devices without tweaking the
+      //       developer options:
+      //       https://bugs.webkit.org/show_bug.cgi?id=216641
+      if (!WebUtils.isSafari || c.devices.output().isNotEmpty) ...[
+        const SizedBox(height: 16),
+        Paddings.dense(
+          Obx(() {
+            return FieldButton(
+              text: (c.devices.output().firstWhereOrNull((e) =>
+                              e.deviceId() == c.media.value?.outputDevice) ??
+                          c.devices.output().firstOrNull)
+                      ?.label() ??
+                  'label_media_no_device_available'.l10n,
+              hint: 'label_media_output'.l10n,
+              onPressed: () async {
+                await OutputSwitchView.show(
+                  context,
+                  output: c.media.value?.outputDevice,
+                );
+
+                if (c.devices.output().isEmpty) {
+                  c.devices.value = await MediaUtils.enumerateDevices();
+                }
+              },
+              style: style.fonts.normal.regular.primary,
+            );
+          }),
+        ),
+      ],
     ],
   );
 }

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -538,8 +538,12 @@ class WebUtils {
         await html.window.navigator.permissions?.query({'name': 'camera'});
 
     if (status?.state != 'granted') {
-      html.MediaStream stream =
-          await html.window.navigator.getUserMedia(video: true);
+      final html.MediaStream? stream = await html.window.navigator.mediaDevices
+          ?.getUserMedia({'video': true});
+
+      if (stream == null) {
+        throw UnsupportedError('`window.navigator.mediaDevices` are `null`');
+      }
 
       for (var e in stream.getTracks()) {
         e.stop();
@@ -553,8 +557,12 @@ class WebUtils {
         await html.window.navigator.permissions?.query({'name': 'microphone'});
 
     if (status?.state != 'granted') {
-      html.MediaStream stream =
-          await html.window.navigator.getUserMedia(audio: true);
+      final html.MediaStream? stream = await html.window.navigator.mediaDevices
+          ?.getUserMedia({'audio': true});
+
+      if (stream == null) {
+        throw UnsupportedError('`window.navigator.mediaDevices` are `null`');
+      }
 
       for (var e in stream.getTracks()) {
         e.stop();


### PR DESCRIPTION
## Synopsis

`Safari` throws `getUserMedia` error when trying to get camera/mic permission, as it is undefined for Safari.




## Solution

This PR replaces `navigator.getUserMedia` with `navigator.mediaDevices.getUserMedia`, which is a thing of Safari, as well as [everywhere else](https://developer.mozilla.org/en/docs/Web/API/MediaDevices).

`navigator.getUserMedia`:

<img width="813" alt="Снимок экрана 2024-01-04 в 12 42 46" src="https://github.com/team113/messenger/assets/21217248/d285bdcd-7664-4b0a-b87d-d2698b14fb47">





## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
