### PR TITLE
Fix background audio stops on `AudioUtilsImpl.once` (#912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Fixed
 
+- Android:
+    - Sent or received message sound stopping music. ([#915], [#912])
 - UI:
     - Chats tab:
         - Chat not disappearing after being kicked from it. ([#864], [#851])
@@ -61,6 +63,8 @@ All user visible changes to this project will be documented in this file. This p
 [#901]: /../../pull/901
 [#909]: /../../issues/909
 [#910]: /../../pull/910
+[#912]: /../../issues/912
+[#915]: /../../pull/915
 
 
 

--- a/lib/util/audio_utils.dart
+++ b/lib/util/audio_utils.dart
@@ -62,7 +62,9 @@ class AudioUtilsImpl {
   void ensureInitialized() {
     try {
       if (_isMobile) {
-        _jaPlayer ??= ja.AudioPlayer();
+        // Set [handleAudioSessionActivation] to `false` to avoid stopping
+        // background audio on [once].
+        _jaPlayer ??= ja.AudioPlayer(handleAudioSessionActivation: false);
       } else {
         _player ??= Player();
       }

--- a/lib/util/audio_utils.dart
+++ b/lib/util/audio_utils.dart
@@ -62,7 +62,7 @@ class AudioUtilsImpl {
   void ensureInitialized() {
     try {
       if (_isMobile) {
-        // Set [handleAudioSessionActivation] to `false` to avoid stopping
+        // Set `handleAudioSessionActivation` to `false` to avoid stopping
         // background audio on [once].
         _jaPlayer ??= ja.AudioPlayer(handleAudioSessionActivation: false);
       } else {


### PR DESCRIPTION
Resolves #912




## Synopsis

Проигрывание звука ставит на паузу аудио, играющее на фоне, не отжимая её по завершении.




## Solution

Проблема будет исправлена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
