### PR TITLE
Use `RtcVideoRenderer.canPlay` for `VideoView` being loaded indication

### DIFF
--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -2175,10 +2175,29 @@ class RtcVideoRenderer extends RtcRenderer {
       }
     }
 
+    // Listen for video to start having frames to be displayed.
+    _delegate.onCanPlay = () {
+      Log.debug(
+        '[${track.kind()} ${track.mediaSourceKind()}] canPlay',
+        '$runtimeType',
+      );
+
+      canPlay.value = true;
+    };
+
     // Listen for resizes to update [width] and [height].
     _delegate.onResize = () {
-      width.value = _delegate.videoWidth;
-      height.value = _delegate.videoHeight;
+      Log.debug(
+        '[${track.kind()} ${track.mediaSourceKind()}] resized to ${_delegate.videoWidth}x${_delegate.videoHeight}',
+        '$runtimeType',
+      );
+
+      width.value =
+          _delegate.videoWidth == 0 ? width.value : _delegate.videoWidth;
+      height.value =
+          _delegate.videoHeight == 0 ? height.value : _delegate.videoHeight;
+
+      canPlay.value = canPlay.value || _delegate.videoHeight != 0;
     };
   }
 
@@ -2196,6 +2215,10 @@ class RtcVideoRenderer extends RtcRenderer {
 
   /// Reactive height of this [RtcVideoRenderer].
   late final RxInt height = RxInt(_delegate.videoHeight);
+
+  /// Indicator whether this [RtcVideoRenderer] has visible frames, meaning it
+  /// may be rendered.
+  final RxBool canPlay = RxBool(false);
 
   /// Returns inner [webrtc.VideoRenderer].
   ///

--- a/lib/ui/page/call/widget/video_view.dart
+++ b/lib/ui/page/call/widget/video_view.dart
@@ -198,7 +198,7 @@ class _RtcVideoViewState extends State<RtcVideoView> {
 
     // Wait for the size to be determined if necessary.
     if (widget.offstageUntilDetermined) {
-      if (widget.renderer.height.value == 0) {
+      if (!widget.renderer.canPlay.value) {
         return Stack(
           children: [
             video,
@@ -214,7 +214,7 @@ class _RtcVideoViewState extends State<RtcVideoView> {
     Widget aspected(BoxFit? fit) {
       if (widget.respectAspectRatio && fit != BoxFit.cover) {
         return Obx(() {
-          if (widget.renderer.height.value == 0) {
+          if (!widget.renderer.canPlay.value) {
             if (widget.framelessBuilder != null) {
               return widget.framelessBuilder!();
             }
@@ -225,6 +225,10 @@ class _RtcVideoViewState extends State<RtcVideoView> {
                 const Center(child: CustomProgressIndicator.big())
               ],
             );
+          }
+
+          if (widget.renderer.height.value == 0) {
+            return video;
           }
 
           return AspectRatio(


### PR DESCRIPTION
## Synopsis

Whether `VideoRenderer` should be displayed or not, is determined via its height being non-zero, which isn't perfect.




## Solution

Use `onCanPlay` callback to determine that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
