### PR TITLE
Bootstrap Sentry metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
       - run: make flutter.build platform=${{ matrix.platform }} profile=yes
                   dart-env='SOCAPP_FCM_VAPID_KEY=${{ secrets.FCM_VAPID_KEY }}
                             SOCAPP_LINK_PREFIX=${{ startsWith(github.ref, 'refs/tags/v') && secrets.LINK_STABLE || secrets.LINK_MAIN }}
-                            SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN || '' }}'
+                            SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}'
         if: ${{ matrix.platform == 'web' }}
 
       # TODO: Add the following `split-debug-info`, when self-hosted Sentry
@@ -226,7 +226,7 @@ jobs:
                             SOCAPP_WS_PORT=${{ secrets.BACKEND_PORT }}
                             SOCAPP_APPCAST_URL=${{ secrets.APPCAST_MAIN }}
                             SOCAPP_LINK_PREFIX=${{ startsWith(github.ref, 'refs/tags/v') && secrets.LINK_STABLE || secrets.LINK_MAIN }}
-                            SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN || '' }}
+                            SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}
                             SOCAPP_USER_AGENT_VERSION=${{ steps.semver.outputs.group1 }}'
         if: ${{ matrix.platform != 'web' }}
 
@@ -366,7 +366,7 @@ jobs:
                             SOCAPP_WS_PORT=${{ secrets.BACKEND_PORT }}
                             SOCAPP_APPCAST_URL=${{ secrets.APPCAST_MAIN }}
                             SOCAPP_LINK_PREFIX=${{ startsWith(github.ref, 'refs/tags/v') && secrets.LINK_STABLE || secrets.LINK_MAIN }}
-                            SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN || '' }}
+                            SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}
                             SOCAPP_USER_AGENT_VERSION=${{ steps.semver.outputs.group1 }}'
 
       - name: Parse application name from Git repository name

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -60,9 +60,9 @@ PODS:
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.21.0):
+  - FirebaseCoreInternal (10.23.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.21.0):
+  - FirebaseInstallations (10.23.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -83,27 +83,35 @@ PODS:
     - Flutter
   - flutter_local_notifications (0.0.1):
     - Flutter
-  - GoogleDataTransport (9.3.0):
+  - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.12.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.13.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.12.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (7.13.0):
+    - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.12.0):
+  - GoogleUtilities/Logger (7.13.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.12.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (7.13.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.12.0)"
-  - GoogleUtilities/Reachability (7.12.0):
+  - "GoogleUtilities/NSData+zlib (7.13.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (7.13.0)
+  - GoogleUtilities/Reachability (7.13.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.12.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (7.13.0):
     - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
   - image_gallery_saver (2.0.2):
     - Flutter
   - image_picker_ios (0.0.1):
@@ -140,22 +148,22 @@ PODS:
     - FlutterMacOS
   - permission_handler_apple (9.3.0):
     - Flutter
-  - PromisesObjC (2.3.1)
-  - ReachabilitySwift (5.0.0)
+  - PromisesObjC (2.4.0)
+  - ReachabilitySwift (5.2.1)
   - screen_brightness_ios (0.1.0):
     - Flutter
-  - SDWebImage (5.18.11):
-    - SDWebImage/Core (= 5.18.11)
-  - SDWebImage/Core (5.18.11)
+  - SDWebImage (5.19.1):
+    - SDWebImage/Core (= 5.19.1)
+  - SDWebImage/Core (5.19.1)
   - sensors (0.0.1):
     - Flutter
-  - Sentry/HybridSDK (8.20.0):
-    - SentryPrivate (= 8.20.0)
+  - Sentry/HybridSDK (8.21.0):
+    - SentryPrivate (= 8.21.0)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.20.0)
-  - SentryPrivate (8.20.0)
+    - Sentry/HybridSDK (= 8.21.0)
+  - SentryPrivate (8.21.0)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -312,15 +320,15 @@ SPEC CHECKSUMS:
   firebase_core: a46c312d8bae4defa3d009b2aa7b5b413aeb394e
   firebase_messaging: e7062cef946e12f93b42abea96937004f8d914d6
   FirebaseCore: 28045c1560a2600d284b9c45a904fe322dc890b6
-  FirebaseCoreInternal: 43c1788eaeee9d1b97caaa751af567ce11010d00
-  FirebaseInstallations: 390ea1d10a4d02b20c965cbfd527ee9b3b412acb
+  FirebaseCoreInternal: 6a292e6f0bece1243a737e81556e56e5e19282e3
+  FirebaseInstallations: 42d6ead4605d6eafb3b6683674e80e18eb6f2c35
   FirebaseMessaging: 06c414a21b122396a26847c523d5c370f8325df5
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_app_badger: b87fc231847b03b92ce1412aa351842e7e97932f
   flutter_background_service_ios: e30e0d3ee69e4cee66272d0c78eacd48c2e94aac
   flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
-  GoogleDataTransport: 57c22343ab29bc686febbf7cbb13bad167c2d8fe
-  GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
+  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
+  GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
   image_gallery_saver: cb43cc43141711190510e92c460eb1655cd343cb
   image_picker_ios: b786a5dcf033a8336a657191401bfdf12017dabb
   instrumentisto-libwebrtc-bin: 295e1721ff9a8ccfc030c0de5f095c7d6b3e53ce
@@ -337,14 +345,14 @@ SPEC CHECKSUMS:
   package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   permission_handler_apple: 036b856153a2b1f61f21030ff725f3e6fece2b78
-  PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  ReachabilitySwift: 5ae15e16814b5f9ef568963fb2c87aeb49158c66
   screen_brightness_ios: 715ca807df953bf676d339f11464e438143ee625
-  SDWebImage: a3ba0b8faac7228c3c8eadd1a55c9c9fe5e16457
+  SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
   sensors: 84eb7a30e47a649e4172b71d6e81be614c280336
-  Sentry: a8d7b373b9f9868442b02a0c425192f693103cbf
-  sentry_flutter: 03e7660857a8cdb236e71456a7e8447b65c8a788
-  SentryPrivate: 006b24af16828441f70e2ab6adf241bd0a8ad130
+  Sentry: ebc12276bd17613a114ab359074096b6b3725203
+  sentry_flutter: dff1df05dc39c83d04f9330b36360fc374574c5e
+  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f

--- a/lib/domain/service/notification.dart
+++ b/lib/domain/service/notification.dart
@@ -114,7 +114,7 @@ class NotificationService extends DisposableService {
     Future<void> Function(RemoteMessage message)? onBackground,
   }) async {
     Log.debug(
-      'init($language, $firebaseOptions, onResponse, onBackground)',
+      'init($language, firebaseOptions, onResponse, onBackground)',
       '$runtimeType',
     );
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -158,6 +158,7 @@ Future<void> main() async {
             exception is HttpException ||
             exception is ClientException ||
             exception is DioException ||
+            exception is TimeoutException ||
             exception is ResubscriptionRequiredException) {
           return null;
         }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -199,6 +199,10 @@ Future<void> main() async {
     },
     appRunner: appRunner,
   );
+
+  final ISentrySpan ready = Sentry.startTransaction('Ready', 'UI');
+  WidgetsBinding.instance.waitUntilFirstFrameRasterized
+      .then((_) => ready.finish());
 }
 
 /// Initializes the [FlutterCallkeep] and displays an incoming call

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -143,6 +143,7 @@ Future<void> main() async {
       options.diagnosticLevel = SentryLevel.info;
       options.enablePrintBreadcrumbs = true;
       options.maxBreadcrumbs = 512;
+      options.enableTimeToFullDisplayTracing = true;
       options.beforeSend = (SentryEvent event, {Hint? hint}) {
         final exception = event.exceptions?.firstOrNull?.throwable;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,8 @@ import 'package:log_me/log_me.dart' as me;
 import 'package:media_kit/media_kit.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+// ignore: implementation_imports
+import 'package:sentry_flutter/src/integrations/integrations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:universal_io/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -69,6 +71,8 @@ import 'util/web/web_utils.dart';
 
 /// Entry point of this application.
 Future<void> main() async {
+  final Stopwatch watch = Stopwatch()..start();
+
   await Config.init();
 
   me.Log.options = me.LogOptions(
@@ -140,6 +144,7 @@ Future<void> main() async {
     (options) {
       options.dsn = Config.sentryDsn;
       options.tracesSampleRate = 1.0;
+      options.sampleRate = 1.0;
       options.release =
           '${Pubspec.name}@${Pubspec.ref ?? Config.version ?? Pubspec.version}';
       options.debug = true;
@@ -147,6 +152,8 @@ Future<void> main() async {
       options.enablePrintBreadcrumbs = true;
       options.maxBreadcrumbs = 512;
       options.enableTimeToFullDisplayTracing = true;
+      options.enableAppHangTracking = true;
+      options.enableTracing = true;
       options.beforeSend = (SentryEvent event, {Hint? hint}) {
         final exception = event.exceptions?.firstOrNull?.throwable;
 
@@ -201,7 +208,23 @@ Future<void> main() async {
     appRunner: appRunner,
   );
 
-  final ISentrySpan ready = Sentry.startTransaction('Ready', 'UI');
+  // TODO: Remove, when Sentry supports app start measurement for all platforms.
+  // ignore: invalid_use_of_internal_member
+  NativeAppStartIntegration.setAppStartInfo(
+    AppStartInfo(
+      AppStartType.cold,
+      start: DateTime.now().subtract(watch.elapsed),
+      end: DateTime.now(),
+    ),
+  );
+
+  // Transaction indicating Flutter engine has rasterized the first frame.
+  final ISentrySpan ready = Sentry.startTransaction(
+    'ui.app.ready',
+    'ui',
+    autoFinishAfter: const Duration(minutes: 2),
+  )..startChild('ready');
+
   WidgetsBinding.instance.waitUntilFirstFrameRasterized
       .then((_) => ready.finish());
 }

--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -19,8 +19,10 @@ import 'dart:async';
 
 import 'package:async/async.dart' show StreamGroup;
 import 'package:dio/dio.dart' as dio show DioException, Options, Response;
+import 'package:flutter/foundation.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mutex/mutex.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:universal_io/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -157,14 +159,17 @@ class GraphQlClient {
   Future<QueryResult> query(
     QueryOptions options, [
     Exception Function(Map<String, dynamic>)? handleException,
-  ]) =>
-      _middleware(() async {
+  ]) {
+    return _middleware(() async {
+      return _transaction(options.operationName, () async {
         final QueryResult result = await _queryLimiter.execute(
           () async => await (await client).query(options).timeout(timeout),
         );
         GraphQlProviderExceptions.fire(result, handleException);
         return result;
       });
+    });
+  }
 
   /// Resolves a single mutation according to the [MutationOptions] specified
   /// and returns a [Future] which resolves with the [QueryResult] or throws an
@@ -178,16 +183,20 @@ class GraphQlClient {
     Exception Function(Map<String, dynamic>)? onException,
   }) async {
     if (raw != null) {
-      QueryResult result =
-          await (await _newClient(raw)).mutate(options).timeout(timeout);
-      GraphQlProviderExceptions.fire(result, onException);
-      return result;
-    } else {
-      return _middleware(() async {
-        QueryResult result =
-            await (await client).mutate(options).timeout(timeout);
+      return await _transaction(options.operationName, () async {
+        final QueryResult result =
+            await (await _newClient(raw)).mutate(options).timeout(timeout);
         GraphQlProviderExceptions.fire(result, onException);
         return result;
+      });
+    } else {
+      return await _middleware(() async {
+        return await _transaction(options.operationName, () async {
+          final QueryResult result =
+              await (await client).mutate(options).timeout(timeout);
+          GraphQlProviderExceptions.fire(result, onException);
+          return result;
+        });
       });
     }
   }
@@ -204,10 +213,12 @@ class GraphQlClient {
   Future<dio.Response<T>> post<T>(
     dynamic data, {
     dio.Options? options,
+    String? operationName,
     Exception Function(Map<String, dynamic>)? onException,
     void Function(int, int)? onSendProgress,
-  }) =>
-      _middleware(() async {
+  }) {
+    return _middleware(() async {
+      return await _transaction(operationName, () async {
         final dio.Options authorized = options ?? dio.Options();
         authorized.headers = (authorized.headers ?? {});
         authorized.headers!['Authorization'] = 'Bearer $token';
@@ -231,6 +242,8 @@ class GraphQlClient {
           rethrow;
         }
       });
+    });
+  }
 
   /// Reconnects the [client] right away if the [token] mismatch is detected.
   Future<void> reconnect() async {
@@ -455,6 +468,30 @@ class GraphQlClient {
       ),
       link: link,
     );
+  }
+
+  /// Completes the [fn] wrapped around [Sentry.startTransaction], meaning the
+  /// [fn] will be recorded as a transaction.
+  Future<T> _transaction<T>(String? operation, Future<T> Function() fn) async {
+    if (operation == null || Config.sentryDsn.isEmpty || kDebugMode) {
+      return await fn();
+    }
+
+    final ISentrySpan transaction = Sentry.startTransaction(
+      '$operation()',
+      'graphql',
+      autoFinishAfter: const Duration(minutes: 1),
+    );
+
+    try {
+      return await fn();
+    } catch (e) {
+      transaction.throwable = e;
+      transaction.status = const SpanStatus.internalError();
+      rethrow;
+    } finally {
+      transaction.finish();
+    }
   }
 }
 

--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -478,10 +478,10 @@ class GraphQlClient {
     }
 
     final ISentrySpan transaction = Sentry.startTransaction(
-      '$operation()',
+      'graphql.$operation()',
       'graphql',
       autoFinishAfter: const Duration(minutes: 1),
-    );
+    )..startChild('query');
 
     try {
       return await fn();

--- a/lib/provider/gql/components/auth.dart
+++ b/lib/provider/gql/components/auth.dart
@@ -78,7 +78,8 @@ mixin AuthGraphQlMixin {
 
     if (token != null) {
       final variables = DeleteSessionArguments(token: token!);
-      final QueryResult result = await client.query(QueryOptions(
+      final QueryResult result = await client.mutate(MutationOptions(
+        operationName: 'DeleteSession',
         document: DeleteSessionMutation(variables: variables).document,
         variables: variables.toJson(),
       ));
@@ -122,6 +123,7 @@ mixin AuthGraphQlMixin {
     );
     final QueryResult result = await client.mutate(
       MutationOptions(
+        operationName: 'SignIn',
         document: SignInMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
@@ -143,8 +145,12 @@ mixin AuthGraphQlMixin {
   Future<ValidateToken$Query> validateToken() async {
     Log.debug('validateToken()', '$runtimeType');
 
-    final QueryResult res = await client
-        .query(QueryOptions(document: ValidateTokenQuery().document));
+    final QueryResult res = await client.query(
+      QueryOptions(
+        operationName: 'ValidateToken',
+        document: ValidateTokenQuery().document,
+      ),
+    );
     return ValidateToken$Query.fromJson(res.data!);
   }
 
@@ -176,6 +182,7 @@ mixin AuthGraphQlMixin {
     final variables = RenewSessionArguments(token: token);
     final QueryResult result = await client.mutate(
       MutationOptions(
+        operationName: 'RenewSession',
         document: RenewSessionMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
@@ -233,8 +240,8 @@ mixin AuthGraphQlMixin {
       email: email,
       phone: phone,
     );
-    await client.query(
-      QueryOptions(
+    await client.mutate(
+      MutationOptions(
         operationName: 'RecoverUserPassword',
         document: RecoverUserPasswordMutation(variables: variables).document,
         variables: variables.toJson(),
@@ -281,14 +288,14 @@ mixin AuthGraphQlMixin {
       phone: phone,
       code: code,
     );
-    await client.query(
-      QueryOptions(
+    await client.mutate(
+      MutationOptions(
         operationName: 'ValidateUserPasswordRecoveryCode',
         document: ValidateUserPasswordRecoveryCodeMutation(variables: variables)
             .document,
         variables: variables.toJson(),
       ),
-      (data) => ValidateUserPasswordRecoveryCodeException(
+      onException: (data) => ValidateUserPasswordRecoveryCodeException(
           ValidateUserPasswordRecoveryCode$Mutation.fromJson(data)
                   .validateUserPasswordRecoveryCode
               as ValidateUserPasswordRecoveryErrorCode),

--- a/lib/provider/gql/components/call.dart
+++ b/lib/provider/gql/components/call.dart
@@ -233,8 +233,10 @@ mixin CallGraphQlMixin {
   /// in this [Chat] already and the authenticated [MyUser] is a member of it.
   /// Joins it if the authenticated [MyUser] is not a member yet.
   Future<StartCall$Mutation$StartChatCall$StartChatCallOk> startChatCall(
-      ChatId chatId, ChatCallCredentials creds,
-      [bool? withVideo]) async {
+    ChatId chatId,
+    ChatCallCredentials creds, [
+    bool? withVideo,
+  ]) async {
     Log.debug('startChatCall($chatId, $creds)', '$runtimeType');
 
     final variables = StartCallArguments(
@@ -242,13 +244,13 @@ mixin CallGraphQlMixin {
       creds: creds,
       withVideo: withVideo,
     );
-    final QueryResult result = await client.query(
-      QueryOptions(
+    final QueryResult result = await client.mutate(
+      MutationOptions(
         operationName: 'StartCall',
         document: StartCallMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
-      (data) => StartChatCallException(
+      onException: (data) => StartChatCallException(
           (StartCall$Mutation.fromJson(data).startChatCall
                   as StartCall$Mutation$StartChatCall$StartChatCallError)
               .code),
@@ -287,15 +289,16 @@ mixin CallGraphQlMixin {
     Log.debug('joinChatCall($chatId, $creds)', '$runtimeType');
 
     final variables = JoinCallArguments(chatId: chatId, creds: creds);
-    final QueryResult result = await client.query(
-      QueryOptions(
+    final QueryResult result = await client.mutate(
+      MutationOptions(
         operationName: 'JoinCall',
         document: JoinCallMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
-      (data) => JoinChatCallException((JoinCall$Mutation.fromJson(data)
-              .joinChatCall as JoinCall$Mutation$JoinChatCall$JoinChatCallError)
-          .code),
+      onException: (data) => JoinChatCallException(
+          (JoinCall$Mutation.fromJson(data).joinChatCall
+                  as JoinCall$Mutation$JoinChatCall$JoinChatCallError)
+              .code),
     );
     return (JoinCall$Mutation.fromJson(result.data!).joinChatCall
         as JoinCall$Mutation$JoinChatCall$JoinChatCallOk);
@@ -329,13 +332,13 @@ mixin CallGraphQlMixin {
     Log.debug('leaveChatCall($chatId, $deviceId)', '$runtimeType');
 
     final variables = LeaveCallArguments(chatId: chatId, deviceId: deviceId);
-    final QueryResult result = await client.query(
-      QueryOptions(
+    final QueryResult result = await client.mutate(
+      MutationOptions(
         operationName: 'LeaveCall',
         document: LeaveCallMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
-      (data) => LeaveChatCallException(
+      onException: (data) => LeaveChatCallException(
           (LeaveCall$Mutation.fromJson(data).leaveChatCall
                   as LeaveCall$Mutation$LeaveChatCall$LeaveChatCallError)
               .code),
@@ -369,13 +372,13 @@ mixin CallGraphQlMixin {
     Log.debug('declineChatCall($chatId)', '$runtimeType');
 
     final variables = DeclineCallArguments(chatId: chatId);
-    final QueryResult result = await client.query(
-      QueryOptions(
+    final QueryResult result = await client.mutate(
+      MutationOptions(
         operationName: 'DeclineCall',
         document: DeclineCallMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
-      (data) => DeclineChatCallException(
+      onException: (data) => DeclineChatCallException(
           (DeclineCall$Mutation.fromJson(data).declineChatCall
                   as DeclineCall$Mutation$DeclineChatCall$DeclineChatCallError)
               .code),

--- a/lib/provider/gql/components/chat.dart
+++ b/lib/provider/gql/components/chat.dart
@@ -186,13 +186,14 @@ mixin ChatGraphQlMixin {
     Log.debug('createDialogChat($responderId)', '$runtimeType');
 
     final variables = CreateDialogArguments(responderId: responderId);
-    final QueryResult result = await client.query(
-      QueryOptions(
+    final QueryResult result = await client.mutate(
+      MutationOptions(
         operationName: 'CreateDialog',
         document: CreateDialogMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
-      (data) => CreateDialogException((CreateDialog$Mutation.fromJson(data)
+      onException: (data) => CreateDialogException((CreateDialog$Mutation
+                      .fromJson(data)
                   .createDialogChat
               as CreateDialog$Mutation$CreateDialogChat$CreateDialogChatError)
           .code),
@@ -213,14 +214,14 @@ mixin ChatGraphQlMixin {
 
     final variables =
         CreateGroupChatArguments(memberIds: memberIds, name: name);
-    final QueryResult result = await client.query(
-      QueryOptions(
+    final QueryResult result = await client.mutate(
+      MutationOptions(
         operationName: 'CreateGroupChat',
         document: CreateGroupChatMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
-      (data) => CreateGroupChatException((CreateGroupChat$Mutation.fromJson(
-                      data)
+      onException: (data) => CreateGroupChatException((CreateGroupChat$Mutation
+                      .fromJson(data)
                   .createGroupChat
               as CreateGroupChat$Mutation$CreateGroupChat$CreateGroupChatError)
           .code),
@@ -545,14 +546,14 @@ mixin ChatGraphQlMixin {
     Log.debug('readChat($chatId, $untilId)', '$runtimeType');
 
     final variables = ReadChatArguments(id: chatId, untilId: untilId);
-    final QueryResult result = await client.query(
-      QueryOptions(
+    final QueryResult result = await client.mutate(
+      MutationOptions(
         operationName: 'ReadChat',
         document: ReadChatMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
-      (data) => ReadChatException((ReadChat$Mutation.fromJson(data).readChat
-              as ReadChat$Mutation$ReadChat$ReadChatError)
+      onException: (data) => ReadChatException((ReadChat$Mutation.fromJson(data)
+              .readChat as ReadChat$Mutation$ReadChat$ReadChatError)
           .code),
     );
     return (ReadChat$Mutation.fromJson(result.data!).readChat
@@ -863,6 +864,7 @@ mixin ChatGraphQlMixin {
           'file': attachment,
         }),
         options: dio.Options(contentType: 'multipart/form-data'),
+        operationName: query.operationName,
         onSendProgress: onSendProgress,
         onException: (data) => UploadAttachmentException((UploadAttachment$Mutation
                         .fromJson(data)
@@ -1302,6 +1304,7 @@ mixin ChatGraphQlMixin {
           'file': file,
         }),
         options: dio.Options(contentType: 'multipart/form-data'),
+        operationName: query.operationName,
         onSendProgress: onSendProgress,
         onException: (data) => UpdateChatAvatarException(
           (UpdateChatAvatar$Mutation.fromJson(data).updateChatAvatar

--- a/lib/provider/gql/components/user.dart
+++ b/lib/provider/gql/components/user.dart
@@ -132,6 +132,7 @@ mixin UserGraphQlMixin {
       before: before,
     );
     QueryResult res = await client.query(QueryOptions(
+      operationName: 'SearchUsers',
       document: SearchUsersQuery(variables: variables).document,
       variables: variables.toJson(),
     ));
@@ -160,6 +161,7 @@ mixin UserGraphQlMixin {
     final variables = UpdateUserNameArguments(name: name);
     QueryResult res = await client.mutate(
       MutationOptions(
+        operationName: 'UpdateUserName',
         document: UpdateUserNameMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
@@ -189,6 +191,7 @@ mixin UserGraphQlMixin {
     final variables = UpdateUserBioArguments(bio: bio);
     QueryResult res = await client.mutate(
       MutationOptions(
+        operationName: 'UpdateUserBio',
         document: UpdateUserBioMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
@@ -220,6 +223,7 @@ mixin UserGraphQlMixin {
     final variables = UpdateUserStatusArguments(text: text);
     QueryResult res = await client.mutate(
       MutationOptions(
+        operationName: 'UpdateUserStatus',
         document: UpdateUserStatusMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
@@ -248,6 +252,7 @@ mixin UserGraphQlMixin {
     final variables = UpdateUserLoginArguments(login: login);
     QueryResult res = await client.mutate(
       MutationOptions(
+        operationName: 'UpdateUserLogin',
         document: UpdateUserLoginMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
@@ -284,6 +289,7 @@ mixin UserGraphQlMixin {
     final variables = UpdateUserPresenceArguments(presence: presence);
     QueryResult res = await client.mutate(
       MutationOptions(
+        operationName: 'UpdateUserPresence',
         document: UpdateUserPresenceMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
@@ -322,6 +328,7 @@ mixin UserGraphQlMixin {
     );
     QueryResult res = await client.mutate(
       MutationOptions(
+        operationName: 'UpdateUserPassword',
         document: UpdateUserPasswordMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
@@ -356,8 +363,12 @@ mixin UserGraphQlMixin {
   Future<MyUserEventsVersionedMixin> deleteMyUser() async {
     Log.debug('deleteMyUser()', '$runtimeType');
 
-    QueryResult res = await client
-        .mutate(MutationOptions(document: DeleteMyUserMutation().document));
+    QueryResult res = await client.mutate(
+      MutationOptions(
+        operationName: 'DeleteMyUser',
+        document: DeleteMyUserMutation().document,
+      ),
+    );
     return DeleteMyUser$Mutation.fromJson(res.data!).deleteMyUser;
   }
 
@@ -929,6 +940,7 @@ mixin UserGraphQlMixin {
         options: file == null
             ? null
             : dio.Options(contentType: 'multipart/form-data'),
+        operationName: query.operationName,
         onSendProgress: onSendProgress,
         onException: (data) => UpdateUserAvatarException(
           (UpdateUserAvatar$Mutation.fromJson(data).updateUserAvatar
@@ -1011,6 +1023,7 @@ mixin UserGraphQlMixin {
         options: file == null
             ? null
             : dio.Options(contentType: 'multipart/form-data'),
+        operationName: query.operationName,
         onSendProgress: onSendProgress,
         onException: (data) => UpdateUserCallCoverException(
           (UpdateUserCallCover$Mutation.fromJson(data).updateUserCallCover
@@ -1297,6 +1310,7 @@ mixin UserGraphQlMixin {
           if (locale != null) 'Accept-Language': locale,
         },
       ),
+      operationName: query.operationName,
       onException: (data) => RegisterFcmDeviceException(
         RegisterFcmDevice$Mutation.fromJson(data).registerFcmDevice
             as RegisterFcmDeviceErrorCode,

--- a/lib/provider/gql/components/user.dart
+++ b/lib/provider/gql/components/user.dart
@@ -46,8 +46,12 @@ mixin UserGraphQlMixin {
   Future<GetMyUser$Query> getMyUser() async {
     Log.debug('getMyUser()', '$runtimeType');
 
-    QueryResult res =
-        await client.query(QueryOptions(document: GetMyUserQuery().document));
+    QueryResult res = await client.query(
+      QueryOptions(
+        operationName: 'GetMyUser',
+        document: GetMyUserQuery().document,
+      ),
+    );
     return GetMyUser$Query.fromJson(res.data!);
   }
 

--- a/lib/ui/page/auth/controller.dart
+++ b/lib/ui/page/auth/controller.dart
@@ -43,10 +43,10 @@ class AuthController extends GetxController {
   /// [ISentrySpan] being a [Sentry] transaction monitoring this
   /// [AuthController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
-    'Ready',
-    'ui.auth',
+    'ui.auth.ready',
+    'ui',
     autoFinishAfter: const Duration(minutes: 2),
-  );
+  )..startChild('ready');
 
   /// Returns user authentication status.
   Rx<RxStatus> get authStatus => _auth.status;

--- a/lib/ui/page/auth/controller.dart
+++ b/lib/ui/page/auth/controller.dart
@@ -40,8 +40,7 @@ class AuthController extends GetxController {
   /// [Timer] periodically increasing the [logoFrame].
   Timer? _animationTimer;
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this
-  /// [AuthController] readiness.
+  /// [Sentry] transaction monitoring this [AuthController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.auth.ready',
     'ui',

--- a/lib/ui/page/auth/controller.dart
+++ b/lib/ui/page/auth/controller.dart
@@ -17,7 +17,9 @@
 
 import 'dart:async';
 
+import 'package:flutter/scheduler.dart';
 import 'package:get/get.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '/domain/service/auth.dart';
 import '/routes.dart';
@@ -38,8 +40,22 @@ class AuthController extends GetxController {
   /// [Timer] periodically increasing the [logoFrame].
   Timer? _animationTimer;
 
+  /// [ISentrySpan] being a [Sentry] transaction monitoring this
+  /// [AuthController] readiness.
+  final ISentrySpan _ready = Sentry.startTransaction(
+    'Ready',
+    'ui.auth',
+    autoFinishAfter: const Duration(minutes: 2),
+  );
+
   /// Returns user authentication status.
   Rx<RxStatus> get authStatus => _auth.status;
+
+  @override
+  void onReady() {
+    SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+    super.onReady();
+  }
 
   @override
   void onClose() {

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -393,8 +393,7 @@ class CallController extends GetxController {
   /// [_notificationDuration].
   final List<Timer> _notificationTimers = [];
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this
-  /// [CallController] readiness.
+  /// [Sentry] transaction monitoring this [CallController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.call.ready',
     'ui',

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -396,8 +396,8 @@ class CallController extends GetxController {
   /// [ISentrySpan] being a [Sentry] transaction monitoring this
   /// [CallController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
-    'Ready',
-    'ui.call',
+    'ui.call.ready',
+    'ui',
     autoFinishAfter: const Duration(minutes: 2),
   );
 
@@ -563,6 +563,8 @@ class CallController extends GetxController {
 
   @override
   void onInit() {
+    ISentrySpan span = _ready.startChild('init');
+
     super.onInit();
 
     _currentCall.value.init(getChat: _chatService.get);
@@ -827,6 +829,8 @@ class CallController extends GetxController {
       }
     }
 
+    span.finish();
+    span = _ready.startChild('chat');
     _initChat();
   }
 

--- a/lib/ui/page/chat_direct_link/controller.dart
+++ b/lib/ui/page/chat_direct_link/controller.dart
@@ -17,7 +17,9 @@
 
 import 'dart:async';
 
+import 'package:flutter/scheduler.dart';
 import 'package:get/get.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '/api/backend/schema.dart';
 import '/domain/model/chat.dart';
@@ -40,6 +42,14 @@ class ChatDirectLinkController extends GetxController {
   /// Authorization service used for signing up.
   final AuthService _auth;
 
+  /// [ISentrySpan] being a [Sentry] transaction monitoring this
+  /// [ChatDirectLinkController] readiness.
+  final ISentrySpan _ready = Sentry.startTransaction(
+    'Ready',
+    'ui.direct_link',
+    autoFinishAfter: const Duration(minutes: 2),
+  );
+
   @override
   void onReady() async {
     if (_auth.status.value.isSuccess) {
@@ -50,6 +60,8 @@ class ChatDirectLinkController extends GetxController {
         await _useChatDirectLink();
       }
     }
+
+    SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
 
     super.onReady();
   }

--- a/lib/ui/page/chat_direct_link/controller.dart
+++ b/lib/ui/page/chat_direct_link/controller.dart
@@ -42,8 +42,7 @@ class ChatDirectLinkController extends GetxController {
   /// Authorization service used for signing up.
   final AuthService _auth;
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this
-  /// [ChatDirectLinkController] readiness.
+  /// [Sentry] transaction monitoring this [ChatDirectLinkController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.direct_link.ready',
     'ui',

--- a/lib/ui/page/chat_direct_link/controller.dart
+++ b/lib/ui/page/chat_direct_link/controller.dart
@@ -45,52 +45,75 @@ class ChatDirectLinkController extends GetxController {
   /// [ISentrySpan] being a [Sentry] transaction monitoring this
   /// [ChatDirectLinkController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
-    'Ready',
-    'ui.direct_link',
+    'ui.direct_link.ready',
+    'ui',
     autoFinishAfter: const Duration(minutes: 2),
   );
 
   @override
   void onReady() async {
-    if (_auth.status.value.isSuccess) {
-      await _useChatDirectLink();
-    } else if (_auth.status.value.isEmpty) {
-      await _register();
+    try {
       if (_auth.status.value.isSuccess) {
         await _useChatDirectLink();
+      } else if (_auth.status.value.isEmpty) {
+        await _register();
+        if (_auth.status.value.isSuccess) {
+          await _useChatDirectLink();
+        }
       }
-    }
 
-    SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+      SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+    } catch (e) {
+      _ready.throwable = e;
+      _ready.finish(status: const SpanStatus.internalError());
+      rethrow;
+    }
 
     super.onReady();
   }
 
   /// Creates a new [MyUser].
   Future<void> _register() async {
+    final ISentrySpan span = _ready.startChild('register');
+
     try {
       await _auth.register();
     } catch (e) {
+      span.throwable = e;
+      span.status = const SpanStatus.internalError();
+
       MessagePopup.error(e);
       rethrow;
+    } finally {
+      span.finish();
     }
   }
 
   /// Uses the [slug] and redirects to the fetched [Routes.chats] page on
   /// success.
   Future<void> _useChatDirectLink() async {
+    final ISentrySpan span = _ready.startChild('use');
+
     try {
       ChatId chatId = await _auth.useChatDirectLink(slug.value!);
       router.chat(chatId, link: slug.value);
     } on UseChatDirectLinkException catch (e) {
+      span.throwable = e;
+      span.status = const SpanStatus.internalError();
+
       if (e.code == UseChatDirectLinkErrorCode.unknownDirectLink) {
         slug.value = null;
       } else {
         MessagePopup.error(e);
       }
     } catch (e) {
+      span.throwable = e;
+      span.status = const SpanStatus.internalError();
+
       MessagePopup.error(e);
       rethrow;
+    } finally {
+      span.finish();
     }
   }
 }

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -29,6 +29,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_list_view/flutter_list_view.dart';
 import 'package:get/get.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '/api/backend/schema.dart'
     hide
@@ -351,6 +352,14 @@ class ChatController extends GetxController {
 
   /// Subscriptions to the [Paginated.updates].
   final List<StreamSubscription> _fragmentSubscriptions = [];
+
+  /// [ISentrySpan] being a [Sentry] transaction monitoring this
+  /// [ChatController] readiness.
+  final ISentrySpan _ready = Sentry.startTransaction(
+    'Ready',
+    'ui.chat',
+    autoFinishAfter: const Duration(minutes: 2),
+  );
 
   /// Returns [MyUser]'s [UserId].
   UserId? get me => _authService.userId;
@@ -713,201 +722,246 @@ class ChatController extends GetxController {
 
   /// Fetches the local [chat] value from [_chatService] by the provided [id].
   Future<void> _fetchChat() async {
-    _ignorePositionChanges = true;
+    final Stopwatch watch = Stopwatch()..start();
 
-    status.value = RxStatus.loading();
-
-    final FutureOr<RxChat?> fetched = _chatService.get(id);
-    chat = fetched is RxChat? ? fetched : await fetched;
-
-    if (chat == null) {
-      status.value = RxStatus.empty();
-    } else {
-      _chatSubscription = chat!.updates.listen((_) {});
-
-      unreadMessages = chat!.chat.value.unreadCount;
-
-      final ChatMessage? draft = chat!.draft.value;
-
-      if (send.field.text.isEmpty) {
-        send.field.unchecked = draft?.text?.val ?? send.field.text;
-      }
-
-      send.inCall = chat!.inCall;
-      send.field.unsubmit();
-      send.replied.value = List.from(
-        draft?.repliesTo
-                .map((e) => e.original)
-                .whereNotNull()
-                .map((e) => Rx(e)) ??
-            <Rx<ChatItem>>[],
+    try {
+      _ready.setMeasurement(
+        'duration_start',
+        watch.elapsedMilliseconds,
+        unit: DurationSentryMeasurementUnit.milliSecond,
       );
 
-      for (Attachment e in draft?.attachments ?? []) {
-        send.attachments.add(MapEntry(GlobalKey(), e));
-      }
+      _ignorePositionChanges = true;
 
-      _chatWorker = ever(chat!.chat, (Chat e) {
-        if (e.id != id) {
-          WebUtils.replaceState(id.val, e.id.val);
-          id = e.id;
+      status.value = RxStatus.loading();
+
+      final FutureOr<RxChat?> fetched = _chatService.get(id);
+
+      chat = fetched is RxChat? ? fetched : await fetched;
+
+      _ready.setMeasurement(
+        'duration_get',
+        watch.elapsedMilliseconds,
+        unit: DurationSentryMeasurementUnit.milliSecond,
+      );
+
+      if (chat == null) {
+        status.value = RxStatus.empty();
+      } else {
+        _chatSubscription = chat!.updates.listen((_) {});
+
+        unreadMessages = chat!.chat.value.unreadCount;
+
+        final ChatMessage? draft = chat!.draft.value;
+
+        if (send.field.text.isEmpty) {
+          send.field.unchecked = draft?.text?.val ?? send.field.text;
         }
-      });
 
-      listController.sliverController.onPaintItemPositionsCallback =
-          (height, positions) {
-        if (positions.isNotEmpty) {
-          _topVisibleItem = positions.last;
+        send.inCall = chat!.inCall;
+        send.field.unsubmit();
+        send.replied.value = List.from(
+          draft?.repliesTo
+                  .map((e) => e.original)
+                  .whereNotNull()
+                  .map((e) => Rx(e)) ??
+              <Rx<ChatItem>>[],
+        );
 
-          _lastVisibleItem = positions.firstWhereOrNull((e) {
-            ListElement? element = elements.values.elementAtOrNull(e.index);
-            return element is ChatMessageElement ||
-                element is ChatInfoElement ||
-                element is ChatCallElement ||
-                element is ChatForwardElement;
-          });
+        for (Attachment e in draft?.attachments ?? []) {
+          send.attachments.add(MapEntry(GlobalKey(), e));
+        }
 
-          if (_lastVisibleItem != null &&
-              status.value.isSuccess &&
-              !status.value.isLoadingMore) {
-            ListElement element =
-                elements.values.elementAt(_lastVisibleItem!.index);
+        _chatWorker = ever(chat!.chat, (Chat e) {
+          if (e.id != id) {
+            WebUtils.replaceState(id.val, e.id.val);
+            id = e.id;
+          }
+        });
 
-            // If the [_lastVisibleItem] is posted after the [_lastSeenItem],
-            // then set the [_lastSeenItem] to this item.
-            if (!element.id.id.isLocal &&
-                (_lastSeenItem.value == null ||
-                    element.id.at.isAfter(_lastSeenItem.value!.at))) {
-              if (element is ChatMessageElement) {
-                _lastSeenItem.value = element.item.value;
-              } else if (element is ChatInfoElement) {
-                _lastSeenItem.value = element.item.value;
-              } else if (element is ChatCallElement) {
-                _lastSeenItem.value = element.item.value;
-              } else if (element is ChatForwardElement) {
-                _lastSeenItem.value = element.forwards.last.value;
+        listController.sliverController.onPaintItemPositionsCallback =
+            (height, positions) {
+          if (positions.isNotEmpty) {
+            _topVisibleItem = positions.last;
+
+            _lastVisibleItem = positions.firstWhereOrNull((e) {
+              ListElement? element = elements.values.elementAtOrNull(e.index);
+              return element is ChatMessageElement ||
+                  element is ChatInfoElement ||
+                  element is ChatCallElement ||
+                  element is ChatForwardElement;
+            });
+
+            if (_lastVisibleItem != null &&
+                status.value.isSuccess &&
+                !status.value.isLoadingMore) {
+              ListElement element =
+                  elements.values.elementAt(_lastVisibleItem!.index);
+
+              // If the [_lastVisibleItem] is posted after the [_lastSeenItem],
+              // then set the [_lastSeenItem] to this item.
+              if (!element.id.id.isLocal &&
+                  (_lastSeenItem.value == null ||
+                      element.id.at.isAfter(_lastSeenItem.value!.at))) {
+                if (element is ChatMessageElement) {
+                  _lastSeenItem.value = element.item.value;
+                } else if (element is ChatInfoElement) {
+                  _lastSeenItem.value = element.item.value;
+                } else if (element is ChatCallElement) {
+                  _lastSeenItem.value = element.item.value;
+                } else if (element is ChatForwardElement) {
+                  _lastSeenItem.value = element.forwards.last.value;
+                }
               }
             }
           }
+        };
+
+        if (chat?.chat.value.isDialog == true) {
+          _userSubscription = chat?.members.values
+              .lastWhereOrNull((u) => u.user.id != me)
+              ?.user
+              .updates
+              .listen((_) {});
         }
-      };
 
-      if (chat?.chat.value.isDialog == true) {
-        _userSubscription = chat?.members.values
-            .lastWhereOrNull((u) => u.user.id != me)
-            ?.user
-            .updates
-            .listen((_) {});
-      }
+        _readWorker ??= ever(_lastSeenItem, readChat);
+        _obscuredWorker ??= ever(router.obscuring, (modals) {
+          if (modals.isEmpty) {
+            readChat(_lastSeenItem.value);
+          }
+        });
 
-      _readWorker ??= ever(_lastSeenItem, readChat);
-      _obscuredWorker ??= ever(router.obscuring, (modals) {
-        if (modals.isEmpty) {
+        // If [RxChat.status] is not successful yet, populate the
+        // [_messageInitializedWorker] to determine the initial messages list
+        // index and offset.
+        if (!chat!.status.value.isSuccess) {
+          _messageInitializedWorker =
+              ever(chat!.status, (RxStatus status) async {
+            if (_messageInitializedWorker != null) {
+              if (status.isSuccess) {
+                _messageInitializedWorker?.dispose();
+                _messageInitializedWorker = null;
+
+                await Future.delayed(Duration.zero);
+
+                if (!this.status.value.isSuccess) {
+                  this.status.value = RxStatus.loadingMore();
+                }
+
+                _determineFirstUnread();
+                var result = _calculateListViewIndex();
+                initIndex = result.index;
+                initOffset = result.offset;
+              }
+            }
+          });
+        } else {
+          _determineFirstUnread();
+          final result = _calculateListViewIndex();
+          initIndex = result.index;
+          initOffset = result.offset;
+
+          status.value = RxStatus.loadingMore();
+        }
+
+        _bottomLoaderStartTimer = Timer(
+          const Duration(seconds: 2),
+          () {
+            if ((!status.value.isSuccess || status.value.isLoadingMore) &&
+                elements.isNotEmpty) {
+              _bottomLoader = LoaderElement.bottom(
+                (chat?.messages.lastOrNull?.value.at
+                        .add(const Duration(microseconds: 1)) ??
+                    PreciseDateTime.now()),
+              );
+
+              elements[_bottomLoader!.id] = _bottomLoader!;
+            }
+          },
+        );
+
+        _ready.setMeasurement(
+          'duration_fetching',
+          watch.elapsedMilliseconds,
+          unit: DurationSentryMeasurementUnit.milliSecond,
+        );
+
+        _ready.setTag('messages', '${chat!.messages.isNotEmpty}');
+        _ready.setTag('local', '${id.isLocal}');
+
+        if (itemId == null) {
+          for (Rx<ChatItem> e in chat!.messages) {
+            _add(e);
+          }
+
+          _subscribeFor(chat: chat);
+
+          await chat!.around();
+
+          // Required in order for [Hive.boxEvents] to add the messages.
+          await Future.delayed(Duration.zero);
+
+          Rx<ChatItem>? firstUnread = _firstUnread;
+          _determineFirstUnread();
+
+          // Scroll to the last read message if [_firstUnread] was updated.
+          // Otherwise, [FlutterListViewDelegate.keepPosition] handles this as the
+          // last read item is already in the list.
+          if (firstUnread?.value.id != _firstUnread?.value.id) {
+            _scrollToLastRead();
+          }
+        } else {
+          await animateTo(itemId!);
+        }
+
+        _ready.setMeasurement(
+          'duration_around',
+          watch.elapsedMilliseconds,
+          unit: DurationSentryMeasurementUnit.milliSecond,
+        );
+
+        if (welcome != null) {
+          chat!.addMessage(welcome!);
+        }
+
+        status.value = RxStatus.success();
+
+        if (_bottomLoader != null) {
+          showLoaders.value = false;
+
+          _bottomLoaderEndTimer = Timer(const Duration(milliseconds: 300), () {
+            if (_bottomLoader != null) {
+              elements.remove(_bottomLoader!.id);
+              _bottomLoader = null;
+              showLoaders.value = true;
+            }
+          });
+        }
+
+        if (_lastSeenItem.value != null) {
           readChat(_lastSeenItem.value);
         }
+      }
+
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        _ensureScrollable();
       });
 
-      // If [RxChat.status] is not successful yet, populate the
-      // [_messageInitializedWorker] to determine the initial messages list
-      // index and offset.
-      if (!chat!.status.value.isSuccess) {
-        _messageInitializedWorker = ever(chat!.status, (RxStatus status) async {
-          if (_messageInitializedWorker != null) {
-            if (status.isSuccess) {
-              _messageInitializedWorker?.dispose();
-              _messageInitializedWorker = null;
+      _ignorePositionChanges = false;
 
-              await Future.delayed(Duration.zero);
-
-              if (!this.status.value.isSuccess) {
-                this.status.value = RxStatus.loadingMore();
-              }
-
-              _determineFirstUnread();
-              var result = _calculateListViewIndex();
-              initIndex = result.index;
-              initOffset = result.offset;
-            }
-          }
-        });
-      } else {
-        _determineFirstUnread();
-        final result = _calculateListViewIndex();
-        initIndex = result.index;
-        initOffset = result.offset;
-
-        status.value = RxStatus.loadingMore();
-      }
-
-      _bottomLoaderStartTimer = Timer(
-        const Duration(seconds: 2),
-        () {
-          if ((!status.value.isSuccess || status.value.isLoadingMore) &&
-              elements.isNotEmpty) {
-            _bottomLoader = LoaderElement.bottom(
-              (chat?.messages.lastOrNull?.value.at
-                      .add(const Duration(microseconds: 1)) ??
-                  PreciseDateTime.now()),
-            );
-
-            elements[_bottomLoader!.id] = _bottomLoader!;
-          }
-        },
+      _ready.setMeasurement(
+        'duration_finish',
+        watch.elapsedMilliseconds,
+        unit: DurationSentryMeasurementUnit.milliSecond,
       );
 
-      if (itemId == null) {
-        for (Rx<ChatItem> e in chat!.messages) {
-          _add(e);
-        }
-
-        _subscribeFor(chat: chat);
-
-        await chat!.around();
-
-        // Required in order for [Hive.boxEvents] to add the messages.
-        await Future.delayed(Duration.zero);
-
-        Rx<ChatItem>? firstUnread = _firstUnread;
-        _determineFirstUnread();
-
-        // Scroll to the last read message if [_firstUnread] was updated.
-        // Otherwise, [FlutterListViewDelegate.keepPosition] handles this as the
-        // last read item is already in the list.
-        if (firstUnread?.value.id != _firstUnread?.value.id) {
-          _scrollToLastRead();
-        }
-      } else {
-        await animateTo(itemId!);
-      }
-
-      if (welcome != null) {
-        chat!.addMessage(welcome!);
-      }
-
-      status.value = RxStatus.success();
-
-      if (_bottomLoader != null) {
-        showLoaders.value = false;
-
-        _bottomLoaderEndTimer = Timer(const Duration(milliseconds: 300), () {
-          if (_bottomLoader != null) {
-            elements.remove(_bottomLoader!.id);
-            _bottomLoader = null;
-            showLoaders.value = true;
-          }
-        });
-      }
-
-      if (_lastSeenItem.value != null) {
-        readChat(_lastSeenItem.value);
-      }
+      SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+    } catch (e) {
+      _ready.throwable = e;
+      _ready.finish(status: const SpanStatus.internalError());
+      rethrow;
     }
-
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      _ensureScrollable();
-    });
-
-    _ignorePositionChanges = false;
   }
 
   /// Returns an [User] from [UserService] by the provided [id].

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -353,8 +353,7 @@ class ChatController extends GetxController {
   /// Subscriptions to the [Paginated.updates].
   final List<StreamSubscription> _fragmentSubscriptions = [];
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this
-  /// [ChatController] readiness.
+  /// [Sentry] transaction monitoring this [ChatController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.chat.ready',
     'ui',

--- a/lib/ui/page/home/page/chat/info/controller.dart
+++ b/lib/ui/page/home/page/chat/info/controller.dart
@@ -22,6 +22,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:get/get.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '/domain/model/chat.dart';
 import '/domain/model/my_user.dart';
@@ -128,6 +129,14 @@ class ChatInfoController extends GetxController {
   /// Indicator whether the [_scrollListener] is already invoked during the
   /// current frame.
   bool _scrollIsInvoked = false;
+
+  /// [ISentrySpan] being a [Sentry] transaction monitoring this
+  /// [ChatInfoController] readiness.
+  final ISentrySpan _ready = Sentry.startTransaction(
+    'Ready',
+    'ui.chat_info',
+    autoFinishAfter: const Duration(minutes: 2),
+  );
 
   /// Returns [MyUser]'s [UserId].
   UserId? get me => _authService.userId;
@@ -374,43 +383,56 @@ class ChatInfoController extends GetxController {
   Future<void> _fetchChat() async {
     status.value = RxStatus.loading();
 
-    final FutureOr<RxChat?> fetched = _chatService.get(chatId);
-    chat = fetched is RxChat? ? fetched : await fetched;
+    try {
+      final FutureOr<RxChat?> fetched = _chatService.get(chatId);
+      chat = fetched is RxChat? ? fetched : await fetched;
 
-    if (chat == null) {
-      status.value = RxStatus.empty();
-    } else {
-      _chatSubscription = chat!.updates.listen((_) {});
+      if (chat == null) {
+        status.value = RxStatus.empty();
+      } else {
+        _chatSubscription = chat!.updates.listen((_) {});
 
-      name.unchecked = chat!.chat.value.name?.val;
+        name.unchecked = chat!.chat.value.name?.val;
 
-      _worker = ever(
-        chat!.chat,
-        (Chat chat) {
-          if (!name.focus.hasFocus &&
-              !name.changed.value &&
-              name.editable.value) {
-            name.unchecked = chat.name?.val;
+        _worker = ever(
+          chat!.chat,
+          (Chat chat) {
+            if (!name.focus.hasFocus &&
+                !name.changed.value &&
+                name.editable.value) {
+              name.unchecked = chat.name?.val;
+            }
+          },
+        );
+
+        _membersSubscription = chat!.members.items.changes.listen((event) {
+          switch (event.op) {
+            case OperationKind.added:
+            case OperationKind.updated:
+              // No-op.
+              break;
+
+            case OperationKind.removed:
+              _scrollListener();
+              break;
           }
-        },
-      );
+        });
 
-      _membersSubscription = chat!.members.items.changes.listen((event) {
-        switch (event.op) {
-          case OperationKind.added:
-          case OperationKind.updated:
-            // No-op.
-            break;
+        status.value = RxStatus.success();
 
-          case OperationKind.removed:
-            _scrollListener();
-            break;
-        }
-      });
+        _ready.setTag(
+          'members',
+          '${chat!.members.length >= chat!.members.perPage}',
+        );
 
-      status.value = RxStatus.success();
+        await chat!.members.around();
 
-      await chat!.members.around();
+        SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+      }
+    } catch (e) {
+      _ready.throwable = e;
+      _ready.finish(status: const SpanStatus.internalError());
+      rethrow;
     }
   }
 

--- a/lib/ui/page/home/page/chat/info/controller.dart
+++ b/lib/ui/page/home/page/chat/info/controller.dart
@@ -130,8 +130,7 @@ class ChatInfoController extends GetxController {
   /// current frame.
   bool _scrollIsInvoked = false;
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this
-  /// [ChatInfoController] readiness.
+  /// [Sentry] transaction monitoring this [ChatInfoController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.chat_info.ready',
     'ui',

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -19,9 +19,11 @@ import 'dart:async';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '/api/backend/schema.dart'
     show AddUserEmailErrorCode, AddUserPhoneErrorCode, Presence;
@@ -118,6 +120,14 @@ class MyProfileController extends GetxController {
   /// [Timer] resetting the [highlightIndex] value after the [_highlightTimeout]
   /// has passed.
   Timer? _highlightTimer;
+
+  /// [ISentrySpan] being a [Sentry] transaction monitoring this
+  /// [MyProfileController] readiness.
+  final ISentrySpan _ready = Sentry.startTransaction(
+    'Ready',
+    'ui.my_profile',
+    autoFinishAfter: const Duration(minutes: 2),
+  );
 
   /// Returns the currently authenticated [MyUser].
   Rx<MyUser?> get myUser => _myUserService.myUser;
@@ -300,6 +310,12 @@ class MyProfileController extends GetxController {
     scrollController.addListener(_ensureNameDisplayed);
 
     super.onInit();
+  }
+
+  @override
+  void onReady() {
+    SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+    super.onReady();
   }
 
   @override

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -124,10 +124,10 @@ class MyProfileController extends GetxController {
   /// [ISentrySpan] being a [Sentry] transaction monitoring this
   /// [MyProfileController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
-    'Ready',
-    'ui.my_profile',
+    'ui.my_profile.ready',
+    'ui',
     autoFinishAfter: const Duration(minutes: 2),
-  );
+  )..startChild('ready');
 
   /// Returns the currently authenticated [MyUser].
   Rx<MyUser?> get myUser => _myUserService.myUser;

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -121,8 +121,7 @@ class MyProfileController extends GetxController {
   /// has passed.
   Timer? _highlightTimer;
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this
-  /// [MyProfileController] readiness.
+  /// [Sentry] transaction monitoring this [MyProfileController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.my_profile.ready',
     'ui',

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -134,8 +134,7 @@ class UserController extends GetxController {
   /// Subscription for the [user] changes.
   StreamSubscription? _userSubscription;
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this
-  /// [UserController] readiness.
+  /// [Sentry] transaction monitoring this [UserController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.user.ready',
     'ui',

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -137,10 +137,10 @@ class UserController extends GetxController {
   /// [ISentrySpan] being a [Sentry] transaction monitoring this
   /// [UserController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
-    'Ready',
-    'ui.user',
+    'ui.user.ready',
+    'ui',
     autoFinishAfter: const Duration(minutes: 2),
-  );
+  )..startChild('ready');
 
   /// Indicates whether this [user] is blocked.
   BlocklistRecord? get isBlocked => user?.user.value.isBlocked;

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -85,8 +85,7 @@ class _HomeViewState extends State<HomeView> {
   /// [ChildBackButtonDispatcher] to get "Back" button in the nested [Router].
   late ChildBackButtonDispatcher _backButtonDispatcher;
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this [HomeView]
-  /// readiness.
+  /// [Sentry] transaction monitoring this [HomeView] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.home.ready',
     'ui',

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -88,10 +88,10 @@ class _HomeViewState extends State<HomeView> {
   /// [ISentrySpan] being a [Sentry] transaction monitoring this [HomeView]
   /// readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
-    'Ready',
-    'ui.home',
+    'ui.home.ready',
+    'ui',
     autoFinishAfter: const Duration(minutes: 2),
-  );
+  )..startChild('ready');
 
   @override
   void initState() {

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -19,7 +19,9 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:get/get.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '/domain/model/user.dart';
 import '/l10n/l10n.dart';
@@ -83,10 +85,22 @@ class _HomeViewState extends State<HomeView> {
   /// [ChildBackButtonDispatcher] to get "Back" button in the nested [Router].
   late ChildBackButtonDispatcher _backButtonDispatcher;
 
+  /// [ISentrySpan] being a [Sentry] transaction monitoring this [HomeView]
+  /// readiness.
+  final ISentrySpan _ready = Sentry.startTransaction(
+    'Ready',
+    'ui.home',
+    autoFinishAfter: const Duration(minutes: 2),
+  );
+
   @override
   void initState() {
     super.initState();
-    widget._depsFactory().then((v) => setState(() => _deps = v));
+
+    widget._depsFactory().then((v) {
+      setState(() => _deps = v);
+      SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+    });
   }
 
   @override

--- a/lib/ui/page/style/controller.dart
+++ b/lib/ui/page/style/controller.dart
@@ -36,8 +36,7 @@ class StyleController extends GetxController {
   /// [PageController] controlling the [PageView] of [StyleView].
   final PageController pages = PageController();
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this
-  /// [StyleController] readiness.
+  /// [Sentry] transaction monitoring this [StyleController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.style.ready',
     'ui',

--- a/lib/ui/page/style/controller.dart
+++ b/lib/ui/page/style/controller.dart
@@ -39,10 +39,10 @@ class StyleController extends GetxController {
   /// [ISentrySpan] being a [Sentry] transaction monitoring this
   /// [StyleController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
-    'Ready',
-    'ui.style',
+    'ui.style.ready',
+    'ui',
     autoFinishAfter: const Duration(minutes: 2),
-  );
+  )..startChild('ready');
 
   @override
   void onReady() {

--- a/lib/ui/page/style/controller.dart
+++ b/lib/ui/page/style/controller.dart
@@ -15,8 +15,10 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart' show PageController;
 import 'package:get/get.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// [StyleView] section.
 enum StyleTab { colors, typography, widgets, icons }
@@ -33,4 +35,18 @@ class StyleController extends GetxController {
 
   /// [PageController] controlling the [PageView] of [StyleView].
   final PageController pages = PageController();
+
+  /// [ISentrySpan] being a [Sentry] transaction monitoring this
+  /// [StyleController] readiness.
+  final ISentrySpan _ready = Sentry.startTransaction(
+    'Ready',
+    'ui.style',
+    autoFinishAfter: const Duration(minutes: 2),
+  );
+
+  @override
+  void onReady() {
+    SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+    super.onReady();
+  }
 }

--- a/lib/ui/page/work/controller.dart
+++ b/lib/ui/page/work/controller.dart
@@ -15,8 +15,10 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 export 'view.dart';
 
@@ -24,6 +26,20 @@ export 'view.dart';
 class WorkController extends GetxController {
   /// [ScrollController] to pass to a [Scrollbar].
   final ScrollController scrollController = ScrollController();
+
+  /// [ISentrySpan] being a [Sentry] transaction monitoring this
+  /// [WorkController] readiness.
+  final ISentrySpan _ready = Sentry.startTransaction(
+    'Ready',
+    'ui.work',
+    autoFinishAfter: const Duration(minutes: 2),
+  );
+
+  @override
+  void onReady() {
+    SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+    super.onReady();
+  }
 
   @override
   void onClose() {

--- a/lib/ui/page/work/controller.dart
+++ b/lib/ui/page/work/controller.dart
@@ -30,10 +30,10 @@ class WorkController extends GetxController {
   /// [ISentrySpan] being a [Sentry] transaction monitoring this
   /// [WorkController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
-    'Ready',
-    'ui.work',
+    'ui.work.ready',
+    'ui',
     autoFinishAfter: const Duration(minutes: 2),
-  );
+  )..startChild('ready');
 
   @override
   void onReady() {

--- a/lib/ui/page/work/controller.dart
+++ b/lib/ui/page/work/controller.dart
@@ -27,8 +27,7 @@ class WorkController extends GetxController {
   /// [ScrollController] to pass to a [Scrollbar].
   final ScrollController scrollController = ScrollController();
 
-  /// [ISentrySpan] being a [Sentry] transaction monitoring this
-  /// [WorkController] readiness.
+  /// [Sentry] transaction monitoring this [WorkController] readiness.
   final ISentrySpan _ready = Sentry.startTransaction(
     'ui.work.ready',
     'ui',

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -25,9 +25,9 @@ PODS:
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.21.0):
+  - FirebaseCoreInternal (10.23.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.21.0):
+  - FirebaseInstallations (10.23.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -48,27 +48,35 @@ PODS:
   - flutter_local_notifications (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - GoogleDataTransport (9.3.0):
+  - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.12.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.13.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.12.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (7.13.0):
+    - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.12.0):
+  - GoogleUtilities/Logger (7.13.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.12.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (7.13.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.12.0)"
-  - GoogleUtilities/Reachability (7.12.0):
+  - "GoogleUtilities/NSData+zlib (7.13.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (7.13.0)
+  - GoogleUtilities/Reachability (7.13.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.12.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (7.13.0):
     - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
   - just_audio (0.0.1):
     - FlutterMacOS
   - medea_flutter_webrtc (0.10.0-dev):
@@ -91,19 +99,19 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - PromisesObjC (2.3.1)
-  - ReachabilitySwift (5.0.0)
+  - PromisesObjC (2.4.0)
+  - ReachabilitySwift (5.2.1)
   - screen_brightness_macos (0.1.0):
     - FlutterMacOS
   - screen_retriever (0.0.1):
     - FlutterMacOS
-  - Sentry/HybridSDK (8.20.0):
-    - SentryPrivate (= 8.20.0)
+  - Sentry/HybridSDK (8.21.0):
+    - SentryPrivate (= 8.21.0)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.20.0)
-  - SentryPrivate (8.20.0)
+    - Sentry/HybridSDK (= 8.21.0)
+  - SentryPrivate (8.21.0)
   - share_plus (0.0.1):
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
@@ -222,15 +230,15 @@ SPEC CHECKSUMS:
   firebase_core: 2e1a33fd13fb581f0dc809c18be25cdc1a2e10db
   firebase_messaging: 0ea7ba8abbaa3228b36b1e64b5ad5268996b0d1a
   FirebaseCore: 28045c1560a2600d284b9c45a904fe322dc890b6
-  FirebaseCoreInternal: 43c1788eaeee9d1b97caaa751af567ce11010d00
-  FirebaseInstallations: 390ea1d10a4d02b20c965cbfd527ee9b3b412acb
+  FirebaseCoreInternal: 6a292e6f0bece1243a737e81556e56e5e19282e3
+  FirebaseInstallations: 42d6ead4605d6eafb3b6683674e80e18eb6f2c35
   FirebaseMessaging: 06c414a21b122396a26847c523d5c370f8325df5
   flutter_app_badger: 55a64b179f8438e89d574320c77b306e327a1730
   flutter_custom_cursor: 629957115075c672287bd0fa979d863ccf6024f7
   flutter_local_notifications: 3805ca215b2fb7f397d78b66db91f6a747af52e4
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  GoogleDataTransport: 57c22343ab29bc686febbf7cbb13bad167c2d8fe
-  GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
+  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
+  GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
   just_audio: 9b67ca7b97c61cfc9784ea23cd8cc55eb226d489
   medea_flutter_webrtc: 08f036f87205586e697455da2e2ee778eb6271ef
   medea_jason: b3355be56a78da19da91aee19a3ac56356d18997
@@ -240,13 +248,13 @@ SPEC CHECKSUMS:
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
-  PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  ReachabilitySwift: 5ae15e16814b5f9ef568963fb2c87aeb49158c66
   screen_brightness_macos: 2d6d3af2165592d9a55ffcd95b7550970e41ebda
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
-  Sentry: a8d7b373b9f9868442b02a0c425192f693103cbf
-  sentry_flutter: 03e7660857a8cdb236e71456a7e8447b65c8a788
-  SentryPrivate: 006b24af16828441f70e2ab6adf241bd0a8ad130
+  Sentry: ebc12276bd17613a114ab359074096b6b3725203
+  sentry_flutter: dff1df05dc39c83d04f9330b36360fc374574c5e
+  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1619,10 +1619,10 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: d2ee9c850d876d285f22e2e662f400ec2438df9939fe4acd5d780df9841794ce
+      sha256: a460aa48568d47140dd0557410b624d344ffb8c05555107ac65035c1097cf1ad
       url: "https://pub.dev"
     source: hosted
-    version: "7.16.1"
+    version: "7.18.0"
   sentry_dart_plugin:
     dependency: "direct dev"
     description:
@@ -1635,10 +1635,10 @@ packages:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "5b428c189c825f16fb14e9166529043f06b965d5b59bfc3a1415e39c082398c0"
+      sha256: "3d0d1d4e0e407d276ae8128d123263ccbc37e988bae906765efd6f37d544f4c6"
       url: "https://pub.dev"
     source: hosted
-    version: "7.16.1"
+    version: "7.18.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ dependencies:
     git:
       url: https://github.com/SleepySquash/scrollable_positioned_list
       path: packages/scrollable_positioned_list/
-  sentry_flutter: ^7.9.0
+  sentry_flutter: ^7.18.0
   share_plus: ^7.0.0
   shared_preferences: ^2.0.18
   sliding_up_panel: ^2.0.0+1

--- a/test/e2e/mock/graphql.dart
+++ b/test/e2e/mock/graphql.dart
@@ -130,6 +130,7 @@ class MockGraphQlClient extends GraphQlClient {
   Future<dio.Response<T>> post<T>(
     dynamic data, {
     dio.Options? options,
+    String? operationName,
     Exception Function(Map<String, dynamic>)? onException,
     void Function(int, int)? onSendProgress,
   }) async {


### PR DESCRIPTION
## Synopsis

Sentry has metrics, and application should utilize them to better understand its performance.




## Solution

This PR adds metrics for GraphQL operations and for `Chat`/`User` page readiness.

The naming of the transactions is taken from [Sentry JavaScript guidelines](https://docs.sentry.io/platforms/javascript/enriching-events/transaction-name/) and looks like that:
- `graphql.RecentChats()`
- `graphql.SignIn()`
- `ui.chat.ready`
- `ui.app.ready`

`graphql` transactions are about GraphQL layer, and `ui` ones are about UI.

Here's what the transactions look like:

<img width="1339" alt="Снимок экрана 2024-03-27 в 15 31 38" src="https://github.com/team113/messenger/assets/21217248/8c876fc8-dfa0-44ff-bfc7-29c168a29d6f">

Some transactions (`ui.chat.ready` and `ui.direct_link.ready`) have spans:

<img width="1004" alt="Снимок экрана 2024-03-27 в 15 32 59" src="https://github.com/team113/messenger/assets/21217248/93b9efc3-470c-47be-80ee-bacf51365ef2">





## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
