### PR TITLE
Debounce first `ChatEvent`s when subscribed with version (#792)

### DIFF
--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -74,13 +74,7 @@ class HiveRxChat extends RxChat {
         unreadCount = RxInt(hiveChat.value.unreadCount),
         // TODO: Don't ignore version, when all events are surely delivered by
         //       subscribing to `chatEvents` with that version.
-        ver = hiveChat.value.name?.val == 'named'
-            ? ChatVersion(
-                '031452680279290975191536964834527342193031452680279888553166213896908846608141',
-              )
-            : hiveChat.value.favoritePosition == null
-                ? hiveChat.ver
-                : null;
+        ver = hiveChat.value.favoritePosition == null ? hiveChat.ver : null;
 
   @override
   final Rx<Chat> chat;


### PR DESCRIPTION
Resolves #792




## Synopsis

Из-за того, что на `chatEvents` может идти подписка с версией, отстающей от актуальной, поэтому события налетают один за другим, то показывая звонок, то его скрывая, то показывая какие-то вещи, то их скрывая, итд.




## Solution

PR добавляет ивенты в список ивентов, которые затем по дебаунсу будут обработаны.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
