### PR TITLE
Implement `UpgradeWorker` notifying users about upgrades available (#896)

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -95,6 +95,18 @@ class Config {
   /// mismatch is detected.
   static String? credentials;
 
+  /// URL to fetch releases and its notes from.
+  ///
+  /// Intended to be used in [UpgradeWorker] to notify users about new releases
+  /// available.
+  ///
+  /// Response must be a valid JSON format representing the GitHub REST API
+  /// response for releases:
+  /// https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
+  ///
+  /// If `null` is specified, then no releases should be fetched at all.
+  static String? releasesUrl = 'https://api.github.com/repos/team113/messenger/releases?perPage=5';
+
   /// Returns a [Map] being a configuration passed to a [FlutterCallkeep]
   /// instance to initialize it.
   static Map<String, dynamic> get callKeep {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,6 +59,7 @@ import 'store/auth.dart';
 import 'store/model/window_preferences.dart';
 import 'themes.dart';
 import 'ui/worker/cache.dart';
+import 'ui/worker/upgrade.dart';
 import 'ui/worker/window.dart';
 import 'util/backoff.dart';
 import 'util/log.dart';
@@ -115,6 +116,7 @@ Future<void> main() async {
     await L10n.init();
 
     Get.put(CacheWorker(Get.findOrNull(), Get.findOrNull()));
+    Get.put(UpgradeWorker());
 
     WebUtils.deleteLoader();
 

--- a/lib/ui/worker/upgrade.dart
+++ b/lib/ui/worker/upgrade.dart
@@ -1,0 +1,187 @@
+import 'package:collection/collection.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+import '/config.dart';
+import '/domain/service/disposable_service.dart';
+import '/l10n/l10n.dart';
+import '/pubspec.g.dart';
+import '/routes.dart';
+import '/themes.dart';
+import '/ui/page/login/widget/primary_button.dart';
+import '/ui/widget/outlined_rounded_button.dart';
+import '/util/log.dart';
+import '/util/message_popup.dart';
+import '/util/platform_utils.dart';
+
+class UpgradeWorker extends DisposableService {
+  final List<Release> _releases = [];
+
+  @override
+  void onReady() {
+    _fetchUpdates();
+    super.onReady();
+  }
+
+  Future<void> _fetchUpdates() async {
+    if (Config.releasesUrl == null) {
+      return;
+    }
+
+    try {
+      final Response response =
+          await (await PlatformUtils.dio).get(Config.releasesUrl!);
+
+      _releases.addAll(
+        (response.data as List).map((e) => Release.fromJson(e)).toList(),
+      );
+
+      final Release? best =
+          _releases.firstWhereOrNull((e) => e.name != Pubspec.version);
+
+      if (best != null) {
+        _schedulePopup(best);
+      }
+    } catch (e) {
+      Log.info('Failed to fetch releases: $e', '$runtimeType');
+    }
+  }
+
+  void _schedulePopup(Release release) {
+    Future.delayed(const Duration(seconds: 1), () {
+      SchedulerBinding.instance.addPostFrameCallback((_) async {
+        final style = Theme.of(router.context!).style;
+
+        await MessagePopup.alert(
+          'Доступно обновление',
+          additional: [
+            Text(release.name, style: style.fonts.medium.regular.onBackground),
+            const SizedBox(height: 8),
+            MarkdownBody(
+              data: release.body,
+              onTapLink: (_, href, __) async => await launchUrlString(href!),
+              styleSheet: MarkdownStyleSheet(
+                h2Padding: const EdgeInsets.fromLTRB(0, 24, 0, 4),
+
+                // TODO: Exception.
+                h2: style.fonts.largest.bold.onBackground
+                    .copyWith(fontSize: 20),
+
+                p: style.fonts.normal.regular.onBackground,
+                code: style.fonts.small.regular.onBackground.copyWith(
+                  letterSpacing: 1.2,
+                  backgroundColor: style.colors.secondaryHighlight,
+                ),
+                codeblockDecoration: BoxDecoration(
+                  color: style.colors.secondaryHighlight,
+                ),
+                codeblockPadding: const EdgeInsets.all(16),
+                blockquoteDecoration: BoxDecoration(
+                  color: style.colors.secondaryHighlight,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              release.publishedAt.toRelative(),
+              style: style.fonts.small.regular.secondary,
+            ),
+          ],
+          button: (context) {
+            return Row(
+              children: [
+                Expanded(
+                  child: OutlinedRoundedButton(
+                    key: const Key('Skip'),
+                    maxWidth: double.infinity,
+                    onPressed: () => Navigator.of(context).pop(false),
+                    color: style.colors.onBackgroundOpacity7,
+                    child: Text(
+                      'Пропустить'.l10n,
+                      style: style.fonts.medium.regular.onBackground,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: PrimaryButton(
+                    key: const Key('Download'),
+                    onPressed: () => Navigator.of(context).pop(true),
+                    title: 'btn_download'.l10n,
+                  ),
+                ),
+              ],
+            );
+          },
+        );
+      });
+    });
+  }
+}
+
+class Release {
+  const Release({
+    required this.url,
+    required this.name,
+    required this.body,
+    required this.publishedAt,
+    required this.assets,
+  });
+
+  factory Release.fromJson(Map<String, dynamic> json) {
+    return Release(
+      url: json['url'],
+      name: json['name'],
+      body: json['body'],
+      publishedAt: DateTime.parse(json['published_at']),
+      assets: (json['assets'] as List)
+          .map((e) => ReleaseAsset.fromJson(e))
+          .toList(),
+    );
+  }
+
+  final String url;
+  final String name;
+  final String body;
+  final DateTime publishedAt;
+  final List<ReleaseAsset> assets;
+
+  @override
+  String toString() {
+    return 'Release(url: $url, name: $name, body: $body, publishedAt: $publishedAt, assets: $assets)';
+  }
+}
+
+class ReleaseAsset {
+  const ReleaseAsset({
+    required this.url,
+    required this.name,
+    required this.contentType,
+    required this.downloadCount,
+    required this.size,
+  });
+
+  factory ReleaseAsset.fromJson(Map<String, dynamic> json) {
+    return ReleaseAsset(
+      url: json['url'],
+      name: json['name'],
+      contentType: json['content_type'],
+      downloadCount: json['download_count'],
+      size: json['size'],
+    );
+  }
+
+  final String url;
+  final String name;
+  final String contentType;
+  final int downloadCount;
+  final int size;
+
+  @override
+  String toString() {
+    return 'ReleaseAsset(url: $url, name: $name, contentType: $contentType, downloadCount: $downloadCount, size: $size)';
+  }
+}

--- a/lib/util/message_popup.dart
+++ b/lib/util/message_popup.dart
@@ -52,6 +52,7 @@ class MessagePopup {
     String title, {
     List<TextSpan> description = const [],
     List<Widget> additional = const [],
+    Widget Function(BuildContext) button = _defaultButton,
   }) {
     final style = Theme.of(router.context!).style;
 
@@ -93,16 +94,7 @@ class MessagePopup {
               const SizedBox(height: 25),
               Padding(
                 padding: ModalPopup.padding(context),
-                child: OutlinedRoundedButton(
-                  key: const Key('Proceed'),
-                  maxWidth: double.infinity,
-                  onPressed: () => Navigator.of(context).pop(true),
-                  color: style.colors.primary,
-                  child: Text(
-                    'btn_proceed'.l10n,
-                    style: style.fonts.normal.regular.onPrimary,
-                  ),
-                ),
+                child: button(context),
               ),
               const SizedBox(height: 16),
             ],
@@ -115,4 +107,19 @@ class MessagePopup {
   /// Shows a [FloatingSnackBar] with the [title] message.
   static void success(String title, {double bottom = 16}) =>
       FloatingSnackBar.show(title, bottom: bottom);
+
+  static Widget _defaultButton(BuildContext context) {
+    final style = Theme.of(context).style;
+
+    return OutlinedRoundedButton(
+      key: const Key('Proceed'),
+      maxWidth: double.infinity,
+      onPressed: () => Navigator.of(context).pop(true),
+      color: style.colors.primary,
+      child: Text(
+        'btn_proceed'.l10n,
+        style: style.fonts.normal.regular.onPrimary,
+      ),
+    );
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.1.0-alpha.12.3
+version: 0.1.0-alpha.12.1
 publish_to: none
 
 environment:


### PR DESCRIPTION
Resolves #896




## Synopsis

> Узнать о наличии новой версии сейчас невозможно. Да и сам факт, что нужно руками всё перекачивать, удручает.




## Solution

This PR implements the `UpgradeWorker` using GitHub REST API endpoint for releases to fetch information about upgrades available.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
