### PR TITLE
issue-471 first commit

### DIFF
--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -551,6 +551,11 @@ class ChatView extends StatelessWidget {
                           child: ContextMenuInterceptor(child: Container()),
                         ),
                         Obx(() {
+
+                          /// TODO: Keep Chat scroll position when leaving and re-entering it
+                          /// https://github.com/team113/messenger/issues/471
+
+
                           final Widget child = FlutterListView(
                             key: const Key('MessagesList'),
                             controller: c.listController,


### PR DESCRIPTION
Resolves #471 

## Synopsis

The chat page of the Gapopa messenger lacks the feature to save the scroll position upon re-entering the chat. Currently, when users navigate away from the chat page and return, the scroll position resets to the default position.

## Solution

The proposed solution involves creating a singleton runtime storage class to centralize storing and updating the last scroll positions of chat rooms. This class will provide methods for adding and updating scroll position data, which the chat controller will utilize upon entering or exiting a chat room. 