### PR TITLE
Use `all_sensors` for `proximityEvents` to dim the screen in `Call` (#808)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ app.*.map.json
 app.*.symbols
 
 # Android Studio will place build artifacts here
+/android/app/build
 /android/app/debug
 /android/app/profile
 /android/app/release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All user visible changes to this project will be documented in this file. This p
     - Profile page:
         - Work with us tab hiding and showing. ([#794], [#789])
         - Cache maximum size slider. ([#794], [#789])
+    - Media panel:
+        - Screen dimming when close to ear on mobile. ([#823], [#808])
 
 ### Changed
 
@@ -84,8 +86,10 @@ All user visible changes to this project will be documented in this file. This p
 [#794]: /../../pull/794
 [#796]: /../../pull/796
 [#797]: /../../pull/797
+[#808]: /../../issues/808
 [#810]: /../../issues/810
 [#816]: /../../pull/816
+[#823]: /../../pull/823
 
 
 

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -18,6 +18,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:all_sensors/all_sensors.dart';
 import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
@@ -46,6 +47,7 @@ import '/provider/gql/exceptions.dart'
 import '/routes.dart';
 import '/ui/page/home/widget/gallery_popup.dart';
 import '/util/audio_utils.dart';
+import '/util/log.dart';
 import '/util/message_popup.dart';
 import '/util/obs/obs.dart';
 import '/util/platform_utils.dart';
@@ -372,6 +374,9 @@ class CallController extends GetxController {
 
   /// Subscription for the [chat] changes.
   StreamSubscription? _chatSubscription;
+
+  /// Subscription for the [proximityEvents] dimming the screen.
+  StreamSubscription? _proximitySubscription;
 
   /// [Worker] reacting on [OngoingCall.chatId] changes to fetch the new [chat].
   late final Worker _chatWorker;
@@ -785,6 +790,17 @@ class CallController extends GetxController {
       }
     });
 
+    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
+      try {
+        _proximitySubscription = proximityEvents?.listen((_) {});
+      } catch (e) {
+        Log.warning(
+          'Failed to initialize proximity sensor: $e',
+          '$runtimeType',
+        );
+      }
+    }
+
     _initChat();
   }
 
@@ -837,6 +853,7 @@ class CallController extends GetxController {
     }
     _notificationTimers.clear();
     _chatSubscription?.cancel();
+    _proximitySubscription?.cancel();
   }
 
   /// Drops the call.

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -792,7 +792,9 @@ class CallController extends GetxController {
 
     if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
       try {
-        _proximitySubscription = proximityEvents?.listen((_) {});
+        _proximitySubscription = proximityEvents?.listen((e) {
+          Log.debug('[debug] proximityEvents: ${e.getValue()}');
+        });
       } catch (e) {
         Log.warning(
           'Failed to initialize proximity sensor: $e',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.16"
+  all_sensors:
+    dependency: "direct main"
+    description:
+      name: all_sensors
+      sha256: "5de1d20c3fee63d18be29ed27c368143d980e7fc5a805c3903946028816ac375"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   analyzer:
     dependency: "direct overridden"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
+  all_sensors: ^0.4.2
   animated_size_and_fade: ^3.0.0
   async: ^2.10.0
   back_button_interceptor: ^7.0.0


### PR DESCRIPTION
Resolves #808




## Synopsis

In mobile call, when phone is held close to an ear, the screen doesn't dim, causing cheek to accidentally touch something.




## Solution

Use proximity sensor to dim the screen.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
