### PR TITLE
Don't clean `CredentialsHiveProvider` on `Config.schema` changes

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -89,7 +89,7 @@ class Config {
   static me.LogLevel logLevel = me.LogLevel.info;
 
   /// Version of the [Hive] schema, used to clear cache if mismatch is detected.
-  static String? schema = '0';
+  static String? schema;
 
   /// Version of the [CredentialsHiveProvider] schema, used to clear it, if
   /// mismatch is detected.

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -91,6 +91,10 @@ class Config {
   /// Version of the [Hive] schema, used to clear cache if mismatch is detected.
   static String? schema = '0';
 
+  /// Version of the [CredentialsHiveProvider] schema, used to clear it, if
+  /// mismatch is detected.
+  static String? credentials;
+
   /// Returns a [Map] being a configuration passed to a [FlutterCallkeep]
   /// instance to initialize it.
   static Map<String, dynamic> get callKeep {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -346,7 +346,7 @@ Future<void> _initHive() async {
   final String version = Config.version ?? Config.schema ?? Pubspec.version;
   final String? storedVersion = box.get(0);
 
-  final String? session = Config.credentials;
+  final String? session = Config.version ?? Config.credentials;
   final String? storedSession = box.get(1);
 
   // If mismatch is detected, then clean the existing [Hive] cache.

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -131,7 +131,7 @@ class WebUtils {
   }
 
   /// Does nothing as `IndexedDB` is absent on desktop or mobile platforms.
-  static Future<void> cleanIndexedDb() async {
+  static Future<void> cleanIndexedDb({String? except}) async {
     // No-op.
   }
 

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -107,7 +107,7 @@ external dynamic webkitFullscreenElement;
 external dynamic msFullscreenElement;
 
 @JS('cleanIndexedDB')
-external cleanIndexedDB();
+external cleanIndexedDB(dynamic);
 
 @JS('window.isPopup')
 external bool _isPopup;
@@ -449,9 +449,9 @@ class WebUtils {
   }
 
   /// Clears the browser's `IndexedDB`.
-  static Future<void> cleanIndexedDb() async {
+  static Future<void> cleanIndexedDb({String? except}) async {
     try {
-      await promiseToFuture(cleanIndexedDB());
+      await promiseToFuture(cleanIndexedDB(except));
     } catch (e) {
       consoleError(e);
     }

--- a/web/index.html
+++ b/web/index.html
@@ -299,10 +299,12 @@
   </script>
   <!-- Clean the whole IndexedDB. -->
   <script>
-    async function cleanIndexedDB() {
+    async function cleanIndexedDB(except) {
       var databases = await window.indexedDB.databases();
       for (var d of databases) {
-        window.indexedDB.deleteDatabase(d.name);
+        if (except == null || d.name != except) {
+          window.indexedDB.deleteDatabase(d.name);
+        }
       }
     }
   </script>


### PR DESCRIPTION
## Synopsis

`Config.schema` cleans all the cache, which may be inappropriate, as it forces user to logout.




## Solution

Introduce separate `Config.session` version for cleaning `CredentialsHiveProvider`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
