### PR TITLE
Redesign `MyProfile` page to display `UserBioField` in a separate `Block`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All user visible changes to this project will be documented in this file. This p
         - Redesigned editing mode and actions. ([#868])
     - User page:
         - Redesigned editing mode and actions. ([#868])
+    - Profile page:
+        - About field in separate block. ([#891])
 
 ### Fixed
 
@@ -45,6 +47,7 @@ All user visible changes to this project will be documented in this file. This p
 [#877]: /../../pull/877
 [#880]: /../../pull/880
 [#886]: /../../pull/886
+[#891]: /../../pull/891
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -642,6 +642,7 @@ label_delete_message = Delete the message?
 label_delete_messages = Delete the messages?
 label_delete_phone_number = Delete phone number
 label_delivered = Delivered
+label_description = Description
 label_details = Details.
 label_device_by_default = By default - {$device}
 label_dialog_created = Dialog created

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -667,6 +667,7 @@ label_delete_message = Удалить сообщение?
 label_delete_messages = Удалить сообщения?
 label_delete_phone_number = Удалить номер телефона
 label_delivered = Доставлено
+label_description = Описание
 label_details = Подробнее.
 label_device_by_default = По умолчанию - {$device}
 label_dialog_created = Диалог создан

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -95,6 +95,8 @@ class MyProfileController extends GetxController {
   /// Indicator whether the [MyUser.chatDirectLink] editing mode is enabled.
   final RxBool linkEditing = RxBool(false);
 
+  final RxBool displayName = RxBool(false);
+
   /// Service responsible for [MyUser] management.
   final MyUserService _myUserService;
 
@@ -293,6 +295,8 @@ class MyProfileController extends GetxController {
       },
     );
 
+    scrollController.addListener(_ensureNameDisplayed);
+
     super.onInit();
   }
 
@@ -300,6 +304,7 @@ class MyProfileController extends GetxController {
   void onClose() {
     _profileWorker?.dispose();
     _devicesSubscription?.cancel();
+    scrollController.removeListener(_ensureNameDisplayed);
     super.onClose();
   }
 
@@ -466,6 +471,12 @@ class MyProfileController extends GetxController {
     _highlightTimer = Timer(_highlightTimeout, () {
       highlightIndex.value = null;
     });
+  }
+
+  /// Ensures the [displayName] is either `true` or `false` based on the
+  /// [scrollController].
+  void _ensureNameDisplayed() {
+    displayName.value = scrollController.position.pixels >= 250;
   }
 }
 

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -95,6 +95,8 @@ class MyProfileController extends GetxController {
   /// Indicator whether the [MyUser.chatDirectLink] editing mode is enabled.
   final RxBool linkEditing = RxBool(false);
 
+  /// Indicator whether [MyUser.name] and [MyUser.avatar] should be displayed in
+  /// the [AppBar].
   final RxBool displayName = RxBool(false);
 
   /// Service responsible for [MyUser] management.

--- a/lib/ui/page/home/page/my_profile/widget/bio.dart
+++ b/lib/ui/page/home/page/my_profile/widget/bio.dart
@@ -91,7 +91,7 @@ class _UserBioFieldState extends State<UserBioField> {
     return ReactiveTextField(
       key: const Key('BioField'),
       state: _state,
-      label: 'label_about'.l10n,
+      label: 'label_description'.l10n,
       filled: true,
       maxLines: null,
       formatters: [LengthLimitingTextInputFormatter(4096)],

--- a/lib/ui/page/home/page/my_profile/widget/login.dart
+++ b/lib/ui/page/home/page/my_profile/widget/login.dart
@@ -52,7 +52,6 @@ class _UserLoginFieldState extends State<UserLoginField> {
   /// State of the [ReactiveTextField].
   late final TextFieldState _state = TextFieldState(
     text: widget.login?.val,
-    approvable: true,
     onChanged: (s) async {
       s.error.value = null;
 
@@ -65,8 +64,7 @@ class _UserLoginFieldState extends State<UserLoginField> {
       } on FormatException catch (_) {
         s.error.value = 'err_incorrect_login_input'.l10n;
       }
-    },
-    onSubmitted: (s) async {
+
       if (s.error.value == null) {
         s.editable.value = false;
         s.status.value = RxStatus.loading();
@@ -115,6 +113,7 @@ class _UserLoginFieldState extends State<UserLoginField> {
 
     if (_editing) {
       child = Padding(
+        key: const Key('1'),
         padding: const EdgeInsets.only(top: 8.0),
         child: ReactiveTextField(
           key: const Key('LoginField'),
@@ -129,6 +128,7 @@ class _UserLoginFieldState extends State<UserLoginField> {
                   }
                 },
           label: 'label_login'.l10n,
+          prefixText: '@',
           hint: widget.login == null
               ? 'label_login_hint'.l10n
               : widget.login!.val,
@@ -138,7 +138,7 @@ class _UserLoginFieldState extends State<UserLoginField> {
       child = Paddings.basic(
         InfoTile(
           title: 'label_login'.l10n,
-          content: _state.text,
+          content: '@${_state.text}',
           trailing: WidgetButton(
             onPressed: () => setState(() => _editing = true),
             child: const SvgIcon(SvgIcons.editField),

--- a/lib/ui/page/home/page/my_profile/widget/name.dart
+++ b/lib/ui/page/home/page/my_profile/widget/name.dart
@@ -46,18 +46,7 @@ class _UserNameFieldState extends State<UserNameField> {
   /// State of the [ReactiveTextField].
   late final TextFieldState _state = TextFieldState(
     text: widget.name?.val,
-    approvable: true,
     onChanged: (s) async {
-      s.error.value = null;
-      try {
-        if (s.text.isNotEmpty) {
-          UserName(s.text);
-        }
-      } on FormatException catch (_) {
-        s.error.value = 'err_incorrect_input'.l10n;
-      }
-    },
-    onSubmitted: (s) async {
       s.error.value = null;
       try {
         if (s.text.isNotEmpty) {

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -107,6 +107,9 @@ class UserController extends GetxController {
   /// - `status.isEmpty`, meaning no [block] is executing.
   final Rx<RxStatus> blocklistStatus = Rx(RxStatus.empty());
 
+  /// Indicator whether [AppBar] should display the [UserName] and [UserAvatar].
+  final RxBool displayName = RxBool(false);
+
   /// [UserService] fetching the [user].
   final UserService _userService;
 
@@ -218,6 +221,8 @@ class UserController extends GetxController {
       }
     });
 
+    scrollController.addListener(_ensureNameDisplayed);
+
     super.onInit();
   }
 
@@ -226,6 +231,7 @@ class UserController extends GetxController {
     _userSubscription?.cancel();
     _contactWorker?.dispose();
     _worker?.dispose();
+    scrollController.removeListener(_ensureNameDisplayed);
     super.onClose();
   }
 
@@ -481,6 +487,12 @@ class UserController extends GetxController {
         }
       });
     }
+  }
+
+  /// Ensures the [displayName] is either `true` or `false` based on the
+  /// [scrollController].
+  void _ensureNameDisplayed() {
+    displayName.value = scrollController.position.pixels >= 250;
   }
 }
 

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -184,6 +184,14 @@ class UserView extends StatelessWidget {
                     style: style.fonts.large.regular.onBackground,
                   ),
                 ),
+                const SizedBox(height: 4),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
+                  child: Text(
+                    c.user?.user.value.getStatus() ?? '',
+                    style: style.fonts.small.regular.secondary,
+                  ),
+                ),
               ];
             }
 
@@ -372,10 +380,25 @@ class UserView extends StatelessWidget {
       );
     });
 
-    return Center(
-      child: Row(
+    final Widget title;
+
+    if (!c.displayName.value) {
+      title = Row(
+        key: const Key('Profile'),
         children: [
+          const StyledBackButton(),
           const SizedBox(width: 8),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(32, 0, 32, 0),
+              child: Center(child: Text('label_profile'.l10n)),
+            ),
+          ),
+        ],
+      );
+    } else {
+      title = Row(
+        children: [
           const StyledBackButton(),
           Material(
             elevation: 6,
@@ -418,10 +441,21 @@ class UserView extends StatelessWidget {
               }),
             ),
           ),
-          const SizedBox(width: 40),
-          editButton,
+          const SizedBox(width: 10),
         ],
-      ),
+      );
+    }
+
+    return Row(
+      children: [
+        Expanded(
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 400),
+            child: title,
+          ),
+        ),
+        editButton,
+      ],
     );
   }
 

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -212,7 +212,8 @@ class ReactiveTextField extends StatelessWidget {
             suffix != null ||
             trailing != null ||
             !status.isEmpty ||
-            hasError;
+            hasError ||
+            onCanceled != null;
 
         final Widget cancelButton = AllowOverflow(
           key: const ValueKey('Cancel'),

--- a/test/e2e/features/auth/create_account/.feature
+++ b/test/e2e/features/auth/create_account/.feature
@@ -27,7 +27,6 @@ Feature: Account creation
     And I wait until `MyProfileView` is present
     And I wait until `NameField` is present
     And I fill `NameField` field with "Alice"
-    And I tap `Approve` button
 
     When I scroll `MyProfileScrollable` until `SetPassword` is present
     And I tap `SetPassword` button

--- a/test/e2e/features/profile/l10n/.feature
+++ b/test/e2e/features/profile/l10n/.feature
@@ -27,9 +27,9 @@ Feature: Localization
     And I tap `ChangeLanguage` button
     And I tap `Language_ru` button
     And I tap `CloseButton` button
-    Then I wait until text "Аккаунт" is present
+    Then I wait until text "Язык" is present
 
     When I tap `ChangeLanguage` button
     And I tap `Language_en` button
     And I tap `CloseButton` button
-    Then I wait until text "Account" is present
+    Then I wait until text "Language" is present

--- a/test/widget/user_profile_test.dart
+++ b/test/widget/user_profile_test.dart
@@ -522,13 +522,13 @@ void main() async {
     await tester.pumpAndSettle(const Duration(seconds: 2));
 
     expect(find.text('user name'), findsAny);
-    expect(find.byKey(const Key('Present')), findsOneWidget);
     await tester.dragUntilVisible(
       find.byKey(const Key('NumCopyable')),
       find.byKey(const Key('UserScrollable')),
       const Offset(1, 1),
     );
     await tester.pumpAndSettle(const Duration(seconds: 2));
+    expect(find.byKey(const Key('Present')), findsOneWidget);
     expect(find.text('5769space2360space9862space1822'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('MoreButton')));


### PR DESCRIPTION
## Synopsis

Little changes of design.




## Solution

This PR:
- moves `UserBioField` into separate `Block`;
- adds `displayName` to `User` and `MyProfile` pages;
- adds `User.status` displaying under `User.name`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
