### PR TITLE
Fix `UserNum` formatting in notifications (#909)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All user visible changes to this project will be documented in this file. This p
     - Chat page:
         - Images displayed with vertical gaps on narrow screens. ([#901], [#888])
         - Messages marked as read when gallery is opened. ([#897], [#854])
+    - Gapopa ID displaying incorrectly in notifications. ([#910], [#909])
 - Web:
     - Missing blurred image previews in gallery. ([#880])
 
@@ -58,6 +59,8 @@ All user visible changes to this project will be documented in this file. This p
 [#891]: /../../pull/891
 [#897]: /../../pull/897
 [#901]: /../../pull/901
+[#909]: /../../issues/909
+[#910]: /../../pull/910
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -296,7 +296,7 @@ err_contact_unknown_user = User with the provided ID doesn\'t exist
 err_could_not_download = An error occurred while downloading. Please, try again.
 err_data_transfer =
     Data transfer error. Please, check your network connection.
-err_dialog = Can't perfom this action in a dialog
+err_dialog = Can't perform this action in a dialog
 err_dimensions_too_big = File dimensions exceed 32767 x 32767 pixels.
 err_email_occupied = Specified E-mail is linked to another account. Please, annulate the previous verification.
 err_incorrect_chat_name = Incorrect name
@@ -314,7 +314,7 @@ err_unknown_registration_token = Unknown registration token
 err_login_occupied = This login is already taken.
 err_media_devices_are_null = Cannot retrieve `MediaStream` with `video` constraints due to `window.navigator.mediaDevices` being `null`. Seems like your browser\'s configuration doesn\'t allow media devices to be retrieved. Tune up the settings, or ensure the devices are available.
 err_message_was_read = Message was read
-err_monolog = Can't perfom this action in a monolog
+err_monolog = Can't perform this action in a monolog
 err_network = Connection to the server refused
 err_no_access_to_gallery = Access to the gallery denied. Please, make sure the application has permissions to access the gallery.
 err_no_filename = File should have a name

--- a/lib/ui/page/home/widget/avatar.dart
+++ b/lib/ui/page/home/widget/avatar.dart
@@ -154,7 +154,7 @@ class AvatarWidget extends StatelessWidget {
         isOnline: badge && myUser?.online == true,
         isAway: myUser?.presence == Presence.away,
         avatar: myUser?.avatar,
-        title: myUser?.name?.val ?? myUser?.num.val,
+        title: myUser?.name?.val ?? myUser?.num.toString(),
         color: myUser?.num.val.sum(),
         radius: radius,
         opacity: opacity,

--- a/lib/ui/widget/member_tile.dart
+++ b/lib/ui/widget/member_tile.dart
@@ -119,9 +119,7 @@ class MemberTile extends StatelessWidget {
                         description: [
                           TextSpan(text: 'alert_user_will_be_removed1'.l10n),
                           TextSpan(
-                            text: myUser?.name?.val ??
-                                myUser?.num.val ??
-                                user?.title,
+                            text: user?.title,
                             style: style.fonts.normal.regular.onBackground,
                           ),
                           TextSpan(text: 'alert_user_will_be_removed2'.l10n),

--- a/lib/ui/worker/chat.dart
+++ b/lib/ui/worker/chat.dart
@@ -321,7 +321,7 @@ class _ChatWatchData {
     List<Attachment> attachments = const [],
   }) {
     final String name = author?.title ?? 'x';
-    final String num = author?.num.val ?? 'err_unknown_user'.l10n;
+    final String num = author?.num.toString() ?? 'err_unknown_user'.l10n;
     final String type = isGroup ? 'group' : 'dialog';
     String attachmentsType = attachments.every((e) => e is ImageAttachment)
         ? 'image'
@@ -357,20 +357,20 @@ class _ChatWatchData {
           return 'fcm_user_joined_group_by_link'.l10nfmt(
             {
               'authorName': action.user.title,
-              'authorNum': action.user.num.val,
+              'authorNum': action.user.num.toString(),
             },
           );
         } else if (action.user.id == me?.call()) {
           return 'fcm_user_added_you_to_group'.l10nfmt({
             'authorName': author?.title ?? 'x',
-            'authorNum': author?.num.val ?? 'err_unknown_user'.l10n,
+            'authorNum': author?.num.toString() ?? 'err_unknown_user'.l10n,
           });
         } else {
           return 'fcm_user_added_user'.l10nfmt({
             'authorName': author?.title ?? 'x',
-            'authorNum': author?.num.val ?? 'err_unknown_user'.l10n,
+            'authorNum': author?.num.toString() ?? 'err_unknown_user'.l10n,
             'userName': action.user.title,
-            'userNum': action.user.num.val,
+            'userNum': action.user.num.toString(),
           });
         }
 
@@ -381,20 +381,20 @@ class _ChatWatchData {
           return 'fcm_user_left_group'.l10nfmt(
             {
               'authorName': action.user.title,
-              'authorNum': action.user.num.val,
+              'authorNum': action.user.num.toString(),
             },
           );
         } else if (action.user.id == me?.call()) {
           return 'fcm_user_removed_you'.l10nfmt({
             'authorName': author?.title ?? 'x',
-            'authorNum': author?.num.val ?? 'err_unknown_user'.l10n,
+            'authorNum': author?.num.toString() ?? 'err_unknown_user'.l10n,
           });
         } else {
           return 'fcm_user_removed_user'.l10nfmt({
             'authorName': author?.title ?? 'x',
-            'authorNum': author?.num.val ?? 'err_unknown_user'.l10n,
+            'authorNum': author?.num.toString() ?? 'err_unknown_user'.l10n,
             'userName': action.user.title,
-            'userNum': action.user.num.val,
+            'userNum': action.user.num.toString(),
           });
         }
 
@@ -403,7 +403,7 @@ class _ChatWatchData {
 
         return 'fcm_group_avatar_changed'.l10nfmt({
           'userName': author?.title ?? 'x',
-          'userNum': author?.num.val ?? 'err_unknown_user'.l10n,
+          'userNum': author?.num.toString() ?? 'err_unknown_user'.l10n,
           'operation': action.avatar == null ? 'delete' : 'update',
         });
 
@@ -412,7 +412,7 @@ class _ChatWatchData {
 
         return 'fcm_group_name_changed'.l10nfmt({
           'userName': author?.title ?? 'x',
-          'userNum': author?.num.val ?? 'err_unknown_user'.l10n,
+          'userNum': author?.num.toString() ?? 'err_unknown_user'.l10n,
           'operation': action.name == null ? 'delete' : 'update',
           'groupName': action.name?.val ?? '',
         });


### PR DESCRIPTION
Resolves #909
## Synopsis
В уведомлении неправильно форматируется `UserNum`
## Solution
`user.num.val` -> `user.num.toString()`
## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
