### PR TITLE
Flaky local to remote `Chat` transition E2E test (#922)

### DIFF
--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -2161,10 +2161,11 @@ class ChatRepository extends DisposableInterface
             final HiveRxChat? localChat = chats[localId];
 
             if (localChat != null) {
+              await localChat.updateChat(data.chat);
+
               chats.move(localId, chatId);
               paginated.move(localId, chatId);
 
-              await localChat.updateChat(data.chat);
               entry = localChat;
             }
 

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -995,19 +995,6 @@ class HiveRxChat extends RxChat {
             }
           }
 
-          // If [Chat.lastItem] has changed during the query then set
-          // [PageInfo.hasNext] to `true`.
-          if (page.info.hasNext == false &&
-              page.edges.isNotEmpty &&
-              chat.value.lastItem != null &&
-              page.edges.last.value.at.isBefore(chat.value.lastItem!.at)) {
-            if (_provider.graphQlProvider.reversed) {
-              reversed.info.hasPrevious = true;
-            } else {
-              reversed.info.hasNext = true;
-            }
-          }
-
           return reversed;
         },
       ),

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -853,17 +853,23 @@ class HiveRxChat extends RxChat {
       // Retrieve all the [HiveChatItem]s to put them in the [newChat].
       final Iterable<HiveChatItem> saved = await _local.values;
 
-      // Clear and close the current [ChatItemHiveProvider].
-      await clear();
+      final local = ChatItemHiveProvider(id);
+      await local.init(userId: me);
+
+      final sorting = ChatItemSortingHiveProvider(id);
+      await sorting.init(userId: me);
+
+      // Clear and close the current [Hive] providers.
+      await _local.clear();
+      await _sorting.clear();
       _local.close();
       _sorting.close();
 
-      _local = ChatItemHiveProvider(id);
-      await _local.init(userId: me);
-      _provider.hive = _local;
+      await clear();
 
-      _sorting = ChatItemSortingHiveProvider(id);
-      await _sorting.init(userId: me);
+      _local = local;
+      _sorting = sorting;
+      _provider.hive = _local;
 
       for (var e in saved.whereType<HiveChatMessage>()) {
         // Copy the [HiveChatMessage] to the new [ChatItemHiveProvider].

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -1300,7 +1300,7 @@ class HiveRxChat extends RxChat {
       _muteTimer = Timer(
         chat.value.muted!.until!.val.difference(DateTime.now()),
         () async {
-          _chatLocal.txn((txn) async {
+          await _chatLocal.txn((txn) async {
             final HiveChat? chat = await txn.get(id.val);
             if (chat != null) {
               chat.value.muted = null;
@@ -1511,7 +1511,7 @@ class HiveRxChat extends RxChat {
       case ChatEventsKind.chat:
         Log.debug('_chatEvent(${event.kind})', '$runtimeType($id)');
         final node = event as ChatEventsChat;
-        _chatLocal.txn((txn) async {
+        await _chatLocal.txn((txn) async {
           final HiveChat? chatEntity = await txn.get(id.val);
           if (chatEntity != null) {
             chatEntity.value = node.chat.value;

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -877,7 +877,7 @@ class HiveRxChat extends RxChat {
         put(copy, ignoreBounds: true);
       }
 
-      _pagination.around();
+      await _pagination.around();
     }
   }
 
@@ -986,6 +986,19 @@ class HiveRxChat extends RxChat {
                 chatEntity.value.firstItem != firstItem) {
               chatEntity.value.firstItem = firstItem;
               _chatLocal.put(chatEntity);
+            }
+          }
+
+          // If [Chat.lastItem] has changed during the query then set
+          // [PageInfo.hasNext] to `true`.
+          if (page.info.hasNext == false &&
+              page.edges.isNotEmpty &&
+              chat.value.lastItem != null &&
+              page.edges.last.value.at.isBefore(chat.value.lastItem!.at)) {
+            if (_provider.graphQlProvider.reversed) {
+              reversed.info.hasPrevious = true;
+            } else {
+              reversed.info.hasNext = true;
             }
           }
 

--- a/lib/store/pagination.dart
+++ b/lib/store/pagination.dart
@@ -367,7 +367,7 @@ class Pagination<T, C, K> {
       items.remove(key);
     });
 
-    return provider.remove(key);
+    await provider.remove(key);
   }
 }
 

--- a/lib/store/pagination.dart
+++ b/lib/store/pagination.dart
@@ -327,6 +327,10 @@ class Pagination<T, C, K> {
     bool put = ignoreBounds;
 
     if (!put) {
+      // Wait for [items] fetching before putting a new one.
+      await _guard.protect(() async => null);
+      await _nextGuard.protect(() async => null);
+      await _previousGuard.protect(() async => null);
       if (items.isEmpty) {
         put = hasNext.isFalse && hasPrevious.isFalse;
       } else if (compare?.call(item, items.last) == 1) {

--- a/lib/store/pagination.dart
+++ b/lib/store/pagination.dart
@@ -84,6 +84,9 @@ class Pagination<T, C, K> {
   /// [Mutex] guarding synchronized access to the [previous].
   final Mutex _previousGuard = Mutex();
 
+  /// [Mutex] guarding synchronized access to the [put] and [remove].
+  final Mutex _itemsGuard = Mutex();
+
   /// [CancelToken] for cancelling [init], [around], [next] and [previous]
   /// query.
   final CancelToken _cancelToken = CancelToken();
@@ -327,19 +330,22 @@ class Pagination<T, C, K> {
     bool put = ignoreBounds;
 
     if (!put) {
-      // Wait for [items] fetching before putting a new one.
-      await _guard.protect(() async => null);
-      await _nextGuard.protect(() async => null);
-      await _previousGuard.protect(() async => null);
-      if (items.isEmpty) {
-        put = hasNext.isFalse && hasPrevious.isFalse;
-      } else if (compare?.call(item, items.last) == 1) {
-        put = hasNext.isFalse;
-      } else if (compare?.call(item, items.first) == -1) {
-        put = hasPrevious.isFalse;
-      } else {
-        put = true;
-      }
+      await _itemsGuard.protect(() async {
+        // Wait for [items] fetching before putting a new one.
+        await _guard.protect(() async => null);
+        await _nextGuard.protect(() async => null);
+        await _previousGuard.protect(() async => null);
+
+        if (items.isEmpty) {
+          put = hasNext.isFalse && hasPrevious.isFalse;
+        } else if (compare?.call(item, items.last) == 1) {
+          put = hasNext.isFalse;
+        } else if (compare?.call(item, items.first) == -1) {
+          put = hasPrevious.isFalse;
+        } else {
+          put = true;
+        }
+      });
     }
 
     if (put) {
@@ -350,14 +356,17 @@ class Pagination<T, C, K> {
   }
 
   /// Removes the item with the provided [key] from the [items] and [provider].
-  Future<void> remove(K key) {
+  Future<void> remove(K key) async {
     Log.debug('remove($key)', '$runtimeType');
 
     if (_disposed) {
       return Future.value();
     }
 
-    items.remove(key);
+    await _itemsGuard.protect(() async {
+      items.remove(key);
+    });
+
     return provider.remove(key);
   }
 }

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -1797,6 +1797,7 @@ class ChatController extends GetxController {
 
           case OperationKind.removed:
             _remove(e.element.value);
+            _ensureScrollable();
             break;
         }
       });
@@ -1810,6 +1811,7 @@ class ChatController extends GetxController {
 
           case OperationKind.removed:
             _remove(e.value!.value);
+            _ensureScrollable();
             break;
         }
       });

--- a/lib/util/obs/sorted_map.dart
+++ b/lib/util/obs/sorted_map.dart
@@ -91,6 +91,6 @@ class SortedObsMap<K, V> extends MapMixin<K, V> {
       return compare;
     }
 
-    return (_, __) => 1;
+    return (_, __) => -1;
   }
 }

--- a/test/widget/chat_update_attachments_test.dart
+++ b/test/widget/chat_update_attachments_test.dart
@@ -627,6 +627,13 @@ void main() async {
         .chats[const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b')]!;
     await tester
         .runAsync(() => chat.updateAttachments(chat.messages.first.value));
+
+    // TODO: This waits for lazy [Hive] boxes to finish receiving events, which
+    //       should be done in a more strict way.
+    for (int i = 0; i < 20; i++) {
+      await tester.pump(const Duration(seconds: 2));
+      await tester.runAsync(() => Future.delayed(1.milliseconds));
+    }
     await tester.pumpAndSettle(const Duration(seconds: 2));
 
     expect(


### PR DESCRIPTION
Resolves #922



## Synopsis

E2E тест `Message can be posted in local dialog` иногда падает.




## Solution

Проблема будет исправлена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
