### PR TITLE
`SearchUserTile` unselects when dialog starts (#867)

### DIFF
--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -149,7 +149,8 @@ class User extends HiveObject {
   set dialog(ChatId dialog) => _dialog = dialog;
 
   /// Returns text representing the title of this [User].
-  String get title => contacts.firstOrNull?.name.val ?? name?.val ?? num.val;
+  String get title =>
+      contacts.firstOrNull?.name.val ?? name?.val ?? num.toString();
 
   @override
   String toString() => '$runtimeType($id)';

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -264,6 +264,11 @@ class RouterState extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Replaces the provided [from] with the specified [to] in the [routes].
+  void replace(String from, String to) {
+    routes.value = routes.map((e) => e.replaceAll(from, to)).toList();
+  }
+
   /// Returns guarded route based on [_auth] status.
   ///
   /// - [Routes.home] is allowed always.

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -745,6 +745,7 @@ class ChatController extends GetxController {
       _chatWorker = ever(chat!.chat, (Chat e) {
         if (e.id != id) {
           WebUtils.replaceState(id.val, e.id.val);
+          router.replace(id.val, e.id.val);
           id = e.id;
         }
       });

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -745,7 +745,6 @@ class ChatController extends GetxController {
       _chatWorker = ever(chat!.chat, (Chat e) {
         if (e.id != id) {
           WebUtils.replaceState(id.val, e.id.val);
-          router.replace(id.val, e.id.val);
           id = e.id;
         }
       });

--- a/lib/ui/widget/member_tile.dart
+++ b/lib/ui/widget/member_tile.dart
@@ -96,12 +96,12 @@ class MemberTile extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(width: 16),
+          if (!me) const SizedBox(width: 4),
         ],
         AnimatedButton(
           enabled: !me,
           decorator: (child) => Padding(
-            padding: const EdgeInsets.all(12),
+            padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
             child: child,
           ),
           onPressed: me

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -33,6 +33,7 @@ import 'package:win32/win32.dart';
 import '/config.dart';
 import '/domain/model/chat.dart';
 import '/domain/model/session.dart';
+import '/routes.dart';
 import '/util/ios_utils.dart';
 import '/util/platform_utils.dart';
 import 'web_utils.dart';
@@ -231,7 +232,7 @@ class WebUtils {
 
   /// Replaces the provided [from] with the specified [to] in the current URL.
   static void replaceState(String from, String to) {
-    // No-op.
+    router.replace(from, to);
   }
 
   /// Sets the favicon being used to an alert style.

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -542,9 +542,9 @@ class WebUtils {
     ChatId newChatId, {
     WebStoredCall? newState,
   }) {
-    newState ??= WebUtils.getCall(chatId);
-    WebUtils.removeCall(chatId);
-    WebUtils.setCall(newState!);
+    newState ??= getCall(chatId);
+    removeCall(chatId);
+    setCall(newState!);
     replaceState(chatId.val, newChatId.val);
   }
 
@@ -666,6 +666,7 @@ class WebUtils {
 
   /// Replaces the provided [from] with the specified [to] in the current URL.
   static void replaceState(String from, String to) {
+    router.replace(from, to);
     html.window.history.replaceState(
       null,
       html.document.title,


### PR DESCRIPTION
Resolves #867




## Synopsis

Если начать диалог с пользователем из поиска, этот пользователь перестанет быть выделенным.




## Solution

Проблема будет исправлена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
