### PR TITLE
Edit message in group with one user (#627)

### DIFF
--- a/lib/domain/model/chat.dart
+++ b/lib/domain/model/chat.dart
@@ -238,9 +238,7 @@ class Chat extends HiveObject implements Comparable<Chat> {
       }
     }
 
-    return lastReads.firstWhereOrNull(
-            (e) => !e.at.isBefore(item.at) && e.memberId != me) !=
-        null;
+    return lastReads.any((e) => !e.at.isBefore(item.at) && e.memberId != me);
   }
 
   /// Indicates whether the provided [ChatItem] was read only partially by some

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -1867,10 +1867,6 @@ class HiveRxChat extends RxChat {
                         }
                       }
 
-                      // TODO: https://github.com/team113/messenger/issues/627
-                      chatEntity.value.lastReads
-                          .removeWhere((e) => e.memberId == action.user.id);
-                      reads.removeWhere((e) => e.memberId == action.user.id);
                       _chatRepository.onMemberRemoved(id, action.user.id);
                       break;
 

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -1073,7 +1073,9 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                                       .add(ChatController.editMessageTimeout)
                                       .isAfter(PreciseDateTime.now()) ||
                                   !widget.chat.value!.isRead(
-                                      widget.note.value!.value, widget.me)))
+                                    widget.note.value!.value,
+                                    widget.me,
+                                  )))
                             ContextMenuButton(
                               key: const Key('EditButton'),
                               label: 'btn_edit'.l10n,

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -1072,7 +1072,9 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                               (_at
                                       .add(ChatController.editMessageTimeout)
                                       .isAfter(PreciseDateTime.now()) ||
-                                  !_isRead))
+                                  !widget.chat.value!.isRead(
+                                      widget.note.value!.value, widget.me) ||
+                                  widget.chat.value?.isMonolog == true))
                             ContextMenuButton(
                               key: const Key('EditButton'),
                               label: 'btn_edit'.l10n,

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -1073,8 +1073,7 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                                       .add(ChatController.editMessageTimeout)
                                       .isAfter(PreciseDateTime.now()) ||
                                   !widget.chat.value!.isRead(
-                                      widget.note.value!.value, widget.me) ||
-                                  widget.chat.value?.isMonolog == true))
+                                      widget.note.value!.value, widget.me)))
                             ContextMenuButton(
                               key: const Key('EditButton'),
                               label: 'btn_edit'.l10n,

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1650,7 +1650,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                                 (item.at
                                         .add(ChatController.editMessageTimeout)
                                         .isAfter(PreciseDateTime.now()) ||
-                                    !_isRead ||
+                                    !widget.chat.value!
+                                        .isRead(widget.item.value, widget.me) ||
                                     widget.chat.value?.isMonolog == true))
                               ContextMenuButton(
                                 key: const Key('EditButton'),

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1650,8 +1650,10 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                                 (item.at
                                         .add(ChatController.editMessageTimeout)
                                         .isAfter(PreciseDateTime.now()) ||
-                                    !widget.chat.value!
-                                        .isRead(widget.item.value, widget.me)))
+                                    !widget.chat.value!.isRead(
+                                      widget.item.value,
+                                      widget.me,
+                                    )))
                               ContextMenuButton(
                                 key: const Key('EditButton'),
                                 label: 'btn_edit'.l10n,

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1651,8 +1651,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                                         .add(ChatController.editMessageTimeout)
                                         .isAfter(PreciseDateTime.now()) ||
                                     !widget.chat.value!
-                                        .isRead(widget.item.value, widget.me) ||
-                                    widget.chat.value?.isMonolog == true))
+                                        .isRead(widget.item.value, widget.me)))
                               ContextMenuButton(
                                 key: const Key('EditButton'),
                                 label: 'btn_edit'.l10n,


### PR DESCRIPTION
Resolves #627




## Synopsis

При выходе пользователя из группы мы очищаем `Chat.lastReads` связанные с этим пользователем, из-за чего не можем определить есть ли у нас возможность редактировать сообщения, которые были прочитаны этим пользователем.




## Solution

`Chat.lastReads` не будут удаляться при выходе пользователя из группы.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
