### PR TITLE
Fix `RetryImage` displays `CustomProgressIndicator` incorrectly (#835)

### DIFF
--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -717,8 +717,8 @@ label_files_saved_to_gallery = Файлы добавлены в галерею
 label_forward_message = Переслать сообщение
 label_forwarded_message = Пересланное сообщение
 label_forwarded_messages = {$count ->
-    [1] Forwarded message
-   *[other] Forwarded messages
+    [1] Пересланное сообщение
+   *[other] Пересланные сообщения
 }
 label_gb_occupied = Занято {$count} ГБ
 label_gb_of_gb_occupied = Занято {$a} из {$b} ГБ

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -424,7 +424,9 @@ class ChatController extends GetxController {
             await ChatForwardView.show(
               router.context!,
               id,
-              send.replied.map((e) => ChatItemQuoteInput(item: e)).toList(),
+              send.replied
+                  .map((e) => ChatItemQuoteInput(item: e.value))
+                  .toList(),
               text: send.field.text,
               attachments: send.attachments.map((e) => e.value).toList(),
               onSent: send.clear,
@@ -440,7 +442,7 @@ class ChatController extends GetxController {
                   text: send.field.text.trim().isEmpty
                       ? null
                       : ChatMessageText(send.field.text.trim()),
-                  repliesTo: send.replied.toList(),
+                  repliesTo: send.replied.map((e) => e.value).toList(),
                   attachments: send.attachments.map((e) => e.value).toList(),
                 )
                 .then(
@@ -640,7 +642,7 @@ class ChatController extends GetxController {
                   edit.value!.attachments.map((e) => e.value).toList(),
                 ),
                 repliesTo: ChatMessageRepliesInput(
-                  edit.value!.replied.map((e) => e.id).toList(),
+                  edit.value!.replied.map((e) => e.value.id).toList(),
                 ),
               );
 
@@ -700,7 +702,7 @@ class ChatController extends GetxController {
     chat?.setDraft(
       text: send.field.text.isEmpty ? null : ChatMessageText(send.field.text),
       attachments: persisted.map((e) => e.value).toList(),
-      repliesTo: List.from(send.replied, growable: false),
+      repliesTo: List.from(send.replied.map((e) => e.value), growable: false),
     );
   }
 
@@ -729,7 +731,11 @@ class ChatController extends GetxController {
       send.inCall = chat!.inCall;
       send.field.unsubmit();
       send.replied.value = List.from(
-        draft?.repliesTo.map((e) => e.original).whereNotNull() ?? <ChatItem>[],
+        draft?.repliesTo
+                .map((e) => e.original)
+                .whereNotNull()
+                .map((e) => Rx(e)) ??
+            <Rx<ChatItem>>[],
       );
 
       for (Attachment e in draft?.attachments ?? []) {

--- a/lib/ui/page/home/page/chat/message_field/controller.dart
+++ b/lib/ui/page/home/page/chat/message_field/controller.dart
@@ -140,8 +140,11 @@ class MessageFieldController extends GetxController {
         field.text = item.text?.val ?? '';
         this.attachments.value =
             item.attachments.map((e) => MapEntry(GlobalKey(), e)).toList();
-        replied.value =
-            item.repliesTo.map((e) => e.original).whereNotNull().toList();
+        replied.value = item.repliesTo
+            .map((e) => e.original)
+            .whereNotNull()
+            .map((e) => Rx(e))
+            .toList();
       } else {
         field.text = '';
         this.attachments.clear();
@@ -169,7 +172,7 @@ class MessageFieldController extends GetxController {
   late final RxList<MapEntry<GlobalKey, Attachment>> attachments;
 
   /// [ChatItem] being quoted to reply onto.
-  final RxList<ChatItem> replied = RxList<ChatItem>();
+  final RxList<Rx<ChatItem>> replied = RxList<Rx<ChatItem>>();
 
   /// [ChatItemQuoteInput]s to be forwarded.
   late final RxList<ChatItemQuoteInput> quotes;

--- a/lib/ui/page/home/page/chat/message_field/view.dart
+++ b/lib/ui/page/home/page/chat/message_field/view.dart
@@ -90,7 +90,7 @@ class MessageFieldView extends StatelessWidget {
   /// Callback, called on the [ReactiveTextField] changes.
   final void Function()? onChanged;
 
-  /// Callback, called on an [Attachment] fetching errors.
+  /// Callback, called on the [Attachment] fetching errors.
   final Future<void> Function(ChatItem)? onAttachmentError;
 
   /// [BoxConstraints] replies, attachments and quotes are allowed to occupy.

--- a/lib/ui/page/home/page/chat/message_field/view.dart
+++ b/lib/ui/page/home/page/chat/message_field/view.dart
@@ -60,6 +60,7 @@ class MessageFieldView extends StatelessWidget {
     this.controller,
     this.onChanged,
     this.onItemPressed,
+    this.onAttachmentError,
     this.fieldKey,
     this.sendKey,
     this.canForward = false,
@@ -88,6 +89,9 @@ class MessageFieldView extends StatelessWidget {
 
   /// Callback, called on the [ReactiveTextField] changes.
   final void Function()? onChanged;
+
+  /// Callback, called on an [Attachment] fetching errors.
+  final Future<void> Function(ChatItem)? onAttachmentError;
 
   /// [BoxConstraints] replies, attachments and quotes are allowed to occupy.
   final BoxConstraints? constraints;
@@ -304,27 +308,31 @@ class MessageFieldView extends StatelessWidget {
             },
             padding: const EdgeInsets.symmetric(horizontal: 1),
             children: c.replied.map((e) {
-              return ReorderableDragStartListener(
-                key: Key('Handle_${e.id}'),
-                enabled: !PlatformUtils.isMobile,
-                index: c.replied.indexOf(e),
-                child: Dismissible(
-                  key: Key('${e.id}'),
-                  direction: DismissDirection.horizontal,
-                  onDismissed: (_) => c.replied.remove(e),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 2),
-                    child: WidgetButton(
-                      onPressed: () => onItemPressed?.call(e),
-                      child: _buildPreview(
-                        context,
-                        e,
-                        c,
-                        onClose: () => c.replied.remove(e),
+              return Obx(
+                key: Key('Handle_${e.value.id}'),
+                () {
+                  return ReorderableDragStartListener(
+                    enabled: !PlatformUtils.isMobile,
+                    index: c.replied.indexOf(e),
+                    child: Dismissible(
+                      key: Key('${e.value.id}'),
+                      direction: DismissDirection.horizontal,
+                      onDismissed: (_) => c.replied.remove(e),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 2),
+                        child: WidgetButton(
+                          onPressed: () => onItemPressed?.call(e.value),
+                          child: _buildPreview(
+                            context,
+                            e.value,
+                            c,
+                            onClose: () => c.replied.remove(e),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
-                ),
+                  );
+                },
               );
             }).toList(),
           );
@@ -844,9 +852,11 @@ class MessageFieldView extends StatelessWidget {
                       checksum: image.small.checksum,
                       thumbhash: image.small.thumbhash,
                       fit: BoxFit.cover,
-                      height: double.infinity,
-                      width: double.infinity,
+                      height: 30,
+                      width: 30,
                       borderRadius: BorderRadius.circular(4),
+                      onForbidden: () async =>
+                          await onAttachmentError?.call(item),
                     ),
             );
           }).toList(),

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -851,10 +851,11 @@ class ChatView extends StatelessWidget {
                   onReply: () {
                     final field = c.edit.value ?? c.send;
 
-                    if (field.replied.any((i) => i.id == e.value.id)) {
-                      field.replied.removeWhere((i) => i.id == e.value.id);
+                    if (field.replied.any((i) => i.value.id == e.value.id)) {
+                      field.replied
+                          .removeWhere((i) => i.value.id == e.value.id);
                     } else {
-                      field.replied.add(e.value);
+                      field.replied.add(e);
                     }
                   },
                   onCopy: (text) {
@@ -954,26 +955,30 @@ class ChatView extends StatelessWidget {
                   onReply: () {
                     final MessageFieldController field = c.edit.value ?? c.send;
 
-                    if (element.forwards.any((e) =>
-                            field.replied.any((i) => i.id == e.value.id)) ||
-                        field.replied
-                            .any((i) => i.id == element.note.value?.value.id)) {
+                    if (element.forwards.any(
+                          (e) => field.replied
+                              .any((i) => i.value.id == e.value.id),
+                        ) ||
+                        field.replied.any(
+                          (i) => i.value.id == element.note.value?.value.id,
+                        )) {
                       for (Rx<ChatItem> e in element.forwards) {
-                        field.replied.removeWhere((i) => i.id == e.value.id);
+                        field.replied
+                            .removeWhere((i) => i.value.id == e.value.id);
                       }
 
                       if (element.note.value != null) {
                         field.replied.removeWhere(
-                          (i) => i.id == element.note.value!.value.id,
+                          (i) => i.value.id == element.note.value!.value.id,
                         );
                       }
                     } else {
                       if (element.note.value != null) {
-                        field.replied.add(element.note.value!.value);
+                        field.replied.add(element.note.value!);
                       }
 
                       for (Rx<ChatItem> e in element.forwards) {
-                        field.replied.add(e.value);
+                        field.replied.add(e);
                       }
                     }
                   },
@@ -1392,6 +1397,7 @@ class ChatView extends StatelessWidget {
           onChanged:
               c.chat?.chat.value.isMonolog == true ? null : c.updateTyping,
           onItemPressed: (item) => c.animateTo(item, addToHistory: false),
+          onAttachmentError: c.chat?.updateAttachments,
         );
       }
 
@@ -1401,6 +1407,7 @@ class ChatView extends StatelessWidget {
         onChanged: c.chat?.chat.value.isMonolog == true ? null : c.updateTyping,
         onItemPressed: (item) => c.animateTo(item, addToHistory: false),
         canForward: true,
+        onAttachmentError: c.chat?.updateAttachments,
       );
     });
   }

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -218,6 +218,7 @@ class ChatItemWidget extends StatefulWidget {
         key: key,
         attachment: e,
         width: filled ? double.infinity : null,
+        height: filled ? double.infinity : null,
         onError: onError,
       );
 

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -110,13 +110,11 @@ class _MediaAttachmentState extends State<MediaAttachment> {
               final Size? dimensions = attachment.file.dimensions.value;
               final double ratio =
                   (dimensions?.width ?? 300) / (dimensions?.height ?? 300);
+              final bool narrow = ratio > 3 || ratio < 0.33;
 
               return Image.memory(
                 attachment.file.bytes.value!,
-                fit: widget.fit ??
-                    ((ratio > 3 || ratio < 0.33)
-                        ? BoxFit.contain
-                        : BoxFit.cover),
+                fit: widget.fit ?? (narrow ? BoxFit.contain : BoxFit.cover),
                 width: widget.width,
                 height: widget.height ??
                     max(100, min(dimensions?.height ?? 300, 300)),
@@ -127,11 +125,11 @@ class _MediaAttachmentState extends State<MediaAttachment> {
       } else {
         final ImageFile file = attachment.original as ImageFile;
         final double ratio = (file.width ?? 300) / (file.height ?? 300);
+        final bool narrow = ratio > 3 || ratio < 0.33;
 
         child = RetryImage.attachment(
           attachment as ImageAttachment,
-          fit: widget.fit ??
-              ((ratio > 3 || ratio < 0.33) ? BoxFit.contain : BoxFit.cover),
+          fit: widget.fit ?? (narrow ? BoxFit.contain : BoxFit.cover),
           width: widget.width,
           minWidth: 75,
           height: widget.height ??

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -113,7 +113,10 @@ class _MediaAttachmentState extends State<MediaAttachment> {
 
               return Image.memory(
                 attachment.file.bytes.value!,
-                fit: widget.fit ?? (ratio > 3 ? BoxFit.contain : BoxFit.cover),
+                fit: widget.fit ??
+                    ((ratio > 3 || ratio < 0.33)
+                        ? BoxFit.contain
+                        : BoxFit.cover),
                 width: widget.width,
                 height: widget.height ??
                     max(100, min(dimensions?.height ?? 300, 300)),
@@ -127,7 +130,8 @@ class _MediaAttachmentState extends State<MediaAttachment> {
 
         child = RetryImage.attachment(
           attachment as ImageAttachment,
-          fit: widget.fit ?? (ratio > 3 ? BoxFit.contain : BoxFit.cover),
+          fit: widget.fit ??
+              ((ratio > 3 || ratio < 0.33) ? BoxFit.contain : BoxFit.cover),
           width: widget.width,
           minWidth: 75,
           height: widget.height ??

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -792,9 +792,9 @@ class RecentChatTile extends StatelessWidget {
 
     if (e is ImageAttachment) {
       content = RetryImage(
-        e.medium.url,
-        checksum: e.medium.checksum,
-        thumbhash: e.medium.thumbhash,
+        e.small.url,
+        checksum: e.small.checksum,
+        thumbhash: e.small.thumbhash,
         fit: BoxFit.cover,
         width: double.infinity,
         height: double.infinity,

--- a/lib/ui/page/home/widget/gallery_popup.dart
+++ b/lib/ui/page/home/widget/gallery_popup.dart
@@ -59,7 +59,6 @@ class GalleryItem {
     required this.size,
     this.width,
     this.height,
-    this.aspectRatio,
     this.checksum,
     this.thumbhash,
     this.isVideo = false,
@@ -76,26 +75,17 @@ class GalleryItem {
     String? checksum,
     ThumbHash? thumbhash,
     FutureOr<void> Function()? onError,
-  }) {
-    double? aspectRatio;
-
-    if (width != null && height != null) {
-      aspectRatio = width / height;
-    }
-
-    return GalleryItem(
+  }) => GalleryItem(
       link: link,
       name: name,
       size: size,
       width: width,
       height: height,
-      aspectRatio: aspectRatio,
       checksum: checksum,
       thumbhash: thumbhash,
       isVideo: false,
       onError: onError,
     );
-  }
 
   /// Constructs a [GalleryItem] treated as a video.
   factory GalleryItem.video(
@@ -138,11 +128,17 @@ class GalleryItem {
   /// Height of the image this [GalleryItem] represents.
   final int? height;
 
-  /// Aspect ratio of the image this [GalleryItem] represents.
-  final double? aspectRatio;
-
   /// Callback, called on the fetch errors of this [GalleryItem].
   final FutureOr<void> Function()? onError;
+
+  /// Returns aspect ratio of the image this [GalleryItem] represents.
+  double?  get _aspectRatio {
+    if (width != null && height != null) {
+      return width! / height!;
+    }
+
+    return null;
+  }
 }
 
 /// Animated gallery of [GalleryItem]s.
@@ -558,7 +554,7 @@ class _GalleryPopupState extends State<GalleryPopup>
                         e.link,
                         width: e.width?.toDouble(),
                         height: e.height?.toDouble(),
-                        aspectRatio: e.aspectRatio,
+                        aspectRatio: e._aspectRatio,
                         checksum: e.checksum,
                         thumbhash: e.thumbhash,
                         onForbidden: e.onError,
@@ -681,7 +677,7 @@ class _GalleryPopupState extends State<GalleryPopup>
                               height: _isFullscreen.isTrue
                                   ? double.infinity
                                   : e.height?.toDouble(),
-                              aspectRatio: e.aspectRatio,
+                              aspectRatio: e._aspectRatio,
                               checksum: e.checksum,
                               thumbhash: e.thumbhash,
                               onForbidden: e.onError,

--- a/lib/ui/page/home/widget/gallery_popup.dart
+++ b/lib/ui/page/home/widget/gallery_popup.dart
@@ -75,17 +75,18 @@ class GalleryItem {
     String? checksum,
     ThumbHash? thumbhash,
     FutureOr<void> Function()? onError,
-  }) => GalleryItem(
-      link: link,
-      name: name,
-      size: size,
-      width: width,
-      height: height,
-      checksum: checksum,
-      thumbhash: thumbhash,
-      isVideo: false,
-      onError: onError,
-    );
+  }) =>
+      GalleryItem(
+        link: link,
+        name: name,
+        size: size,
+        width: width,
+        height: height,
+        checksum: checksum,
+        thumbhash: thumbhash,
+        isVideo: false,
+        onError: onError,
+      );
 
   /// Constructs a [GalleryItem] treated as a video.
   factory GalleryItem.video(
@@ -132,7 +133,7 @@ class GalleryItem {
   final FutureOr<void> Function()? onError;
 
   /// Returns aspect ratio of the image this [GalleryItem] represents.
-  double?  get _aspectRatio {
+  double? get _aspectRatio {
     if (width != null && height != null) {
       return width! / height!;
     }

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -16,7 +16,6 @@
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
 import 'dart:async';
-import 'dart:math';
 import 'dart:ui';
 
 import 'package:dio/dio.dart';

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -344,8 +344,10 @@ class _RetryImageState extends State<RetryImage> {
               maxWidth: width ?? double.infinity,
               maxHeight: widget.height ?? double.infinity,
             ),
-            child:
-                AspectRatio(aspectRatio: widget.aspectRatio!, child: thumbhash),
+            child: AspectRatio(
+              aspectRatio: widget.aspectRatio!,
+              child: thumbhash,
+            ),
           );
         }
 

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -255,18 +255,6 @@ class _RetryImageState extends State<RetryImage> {
 
       child = image;
     } else {
-      double loader = CustomProgressIndicator.primarySize;
-
-      if ((widget.width != null && widget.width!.isFinite) ||
-          (widget.height != null && widget.height!.isFinite)) {
-        double size = min(
-          widget.width ?? double.infinity,
-          widget.height ?? double.infinity,
-        );
-
-        loader = min(loader, size * 0.6);
-      }
-
       child = WidgetButton(
         onPressed: widget.cancelable
             ? () {
@@ -284,16 +272,17 @@ class _RetryImageState extends State<RetryImage> {
             : null,
         child: Container(
           key: const Key('Loading'),
-          height: widget.height,
           constraints: const BoxConstraints(minWidth: 200),
           alignment: Alignment.center,
           child: Stack(
             alignment: Alignment.center,
             children: [
               if (!_canceled && widget.displayProgress)
-                CustomProgressIndicator.primary(
-                  value: _progress == 0 ? null : _progress.clamp(0, 1),
-                  size: loader,
+                Padding(
+                  padding: const EdgeInsets.all(6),
+                  child: CustomProgressIndicator.primary(
+                    value: _progress == 0 ? null : _progress.clamp(0, 1),
+                  ),
                 ),
               if (widget.cancelable)
                 Center(
@@ -324,7 +313,6 @@ class _RetryImageState extends State<RetryImage> {
         double? width = widget.width;
 
         if (widget.height != null &&
-            width == null &&
             widget.aspectRatio != null &&
             widget.fit != BoxFit.contain) {
           width ??= widget.height! * widget.aspectRatio!;
@@ -348,6 +336,13 @@ class _RetryImageState extends State<RetryImage> {
               aspectRatio: widget.aspectRatio!,
               child: thumbhash,
             ),
+          );
+        }
+
+        if (widget.borderRadius != null) {
+          thumbhash = ClipRRect(
+            borderRadius: widget.borderRadius!,
+            child: thumbhash,
           );
         }
 

--- a/lib/ui/widget/progress_indicator.dart
+++ b/lib/ui/widget/progress_indicator.dart
@@ -27,7 +27,7 @@ import '/ui/page/call/widget/conditional_backdrop.dart';
 /// busy.
 class CustomProgressIndicator extends StatelessWidget {
   const CustomProgressIndicator({super.key, this.value})
-      : size = defaultSize,
+      : size = 32,
         padding = const EdgeInsets.all(6),
         blur = true,
         backgroundColor = null,
@@ -36,11 +36,9 @@ class CustomProgressIndicator extends StatelessWidget {
         strokeWidth = 2.0;
 
   /// Constructs a [CustomProgressIndicator] with a `primary` style.
-  const CustomProgressIndicator.primary({
-    super.key,
-    this.value,
-    this.size = primarySize,
-  })  : padding = const EdgeInsets.all(4),
+  const CustomProgressIndicator.primary({super.key, this.value})
+      : size = 40,
+        padding = const EdgeInsets.all(4),
         blur = false,
         backgroundColor = null,
         valueColor = null,
@@ -49,22 +47,13 @@ class CustomProgressIndicator extends StatelessWidget {
 
   /// Constructs a [CustomProgressIndicator] with a `big` style.
   const CustomProgressIndicator.big({super.key, this.value})
-      : size = bigSize,
+      : size = 64,
         padding = const EdgeInsets.all(6),
         blur = true,
         backgroundColor = null,
         valueColor = null,
         primary = false,
         strokeWidth = 2.0;
-
-  /// Default size of this [CustomProgressIndicator].
-  static const double defaultSize = 32;
-
-  /// Primary size of this [CustomProgressIndicator].
-  static const double primarySize = 40;
-
-  /// Big size of this [CustomProgressIndicator].
-  static const double bigSize = 64;
 
   /// Value of this [CustomProgressIndicator].
   final double? value;

--- a/lib/ui/widget/progress_indicator.dart
+++ b/lib/ui/widget/progress_indicator.dart
@@ -27,7 +27,7 @@ import '/ui/page/call/widget/conditional_backdrop.dart';
 /// busy.
 class CustomProgressIndicator extends StatelessWidget {
   const CustomProgressIndicator({super.key, this.value})
-      : size = 32,
+      : size = defaultSize,
         padding = const EdgeInsets.all(6),
         blur = true,
         backgroundColor = null,
@@ -36,9 +36,11 @@ class CustomProgressIndicator extends StatelessWidget {
         strokeWidth = 2.0;
 
   /// Constructs a [CustomProgressIndicator] with a `primary` style.
-  const CustomProgressIndicator.primary({super.key, this.value})
-      : size = 40,
-        padding = const EdgeInsets.all(4),
+  const CustomProgressIndicator.primary({
+    super.key,
+    this.value,
+    this.size = primarySize,
+  })  : padding = const EdgeInsets.all(4),
         blur = false,
         backgroundColor = null,
         valueColor = null,
@@ -47,13 +49,22 @@ class CustomProgressIndicator extends StatelessWidget {
 
   /// Constructs a [CustomProgressIndicator] with a `big` style.
   const CustomProgressIndicator.big({super.key, this.value})
-      : size = 64,
+      : size = bigSize,
         padding = const EdgeInsets.all(6),
         blur = true,
         backgroundColor = null,
         valueColor = null,
         primary = false,
         strokeWidth = 2.0;
+
+  /// Default size of this [CustomProgressIndicator].
+  static const double defaultSize = 32;
+
+  /// Primary size of this [CustomProgressIndicator].
+  static const double primarySize = 40;
+
+  /// Big size of this [CustomProgressIndicator].
+  static const double bigSize = 64;
 
   /// Value of this [CustomProgressIndicator].
   final double? value;


### PR DESCRIPTION
Resolves #835




## Synopsis

`RetryImage` может неправильно рисовать `CustomProgressIndicator`.




## Solution

Проблема будет исправлена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
