### PR TITLE
Display `UserBio` in `ChatSubtitle` (#839)

### DIFF
--- a/lib/store/event/user.dart
+++ b/lib/store/event/user.dart
@@ -193,6 +193,7 @@ class EventUserAvatarUpdated extends UserEvent {
 class EventUserBioDeleted extends UserEvent {
   const EventUserBioDeleted(super.userId, this.at);
 
+  /// [PreciseDateTime] when the [UserBio] was deleted.
   final PreciseDateTime at;
 
   @override

--- a/lib/store/event/user.dart
+++ b/lib/store/event/user.dart
@@ -18,8 +18,8 @@
 import '/api/backend/schema.dart' show Presence;
 import '/domain/model/avatar.dart';
 import '/domain/model/precise_date_time/precise_date_time.dart';
-import '/domain/model/user_call_cover.dart';
 import '/domain/model/user.dart';
+import '/domain/model/user_call_cover.dart';
 import '/provider/hive/user.dart';
 import '/store/model/my_user.dart';
 import '/store/model/user.dart';
@@ -29,6 +29,8 @@ import 'my_user.dart' show BlocklistEvent;
 enum UserEventKind {
   avatarDeleted,
   avatarUpdated,
+  bioDeleted,
+  bioUpdated,
   callCoverDeleted,
   callCoverUpdated,
   cameOffline,
@@ -185,6 +187,30 @@ class EventUserAvatarUpdated extends UserEvent {
 
   @override
   UserEventKind get kind => UserEventKind.avatarUpdated;
+}
+
+/// Event of an [UserBio] being deleted.
+class EventUserBioDeleted extends UserEvent {
+  const EventUserBioDeleted(super.userId, this.at);
+
+  final PreciseDateTime at;
+
+  @override
+  UserEventKind get kind => UserEventKind.bioDeleted;
+}
+
+/// Event of an [UserBio] being updated.
+class EventUserBioUpdated extends UserEvent {
+  const EventUserBioUpdated(super.userId, this.bio, this.at);
+
+  /// New [UserBio].
+  final UserBio bio;
+
+  /// [PreciseDateTime] when the [UserBio] was updated.
+  final PreciseDateTime at;
+
+  @override
+  UserEventKind get kind => UserEventKind.bioUpdated;
 }
 
 /// Event of an [UserCallCover] being deleted.

--- a/lib/store/event/user.dart
+++ b/lib/store/event/user.dart
@@ -153,7 +153,7 @@ class UserEventsUser extends UserEvents {
   UserEventsKind get kind => UserEventsKind.user;
 }
 
-/// Events happening with an [User].
+/// Events happening with a [User].
 abstract class UserEvent {
   const UserEvent(this.userId);
 
@@ -164,7 +164,7 @@ abstract class UserEvent {
   UserEventKind get kind;
 }
 
-/// Event of an [UserAvatar] being deleted.
+/// Event of a [UserAvatar] being deleted.
 class EventUserAvatarDeleted extends UserEvent {
   const EventUserAvatarDeleted(super.userId, this.at);
 
@@ -175,7 +175,7 @@ class EventUserAvatarDeleted extends UserEvent {
   UserEventKind get kind => UserEventKind.avatarDeleted;
 }
 
-/// Event of an [UserAvatar] being updated.
+/// Event of a [UserAvatar] being updated.
 class EventUserAvatarUpdated extends UserEvent {
   const EventUserAvatarUpdated(super.userId, this.avatar, this.at);
 
@@ -189,7 +189,7 @@ class EventUserAvatarUpdated extends UserEvent {
   UserEventKind get kind => UserEventKind.avatarUpdated;
 }
 
-/// Event of an [UserBio] being deleted.
+/// Event of a [UserBio] being deleted.
 class EventUserBioDeleted extends UserEvent {
   const EventUserBioDeleted(super.userId, this.at);
 
@@ -199,7 +199,7 @@ class EventUserBioDeleted extends UserEvent {
   UserEventKind get kind => UserEventKind.bioDeleted;
 }
 
-/// Event of an [UserBio] being updated.
+/// Event of a [UserBio] being updated.
 class EventUserBioUpdated extends UserEvent {
   const EventUserBioUpdated(super.userId, this.bio, this.at);
 
@@ -213,7 +213,7 @@ class EventUserBioUpdated extends UserEvent {
   UserEventKind get kind => UserEventKind.bioUpdated;
 }
 
-/// Event of an [UserCallCover] being deleted.
+/// Event of a [UserCallCover] being deleted.
 class EventUserCallCoverDeleted extends UserEvent {
   const EventUserCallCoverDeleted(super.userId, this.at);
 
@@ -224,7 +224,7 @@ class EventUserCallCoverDeleted extends UserEvent {
   UserEventKind get kind => UserEventKind.callCoverDeleted;
 }
 
-/// Event of an [UserCallCover] being updated.
+/// Event of a [UserCallCover] being updated.
 class EventUserCallCoverUpdated extends UserEvent {
   const EventUserCallCoverUpdated(super.userId, this.callCover, this.at);
 
@@ -238,7 +238,7 @@ class EventUserCallCoverUpdated extends UserEvent {
   UserEventKind get kind => UserEventKind.callCoverUpdated;
 }
 
-/// Event of an [User] coming offline.
+/// Event of a [User] coming offline.
 class EventUserCameOffline extends UserEvent {
   const EventUserCameOffline(super.userId, this.at);
 
@@ -249,7 +249,7 @@ class EventUserCameOffline extends UserEvent {
   UserEventKind get kind => UserEventKind.cameOffline;
 }
 
-/// Event of an [User] coming online.
+/// Event of a [User] coming online.
 class EventUserCameOnline extends UserEvent {
   const EventUserCameOnline(super.userId);
 
@@ -257,7 +257,7 @@ class EventUserCameOnline extends UserEvent {
   UserEventKind get kind => UserEventKind.cameOnline;
 }
 
-/// Event of an [User] being deleted.
+/// Event of a [User] being deleted.
 class EventUserDeleted extends UserEvent {
   const EventUserDeleted(super.userId, this.at);
 
@@ -268,7 +268,7 @@ class EventUserDeleted extends UserEvent {
   UserEventKind get kind => UserEventKind.userDeleted;
 }
 
-/// Event of an [UserName] being deleted.
+/// Event of a [UserName] being deleted.
 class EventUserNameDeleted extends UserEvent {
   const EventUserNameDeleted(super.userId, this.at);
 
@@ -279,7 +279,7 @@ class EventUserNameDeleted extends UserEvent {
   UserEventKind get kind => UserEventKind.nameDeleted;
 }
 
-/// Event of an [UserName] being updated.
+/// Event of a [UserName] being updated.
 class EventUserNameUpdated extends UserEvent {
   const EventUserNameUpdated(super.userId, this.name, this.at);
 
@@ -293,7 +293,7 @@ class EventUserNameUpdated extends UserEvent {
   UserEventKind get kind => UserEventKind.nameUpdated;
 }
 
-/// Event of an [User]'s [Presence] being updated.
+/// Event of a [User]'s [Presence] being updated.
 class EventUserPresenceUpdated extends UserEvent {
   const EventUserPresenceUpdated(super.userId, this.presence, this.at);
 
@@ -307,7 +307,7 @@ class EventUserPresenceUpdated extends UserEvent {
   UserEventKind get kind => UserEventKind.presenceUpdated;
 }
 
-/// Event of an [UserTextStatus] being deleted.
+/// Event of a [UserTextStatus] being deleted.
 class EventUserStatusDeleted extends UserEvent {
   const EventUserStatusDeleted(super.userId, this.at);
 
@@ -318,7 +318,7 @@ class EventUserStatusDeleted extends UserEvent {
   UserEventKind get kind => UserEventKind.statusDeleted;
 }
 
-/// Event of an [UserTextStatus] being updated.
+/// Event of a [UserTextStatus] being updated.
 class EventUserStatusUpdated extends UserEvent {
   const EventUserStatusUpdated(super.userId, this.status, this.at);
 

--- a/lib/store/user.dart
+++ b/lib/store/user.dart
@@ -492,6 +492,12 @@ class UserRepository extends DisposableInterface
     } else if (e.$$typename == 'EventUserStatusUpdated') {
       var node = e as UserEventsVersionedMixin$Events$EventUserStatusUpdated;
       return EventUserStatusUpdated(node.userId, node.status, node.at);
+    } else if (e.$$typename == 'EventUserBioDeleted') {
+      final node = e as UserEventsVersionedMixin$Events$EventUserBioDeleted;
+      return EventUserBioDeleted(node.userId, node.at);
+    } else if (e.$$typename == 'EventUserBioUpdated') {
+      final node = e as UserEventsVersionedMixin$Events$EventUserBioUpdated;
+      return EventUserBioUpdated(node.userId, node.bio, node.at);
     } else {
       throw UnimplementedError('Unknown UserEvent: ${e.$$typename}');
     }

--- a/lib/store/user.dart
+++ b/lib/store/user.dart
@@ -252,7 +252,7 @@ class UserRepository extends DisposableInterface
   void update(User user) {
     Log.debug('update($user)', '$runtimeType');
 
-    HiveUser? hiveUser = _userLocal.get(user.id);
+    final HiveUser? hiveUser = _userLocal.get(user.id);
     if (hiveUser != null) {
       hiveUser.value = user;
       put(hiveUser, ignoreVersion: true);
@@ -315,27 +315,27 @@ class UserRepository extends DisposableInterface
     return _graphQlProvider.userEvents(id, ver).asyncExpand((event) async* {
       Log.trace('userEvents($id): ${event.data}', '$runtimeType');
 
-      var events = UserEvents$Subscription.fromJson(event.data!).userEvents;
+      final events = UserEvents$Subscription.fromJson(event.data!).userEvents;
       if (events.$$typename == 'SubscriptionInitialized') {
         events as UserEvents$Subscription$UserEvents$SubscriptionInitialized;
         yield const UserEventsInitialized();
       } else if (events.$$typename == 'User') {
-        var mixin = events as UserEvents$Subscription$UserEvents$User;
+        final mixin = events as UserEvents$Subscription$UserEvents$User;
         yield UserEventsUser(mixin.toHive());
       } else if (events.$$typename == 'UserEventsVersioned') {
-        var mixin = events as UserEventsVersionedMixin;
+        final mixin = events as UserEventsVersionedMixin;
         yield UserEventsEvent(UserEventsVersioned(
           mixin.events.map((e) => _userEvent(e)).toList(),
           mixin.ver,
         ));
       } else if (events.$$typename == 'BlocklistEventsVersioned') {
-        var mixin = events as BlocklistEventsVersionedMixin;
+        final mixin = events as BlocklistEventsVersionedMixin;
         yield UserEventsBlocklistEventsEvent(BlocklistEventsVersioned(
           mixin.events.map((e) => _blocklistEvent(e)).toList(),
           mixin.myVer,
         ));
       } else if (events.$$typename == 'isBlocked') {
-        var node = events as UserEvents$Subscription$UserEvents$IsBlocked;
+        final node = events as UserEvents$Subscription$UserEvents$IsBlocked;
         yield UserEventsIsBlocked(
           node.record == null
               ? null
@@ -354,7 +354,7 @@ class UserRepository extends DisposableInterface
   Future<void> _putUser(HiveUser user, {bool ignoreVersion = false}) async {
     Log.trace('_putUser($user, $ignoreVersion)', '$runtimeType');
 
-    var saved = _userLocal.get(user.value.id);
+    final saved = _userLocal.get(user.value.id);
 
     if (saved == null ||
         saved.ver < user.ver ||
@@ -370,11 +370,11 @@ class UserRepository extends DisposableInterface
 
     _localSubscription = StreamIterator(_userLocal.boxEvents);
     while (await _localSubscription!.moveNext()) {
-      BoxEvent event = _localSubscription!.current;
+      final BoxEvent event = _localSubscription!.current;
       if (event.deleted) {
         users.remove(UserId(event.key))?.dispose();
       } else {
-        RxUser? user = users[UserId(event.key)];
+        final RxUser? user = users[UserId(event.key)];
         if (user == null) {
           users[UserId(event.key)] = HiveRxUser(this, _userLocal, event.value);
         } else {
@@ -449,48 +449,51 @@ class UserRepository extends DisposableInterface
     Log.trace('_userEvent($e)', '$runtimeType');
 
     if (e.$$typename == 'EventUserAvatarDeleted') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserAvatarDeleted;
+      final node = e as UserEventsVersionedMixin$Events$EventUserAvatarDeleted;
       return EventUserAvatarDeleted(node.userId, node.at);
     } else if (e.$$typename == 'EventUserAvatarUpdated') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserAvatarUpdated;
+      final node = e as UserEventsVersionedMixin$Events$EventUserAvatarUpdated;
       return EventUserAvatarUpdated(
         node.userId,
         node.avatar.toModel(),
         node.at,
       );
     } else if (e.$$typename == 'EventUserCallCoverDeleted') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserCallCoverDeleted;
+      final node =
+          e as UserEventsVersionedMixin$Events$EventUserCallCoverDeleted;
       return EventUserCallCoverDeleted(node.userId, node.at);
     } else if (e.$$typename == 'EventUserCallCoverUpdated') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserCallCoverUpdated;
+      final node =
+          e as UserEventsVersionedMixin$Events$EventUserCallCoverUpdated;
       return EventUserCallCoverUpdated(
         node.userId,
         node.callCover.toModel(),
         node.at,
       );
     } else if (e.$$typename == 'EventUserCameOffline') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserCameOffline;
+      final node = e as UserEventsVersionedMixin$Events$EventUserCameOffline;
       return EventUserCameOffline(node.userId, node.at);
     } else if (e.$$typename == 'EventUserCameOnline') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserCameOnline;
+      final node = e as UserEventsVersionedMixin$Events$EventUserCameOnline;
       return EventUserCameOnline(node.userId);
     } else if (e.$$typename == 'EventUserDeleted') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserDeleted;
+      final node = e as UserEventsVersionedMixin$Events$EventUserDeleted;
       return EventUserDeleted(node.userId, node.at);
     } else if (e.$$typename == 'EventUserNameDeleted') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserNameDeleted;
+      final node = e as UserEventsVersionedMixin$Events$EventUserNameDeleted;
       return EventUserNameDeleted(node.userId, node.at);
     } else if (e.$$typename == 'EventUserNameUpdated') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserNameUpdated;
+      final node = e as UserEventsVersionedMixin$Events$EventUserNameUpdated;
       return EventUserNameUpdated(node.userId, node.name, node.at);
     } else if (e.$$typename == 'EventUserPresenceUpdated') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserPresenceUpdated;
+      final node =
+          e as UserEventsVersionedMixin$Events$EventUserPresenceUpdated;
       return EventUserPresenceUpdated(node.userId, node.presence, node.at);
     } else if (e.$$typename == 'EventUserStatusDeleted') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserStatusDeleted;
+      final node = e as UserEventsVersionedMixin$Events$EventUserStatusDeleted;
       return EventUserStatusDeleted(node.userId, node.at);
     } else if (e.$$typename == 'EventUserStatusUpdated') {
-      var node = e as UserEventsVersionedMixin$Events$EventUserStatusUpdated;
+      final node = e as UserEventsVersionedMixin$Events$EventUserStatusUpdated;
       return EventUserStatusUpdated(node.userId, node.status, node.at);
     } else if (e.$$typename == 'EventUserBioDeleted') {
       final node = e as UserEventsVersionedMixin$Events$EventUserBioDeleted;
@@ -509,7 +512,7 @@ class UserRepository extends DisposableInterface
     Log.trace('_blocklistEvent($e)', '$runtimeType');
 
     if (e.$$typename == 'EventBlocklistRecordAdded') {
-      var node =
+      final node =
           e as BlocklistEventsVersionedMixin$Events$EventBlocklistRecordAdded;
       return EventBlocklistRecordAdded(
         e.user.toHive(),

--- a/lib/store/user_rx.dart
+++ b/lib/store/user_rx.dart
@@ -156,15 +156,15 @@ class HiveRxUser extends RxUser {
         Log.debug('_userEvent(${events.kind})', '$runtimeType($id)');
 
         events as UserEventsUser;
-        var saved = _userLocal.get(id);
+        final saved = _userLocal.get(id);
         if (saved == null || saved.ver < events.user.ver) {
           await _userLocal.put(events.user);
         }
         break;
 
       case UserEventsKind.event:
-        var userEntity = _userLocal.get(id);
-        var versioned = (events as UserEventsEvent).event;
+        final userEntity = _userLocal.get(id);
+        final versioned = (events as UserEventsEvent).event;
         if (userEntity == null || versioned.ver <= userEntity.ver) {
           Log.debug(
             '_userEvent(${events.kind}): ignored ${versioned.events.map((e) => e.kind)}',
@@ -251,8 +251,8 @@ class HiveRxUser extends RxUser {
         break;
 
       case UserEventsKind.blocklistEvent:
-        var userEntity = _userLocal.get(id);
-        var versioned = (events as UserEventsBlocklistEventsEvent).event;
+        final userEntity = _userLocal.get(id);
+        final versioned = (events as UserEventsBlocklistEventsEvent).event;
 
         // TODO: Properly account `MyUserVersion` returned.
         if (userEntity != null && userEntity.blockedVer > versioned.ver) {
@@ -265,8 +265,8 @@ class HiveRxUser extends RxUser {
         break;
 
       case UserEventsKind.isBlocked:
-        var versioned = events as UserEventsIsBlocked;
-        var userEntity = _userLocal.get(id);
+        final versioned = events as UserEventsIsBlocked;
+        final userEntity = _userLocal.get(id);
 
         if (userEntity != null) {
           // TODO: Properly account `MyUserVersion` returned.

--- a/lib/store/user_rx.dart
+++ b/lib/store/user_rx.dart
@@ -190,6 +190,15 @@ class HiveRxUser extends RxUser {
               userEntity.value.avatar = event.avatar;
               break;
 
+            case UserEventKind.bioDeleted:
+              userEntity.value.bio = null;
+              break;
+
+            case UserEventKind.bioUpdated:
+              event as EventUserBioUpdated;
+              userEntity.value.bio = event.bio;
+              break;
+
             case UserEventKind.cameOffline:
               event as EventUserCameOffline;
               userEntity.value.online = false;

--- a/lib/ui/page/home/page/chat/info/view.dart
+++ b/lib/ui/page/home/page/chat/info/view.dart
@@ -16,9 +16,9 @@
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
 import 'package:animated_size_and_fade/animated_size_and_fade.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
-import 'package:flutter/material.dart';
 
 import '/domain/model/chat.dart';
 import '/domain/repository/user.dart';

--- a/lib/ui/page/home/page/chat/widget/chat_subtitle.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_subtitle.dart
@@ -179,10 +179,7 @@ class _ChatSubtitleState extends State<ChatSubtitle> {
         final String? subtitle = chat.getSubtitle();
 
         if (subtitle != null) {
-          return Text(
-            subtitle,
-            style: style.fonts.small.regular.secondary,
-          );
+          return Text(subtitle, style: style.fonts.small.regular.secondary);
         }
 
         return const SizedBox();
@@ -203,10 +200,7 @@ class _ChatSubtitleState extends State<ChatSubtitle> {
                 .whereNotNull()
                 .join('space_vertical_space'.l10n);
 
-            return Text(
-              subtitle,
-              style: style.fonts.small.regular.secondary,
-            );
+            return Text(subtitle, style: style.fonts.small.regular.secondary);
           });
         }
       }

--- a/lib/ui/page/home/page/chat/widget/chat_subtitle.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_subtitle.dart
@@ -177,12 +177,14 @@ class _ChatSubtitleState extends State<ChatSubtitle> {
 
       if (chat.isGroup) {
         final String? subtitle = chat.getSubtitle();
+
         if (subtitle != null) {
           return Text(
             subtitle,
             style: style.fonts.small.regular.secondary,
           );
         }
+
         return const SizedBox();
       } else if (chat.isDialog) {
         final RxUser? member = widget.chat.members.values
@@ -190,15 +192,19 @@ class _ChatSubtitleState extends State<ChatSubtitle> {
 
         if (member != null) {
           return Obx(() {
-            final String? subtitle = chat.getSubtitle(partner: member);
+            final String? presence = chat.getSubtitle(partner: member);
             final UserBio? bio = member.user.value.bio;
 
-            if (bio == null && subtitle == null) {
+            if (bio == null && presence == null) {
               return const SizedBox();
             }
 
+            final String subtitle = [presence, bio]
+                .whereNotNull()
+                .join('space_vertical_space'.l10n);
+
             return Text(
-              [subtitle, bio].whereNotNull().join('space_vertical_space'.l10n),
+              subtitle,
               style: style.fonts.small.regular.secondary,
             );
           });

--- a/lib/ui/page/home/page/chat/widget/chat_subtitle.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_subtitle.dart
@@ -176,10 +176,14 @@ class _ChatSubtitleState extends State<ChatSubtitle> {
       }
 
       if (chat.isGroup) {
-        return Text(
-          chat.getSubtitle()!,
-          style: style.fonts.small.regular.secondary,
-        );
+        final String? subtitle = chat.getSubtitle();
+        if (subtitle != null) {
+          return Text(
+            subtitle,
+            style: style.fonts.small.regular.secondary,
+          );
+        }
+        return const SizedBox();
       } else if (chat.isDialog) {
         final RxUser? member = widget.chat.members.values
             .firstWhereOrNull((u) => u.user.value.id != widget.me);
@@ -187,22 +191,14 @@ class _ChatSubtitleState extends State<ChatSubtitle> {
         if (member != null) {
           return Obx(() {
             final String? subtitle = chat.getSubtitle(partner: member);
-            final UserTextStatus? status = member.user.value.status;
+            final UserBio? bio = member.user.value.bio;
 
-            if (status == null && subtitle == null) {
+            if (bio == null && subtitle == null) {
               return const SizedBox();
             }
 
-            final StringBuffer buffer = StringBuffer(status ?? '');
-
-            if (status != null && subtitle != null) {
-              buffer.write('space_vertical_space'.l10n);
-            }
-
-            buffer.write(subtitle ?? '');
-
             return Text(
-              buffer.toString(),
+              [subtitle, bio].whereNotNull().join('space_vertical_space'.l10n),
               style: style.fonts.small.regular.secondary,
             );
           });

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -168,9 +168,12 @@ class UserView extends StatelessWidget {
       return Block(
         padding: Block.defaultPadding.copyWith(top: 8, bottom: 8),
         children: [
-          Text(
-            bio.toString(),
-            style: style.fonts.normal.regular.secondary,
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              bio.toString(),
+              style: style.fonts.normal.regular.secondary,
+            ),
           ),
         ],
       );

--- a/lib/ui/page/home/tab/menu/view.dart
+++ b/lib/ui/page/home/tab/menu/view.dart
@@ -114,8 +114,7 @@ class MenuTabView extends StatelessWidget {
                             ),
                             Obx(() {
                               return Text(
-                                c.myUser.value?.status?.val ??
-                                    'label_online'.l10n,
+                                c.myUser.value?.bio?.val ?? 'label_online'.l10n,
                                 style: style.fonts.small.regular.secondary,
                               );
                             }),


### PR DESCRIPTION
Resolves #839
## Synopsis
Отображать `UserBio` в `ChatSubtitle`.
## Solution
- Перенести с `new-design-preview` текущий дизайн
- Добавить обработку событий `EventUserBioUpdated` / `EventUserBioDeleted` в стор `User`а

## Checklist
- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
