### PR TITLE
`Dock` animation lags, when moving `CallButton`s fast enough (#783)

### DIFF
--- a/lib/ui/page/call/widget/dock.dart
+++ b/lib/ui/page/call/widget/dock.dart
@@ -556,7 +556,7 @@ class _DockState<T extends Object> extends State<Dock<T>> {
   }
 
   /// Populates the [_expandedKeys] according to the [_items].
-  _populateExpandedKeys() {
+  void _populateExpandedKeys() {
     final int length = _items.length + 1;
 
     if (_expandedKeys.length > length) {


### PR DESCRIPTION
Resolves #783




## Synopsis

Если довольно быстро перемещать кнопки между собой в доке во время звонка, то можно наблюдать корявую и прыгающую анимацию.




## Solution

Анимация будет исправлена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
