### PR TITLE
Fix `appcast.xml` Makefile command missing `title` and `enclosure` tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ endif
 appcast-xml-ver = $(shell git describe --tags --dirty --match "v*" --always)
 
 appcast.xml:
-	@echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><rss version=\"2.0\" xmlns:sparkle=\"http://www.andymatuschak.org/xml-namespaces/sparkle\"><channel><item><title>$(appcast-notes-ver)</title><description>$(notes)</description><pubDate>$(shell date -R)</pubDate>$(call xml,"macos","messenger-macos.zip")$(call xml,"windows","messenger-windows.zip")$(call xml,"linux","messenger-linux.zip")$(call xml,"android","messenger-android.zip")$(call xml,"ios","messenger-ios.zip")</item></channel></rss>" \
+	@echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><rss version=\"2.0\" xmlns:sparkle=\"http://www.andymatuschak.org/xml-namespaces/sparkle\"><channel><item><title>$(appcast-xml-ver)</title><description>$(notes)</description><pubDate>$(shell date -R)</pubDate>$(call appcast.xml.release,"macos","messenger-macos.zip")$(call appcast.xml.release,"windows","messenger-windows.zip")$(call appcast.xml.release,"linux","messenger-linux.zip")$(call appcast.xml.release,"android","messenger-android.zip")$(call appcast.xml.release,"ios","messenger-ios.zip")</item></channel></rss>" \
 	> $(or $(out),appcast.xml)
 define appcast.xml.release
 <enclosure sparkle:os=\"$(1)\" url=\"$(link)$(2)\" />

--- a/lib/ui/worker/upgrade.dart
+++ b/lib/ui/worker/upgrade.dart
@@ -134,7 +134,13 @@ class Release {
   factory Release.fromXml(XmlElement xml, {Language? language}) {
     language ??= L10n.languages.first;
 
-    final String title = xml.findElements('title').first.innerText;
+    String title = xml.findElements('title').first.innerText;
+
+    // Omit the leading `v` of the release version, if any.
+    if (title.startsWith('v')) {
+      title = title.substring(1);
+    }
+
     final String? description = xml
             .findElements('description')
             .firstWhereOrNull(


### PR DESCRIPTION
Related to #907




## Synopsis

`appcast.xml` Makefile command uses invalid variables and methods, causing its `title` and `enclosure` outputs to be empty.




## Solution

This PR:
1) Fixes the variable and method names, which makes `make appcast.xml` command to return the correct XML:
```xml
<?xml version="1.0" encoding="utf-8"?>
<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
  <channel>
    <item>
      <title>v0.1.0-alpha.12.3-40-g93b845c4f3-dirty</title>
      <description>${{ secrets.APPCAST_NOTES }}</description>
      <pubDate>Tue, 26 Mar 2024 10:34:57 +0300</pubDate>
      <enclosure sparkle:os="macos" url="messenger-macos.zip" />
      <enclosure sparkle:os="windows" url="messenger-windows.zip" />
      <enclosure sparkle:os="linux" url="messenger-linux.zip" />
      <enclosure sparkle:os="android" url="messenger-android.zip" />
      <enclosure sparkle:os="ios" url="messenger-ios.zip" />
    </item>
  </channel>
</rss>
```
2) Adds to `UpgradeWorker` ignoring the of leading `v`, if any is contained within the `<title>` tag. This is required, as `Pubspec.ref` contains the version without the `v`: `0.1.0-alpha.13`, and `git describe` returns `v0.1.0-alpha.13`: this will cause comparison issues. 




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
