### PR TITLE
Add `Config.schema` cleaning `Hive` storage on changes

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -85,6 +85,12 @@ class Config {
   /// Intended to be used in E2E testing.
   static String? version;
 
+  /// Level of [Log]ger to log.
+  static me.LogLevel logLevel = me.LogLevel.info;
+
+  /// Version of the [Hive] schema, used to clear cache if mismatch is detected.
+  static String? schema = '0';
+
   /// Returns a [Map] being a configuration passed to a [FlutterCallkeep]
   /// instance to initialize it.
   static Map<String, dynamic> get callKeep {
@@ -105,9 +111,6 @@ class Config {
       },
     };
   }
-
-  /// Level of [Log]ger to log.
-  static me.LogLevel logLevel = me.LogLevel.info;
 
   /// Initializes this [Config] by applying values from the following sources
   /// (in the following order):

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -342,7 +342,7 @@ Future<void> _initHive() async {
 
   // Load and compare application version.
   Box box = await Hive.openBox('version');
-  final String version = Config.schema ?? Config.version ?? Pubspec.version;
+  final String version = Config.version ?? Config.schema ?? Pubspec.version;
   final String? stored = box.get(0);
 
   // If mismatch is detected, then clean the existing [Hive] cache.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -342,7 +342,7 @@ Future<void> _initHive() async {
 
   // Load and compare application version.
   Box box = await Hive.openBox('version');
-  final String version = Config.version ?? Pubspec.version;
+  final String version = Config.schema ?? Config.version ?? Pubspec.version;
   final String? stored = box.get(0);
 
   // If mismatch is detected, then clean the existing [Hive] cache.


### PR DESCRIPTION
## Synopsis

Every push to main deploys the application and data in Hive changes over time, causing errors.




## Solution

Thos PR adds `Config.schema` variable, which will be bumped up every time Hive BCs occur.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
