### PR TITLE
Account local `ChatId`s in `ChatRepository.favoriteChat`

### DIFF
--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -1263,6 +1263,10 @@ class ChatRepository extends DisposableInterface
   Future<void> unfavoriteChat(ChatId id) async {
     Log.debug('unfavoriteChat($id)', '$runtimeType');
 
+    if (id.isLocal) {
+      return;
+    }
+
     final HiveRxChat? chat = chats[id];
     final ChatFavoritePosition? oldPosition = chat?.chat.value.favoritePosition;
 

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -1239,10 +1239,15 @@ class ChatRepository extends DisposableInterface
         id = monolog.chat.value.id;
         await _monologLocal.set(id);
       } else if (id.isLocal) {
-        await ensureRemoteDialog(id);
+        final HiveRxChat? chat = await ensureRemoteDialog(id);
+        if (chat != null) {
+          id = chat.id;
+        }
       }
 
-      await _graphQlProvider.favoriteChat(id, newPosition);
+      if (!id.isLocal) {
+        await _graphQlProvider.favoriteChat(id, newPosition);
+      }
     } catch (e) {
       if (chat?.chat.value.isMonolog == true) {
         _localMonologFavoritePosition = null;

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -1238,6 +1238,8 @@ class ChatRepository extends DisposableInterface
 
         id = monolog.chat.value.id;
         await _monologLocal.set(id);
+      } else if (id.isLocal) {
+        await ensureRemoteDialog(id);
       }
 
       await _graphQlProvider.favoriteChat(id, newPosition);


### PR DESCRIPTION
Resolves #836
## Synopsis
Добалвение локального чата в избранное приводит к ошибке
## Solution
Вызывать `ensureRemoteDialog`, если `ChatId.isLocal`
## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
