### PR TITLE
Implement audio player for audio file attachments in Chat (#618)

### DIFF
--- a/lib/domain/model/attachment.dart
+++ b/lib/domain/model/attachment.dart
@@ -115,6 +115,12 @@ class FileAttachment extends Attachment {
         file.endsWith('.3gp');
   }
 
+  bool get isAudio {
+    final String file = filename.toLowerCase();
+    return file.endsWith('.mp3') ||
+        file.endsWith('.wav');
+  }
+
   /// Initializes this [FileAttachment].
   Future<void> init() async {
     if (_initialized) {


### PR DESCRIPTION

Resolves #618 



## Synopsis

Сделать: отображение аудио файлов в виде плеера с возможностью аудио воспроизвести, покрыть интеграционным тестом.




## Solution

- PlayableAsset виджет расширить и произвести его редизайн под описанные выше необходимости.
- Реализовать фичу: Файл ремоутный (FileAttachment) и файл локальный (LocalAttachment) должны иметь возможность идентифицироваться как аудио, чтобы в списке прикреплений отображаться в виде плеера.
- Для воспроизведения аудио использовать AudioUtils класс. Завести в данном классе какое-нибудь поле или метод, которое бы гарантировало воспроизведение только одного аудио каким-нибудь образом.
- Для покрытия тестом написать мок AudioUtils. который будет подтверждать тот факт, что вызов к аудио был совершён, через соответствующие степы.
- Написать тесты
- Написать документацию


## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
