### PR TITLE
Implement and use `Config.link` for `ChatDirectLink`s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
 
       - run: make flutter.build platform=${{ matrix.platform }}
                   dart-env='SOCAPP_FCM_VAPID_KEY=${{ secrets.FCM_VAPID_KEY }}
+                            SOCAPP_LINK_PREFIX=${{ secrets.LINK_PREFIX }}
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN || '' }}'
         if: ${{ matrix.platform == 'web' }}
 
@@ -187,6 +188,7 @@ jobs:
                             SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }}
                             SOCAPP_WS_URL=${{ secrets.BACKEND_WS }}
                             SOCAPP_WS_PORT=${{ secrets.BACKEND_PORT }}
+                            SOCAPP_LINK_PREFIX=${{ secrets.LINK_PREFIX }}
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN || '' }}
                             SOCAPP_USER_AGENT_VERSION=${{ steps.semver.outputs.group1 }}'
         if: ${{ matrix.platform != 'web' }}
@@ -324,6 +326,7 @@ jobs:
                             SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }}
                             SOCAPP_WS_URL=${{ secrets.BACKEND_WS }}
                             SOCAPP_WS_PORT=${{ secrets.BACKEND_PORT }}
+                            SOCAPP_LINK_PREFIX=${{ secrets.LINK_PREFIX }}
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN || '' }}
                             SOCAPP_USER_AGENT_VERSION=${{ steps.semver.outputs.group1 }}'
 

--- a/assets/conf.toml
+++ b/assets/conf.toml
@@ -98,3 +98,14 @@
 # Default:
 #   level = "debug" (if `kDebugMode` or `kProfileMode` is `true`)
 #   level = "info" (if `kReleaseMode` is `true`)
+
+[link]
+# Prefix of the direct chat link URL.
+#
+# The trailing `/` should be omitted.
+#
+# If empty, then the origin domain of the web application, or HTTP server for
+# native applications, is used.
+#
+# Default:
+#   prefix = ""

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -50,9 +50,12 @@ class Config {
   static String sentryDsn = '';
 
   /// Domain considered as an origin of the application.
-  ///
-  /// May be (and intended to be) used as a [ChatDirectLink] prefix.
   static String origin = '';
+
+  /// [ChatDirectLink] prefix.
+  ///
+  /// If empty, then [origin] is used.
+  static String link = '';
 
   /// Directory to download files to.
   static String downloads = '';
@@ -170,6 +173,14 @@ class Config {
             'BGYb_L78Y9C-X8Egon75EL8aci2K2UqRb850ibVpC51TXjmnapW9FoQqZ6Ru9rz5IcBAMwBIgjhBi-wn7jAMZC0');
 
     origin = url;
+
+    link = const bool.hasEnvironment('SOCAPP_LINK_PREFIX')
+        ? const String.fromEnvironment('SOCAPP_LINK_PREFIX')
+        : (document['link']?['url'] ?? '');
+
+    if (link.isEmpty) {
+      link = origin;
+    }
 
     logLevel = me.LogLevel.values.firstWhere(
       (e) => const bool.hasEnvironment('SOCAPP_LOG_LEVEL')

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -176,7 +176,7 @@ class Config {
 
     link = const bool.hasEnvironment('SOCAPP_LINK_PREFIX')
         ? const String.fromEnvironment('SOCAPP_LINK_PREFIX')
-        : (document['link']?['url'] ?? '');
+        : (document['link']?['prefix'] ?? '');
 
     logLevel = me.LogLevel.values.firstWhere(
       (e) => const bool.hasEnvironment('SOCAPP_LOG_LEVEL')

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -172,15 +172,9 @@ class Config {
         : (document['fcm']?['vapidKey'] ??
             'BGYb_L78Y9C-X8Egon75EL8aci2K2UqRb850ibVpC51TXjmnapW9FoQqZ6Ru9rz5IcBAMwBIgjhBi-wn7jAMZC0');
 
-    origin = url;
-
     link = const bool.hasEnvironment('SOCAPP_LINK_PREFIX')
         ? const String.fromEnvironment('SOCAPP_LINK_PREFIX')
         : (document['link']?['url'] ?? '');
-
-    if (link.isEmpty) {
-      link = origin;
-    }
 
     logLevel = me.LogLevel.values.firstWhere(
       (e) => const bool.hasEnvironment('SOCAPP_LOG_LEVEL')
@@ -189,6 +183,8 @@ class Config {
       orElse: () =>
           kDebugMode || kProfileMode ? me.LogLevel.debug : me.LogLevel.info,
     );
+
+    origin = url;
 
     // Change default values to browser's location on web platform.
     if (PlatformUtils.isWeb) {
@@ -248,6 +244,7 @@ class Config {
             userAgentVersion =
                 remote['user']?['agent']?['version'] ?? userAgentVersion;
             vapidKey = remote['fcm']?['vapidKey'] ?? vapidKey;
+            link = remote['link']?['prefix'] ?? link;
             if (remote['log']?['level'] != null) {
               logLevel = me.LogLevel.values.firstWhere(
                 (e) => e.name == remote['log']?['level'],
@@ -269,6 +266,10 @@ class Config {
       } else {
         origin = '${Uri.base.scheme}://${Uri.base.host}';
       }
+    }
+
+    if (link.isEmpty) {
+      link = origin;
     }
 
     ws = '$wsUrl:$wsPort$graphql';

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -172,6 +172,8 @@ class Config {
         : (document['fcm']?['vapidKey'] ??
             'BGYb_L78Y9C-X8Egon75EL8aci2K2UqRb850ibVpC51TXjmnapW9FoQqZ6Ru9rz5IcBAMwBIgjhBi-wn7jAMZC0');
 
+    origin = url;
+
     link = const bool.hasEnvironment('SOCAPP_LINK_PREFIX')
         ? const String.fromEnvironment('SOCAPP_LINK_PREFIX')
         : (document['link']?['url'] ?? '');
@@ -183,8 +185,6 @@ class Config {
       orElse: () =>
           kDebugMode || kProfileMode ? me.LogLevel.debug : me.LogLevel.info,
     );
-
-    origin = url;
 
     // Change default values to browser's location on web platform.
     if (PlatformUtils.isWeb) {

--- a/lib/ui/page/home/introduction/controller.dart
+++ b/lib/ui/page/home/introduction/controller.dart
@@ -57,7 +57,7 @@ class IntroductionController extends GetxController {
 
   /// Origin to display withing the [link] field.
   late final String _origin =
-      '${Config.origin.substring(Config.origin.indexOf(':') + 3)}${Routes.chatDirectLink}/';
+      '${Config.link.substring(Config.link.indexOf(':') + 3)}${Routes.chatDirectLink}/';
 
   /// Creates a [ChatDirectLink] from the [link].
   Future<void> createLink() async {

--- a/lib/ui/page/home/widget/direct_link.dart
+++ b/lib/ui/page/home/widget/direct_link.dart
@@ -156,7 +156,7 @@ class _DirectLinkFieldState extends State<DirectLinkField> {
         child: ReactiveTextField(
           key: const Key('LinkField'),
           state: _state,
-          label: '${Config.origin}/',
+          label: '${Config.link}/',
         ),
       );
     } else {
@@ -195,7 +195,7 @@ class _DirectLinkFieldState extends State<DirectLinkField> {
                     child: WidgetButton(
                       onPressed: () {
                         final share =
-                            '${Config.origin}${Routes.chatDirectLink}/${_state.text}';
+                            '${Config.link}${Routes.chatDirectLink}/${_state.text}';
 
                         if (PlatformUtils.isMobile) {
                           Share.share(share);
@@ -208,7 +208,7 @@ class _DirectLinkFieldState extends State<DirectLinkField> {
                         fromMe: true,
                         style: style.fonts.medium.regular.primary,
                         text:
-                            '${Config.origin}${Routes.chatDirectLink}/${_state.text}',
+                            '${Config.link}${Routes.chatDirectLink}/${_state.text}',
                       ),
                     ),
                   ),
@@ -224,7 +224,7 @@ class _DirectLinkFieldState extends State<DirectLinkField> {
                         ),
                         child: QrImageView(
                           data:
-                              '${Config.origin}${Routes.chatDirectLink}/${widget.link?.slug.val}',
+                              '${Config.link}${Routes.chatDirectLink}/${widget.link?.slug.val}',
                           version: QrVersions.auto,
                           size: 300.0,
                         ),
@@ -252,7 +252,7 @@ class _DirectLinkFieldState extends State<DirectLinkField> {
                 child: WidgetButton(
                   onPressed: () {
                     final share =
-                        '${Config.origin}${Routes.chatDirectLink}/${_state.text}';
+                        '${Config.link}${Routes.chatDirectLink}/${_state.text}';
 
                     if (PlatformUtils.isMobile) {
                       Share.share(share);


### PR DESCRIPTION
## Synopsis

Application uses `Config.origin` (the domain of the web application, or HTTP server URL for native applications) for `ChatDirectLink`s being shared.




## Solution

We'd like to be able to specify different prefixes for `ChatDirectLink`s. This PR adds such a parameter: `Config.link`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
