### PR TITLE
Keep `CallMember`s in dialed state when `ChatCallRoomJoinLink` is changed

### DIFF
--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -1796,8 +1796,20 @@ class OngoingCall {
         'Closing the previous one and connecting to the new',
         '$runtimeType',
       );
+
+      final List<CallMember> connected = members.values
+          .where((e) => e.isConnected.value == true && e.id != _me)
+          .toList();
+
       _closeRoom(false);
       _initRoom();
+
+      members.addEntries(
+        connected
+            .map((e) => MapEntry(e.id, CallMember(e.id, null, isDialing: true)))
+            .toList(),
+      );
+
       await _setInitialMediaSettings();
       await _initLocalMedia();
     }


### PR DESCRIPTION
## Synopsis

When `ChatCallRoomJoinLink` changes, the `CallMember`s get cleared.




## Solution

Keep the members who were connected in dialed state.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
