### PR TITLE
Bootstrap performance reporting in E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,13 +556,6 @@ jobs:
               "\\[CONFIG\\]: Remote configuration fetch failed"
             ]
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: e2e-perf-${{ github.run_number }}
-          path: test/e2e/reports/*.timeline_summary.json
-          if-no-files-found: warn
-          retention-days: 1
-
       # Grant permissions to `.cache/` dir created in the previous step, since
       # `hashFile` may fail: https://github.com/actions/runner/issues/449
       - run: sudo chmod -R 755 .cache/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,6 +556,13 @@ jobs:
               "\\[CONFIG\\]: Remote configuration fetch failed"
             ]
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: e2e-perf-${{ github.run_number }}
+          path: test/e2e/reports/*.timeline_summary.json
+          if-no-files-found: warn
+          retention-days: 1
+
       # Grant permissions to `.cache/` dir created in the previous step, since
       # `hashFile` may fail: https://github.com/actions/runner/issues/449
       - run: sudo chmod -R 755 .cache/

--- a/test/e2e/configuration.dart
+++ b/test/e2e/configuration.dart
@@ -29,6 +29,7 @@ import 'package:messenger/main.dart' as app;
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/util/platform_utils.dart';
 
+import 'hook/performance.dart';
 import 'hook/reset_app.dart';
 import 'mock/graphql.dart';
 import 'mock/platform_utils.dart';
@@ -281,7 +282,7 @@ final FlutterTestConfiguration gherkinTestConfiguration =
         waitUntilKeyExists,
         waitUntilMessageStatus,
       ]
-      ..hooks = [ResetAppHook()]
+      ..hooks = [ResetAppHook(), PerformanceHook()]
       ..reporters = [
         StdoutReporter(MessageLevel.verbose)
           ..setWriteLineFn(print)

--- a/test/e2e/configuration.dart
+++ b/test/e2e/configuration.dart
@@ -212,6 +212,7 @@ final FlutterTestConfiguration gherkinTestConfiguration =
         rightClickWidget,
         scrollAndSee,
         scrollToBottom,
+        scrollToTop,
         scrollUntilPresent,
         seeBlockedUsers,
         seeChatAsDismissed,

--- a/test/e2e/configuration.dart
+++ b/test/e2e/configuration.dart
@@ -282,7 +282,13 @@ final FlutterTestConfiguration gherkinTestConfiguration =
         waitUntilKeyExists,
         waitUntilMessageStatus,
       ]
-      ..hooks = [ResetAppHook(), PerformanceHook()]
+      ..hooks = [
+        ResetAppHook(),
+
+        // [IntegrationTestWidgetsFlutterBinding.traceAction] being used is only
+        // supported on Dart VM platforms.
+        if (!PlatformUtils.isWeb) PerformanceHook(),
+      ]
       ..reporters = [
         StdoutReporter(MessageLevel.verbose)
           ..setWriteLineFn(print)

--- a/test/e2e/features/user/blocklist/.feature
+++ b/test/e2e/features/user/blocklist/.feature
@@ -29,5 +29,6 @@ Feature: Blocklist
     And I tap `Proceed` button
     Then Bob sends message to me and receives blocked exception
 
-    When I tap `Unblock` button
+    When I scroll `UserScrollable` to top
+    And I tap `Unblock` button
     Then Bob sends message to me and receives no exception

--- a/test/e2e/hook/performance.dart
+++ b/test/e2e/hook/performance.dart
@@ -1,0 +1,84 @@
+// Copyright © 2022-2024 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:async';
+
+import 'package:gherkin/gherkin.dart';
+import 'package:integration_test/integration_test.dart';
+
+/// [Hook] gathering performance results of a test.
+class PerformanceHook extends Hook {
+  /// [Completer] measuring the performance between [onBeforeScenario] and
+  /// [onAfterScenario].
+  Completer? _completer;
+
+  /// [Future]s of the [IntegrationTestWidgetsFlutterBinding.traceAction].
+  final List<Future> _futures = [];
+
+  Map<String, dynamic>? _data;
+
+  @override
+  int get priority => 0;
+
+  @override
+  Future<void> onBeforeScenario(
+    TestConfiguration config,
+    String scenario,
+    Iterable<Tag> tags,
+  ) async {
+    if (!(_completer?.isCompleted ?? true)) {
+      _completer?.completeError(TimeoutException('Next scenario is being run'));
+    }
+
+    _completer = Completer();
+
+    _futures.add(
+      IntegrationTestWidgetsFlutterBinding.instance.traceAction(
+        () => _completer!.future,
+        reportKey: scenario.asPath,
+      ),
+    );
+  }
+
+  @override
+  Future<void> onAfterScenario(
+    TestConfiguration config,
+    String scenario,
+    Iterable<Tag> tags,
+  ) async {
+    _completer?.complete();
+    _completer = null;
+
+    await Future.wait(_futures);
+    _data = IntegrationTestWidgetsFlutterBinding.instance.reportData;
+  }
+
+  @override
+  Future<void> onAfterRun(TestConfiguration config) async {
+    if (_data != null) {
+      IntegrationTestWidgetsFlutterBinding.instance.reportData?.addAll(_data!);
+    }
+  }
+}
+
+/// Extension adding method removing any prohibited for filename symbols.
+extension on String {
+  /// Returns this [String] with any prohibited for a filename symbols removed.
+  String get asPath {
+    return replaceAll(' ', '_').replaceAll('\'', '_').replaceAll('"', '_');
+  }
+}

--- a/test/e2e/hook/performance.dart
+++ b/test/e2e/hook/performance.dart
@@ -19,6 +19,7 @@ import 'dart:async';
 
 import 'package:gherkin/gherkin.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:messenger/config.dart';
 
 /// [Hook] gathering performance results of a test.
 ///
@@ -82,7 +83,10 @@ class PerformanceHook extends Hook {
   @override
   Future<void> onAfterRun(TestConfiguration config) async {
     if (_data.isNotEmpty) {
-      IntegrationTestWidgetsFlutterBinding.instance.reportData?.addAll(_data);
+      IntegrationTestWidgetsFlutterBinding.instance.reportData?['traces'] =
+          _data;
+      IntegrationTestWidgetsFlutterBinding.instance.reportData?['level'] =
+          Config.logLevel.index;
     }
   }
 }

--- a/test/e2e/hook/reset_app.dart
+++ b/test/e2e/hook/reset_app.dart
@@ -25,6 +25,7 @@ import 'package:hive/hive.dart';
 import 'package:messenger/main.dart';
 import 'package:messenger/ui/worker/cache.dart';
 import 'package:messenger/util/platform_utils.dart';
+import 'package:universal_io/io.dart';
 
 import '../steps/internet.dart';
 
@@ -48,7 +49,13 @@ class ResetAppHook extends Hook {
         .removeWhere((e) => e is DelayedInterceptor);
 
     await Future.delayed(Duration.zero);
-    await Hive.close();
+
+    try {
+      await Hive.close();
+    } on PathNotFoundException {
+      // `.lock` file might not exist here, so no-op.
+    }
+
     await Hive.clean('hive');
 
     svg.cache.clear();

--- a/test/e2e/steps/scroll_until.dart
+++ b/test/e2e/steps/scroll_until.dart
@@ -61,38 +61,60 @@ final StepDefinitionGeneric<CustomWorld> scrollUntilPresent =
   },
 );
 
-/// Scrolls the provided [Scrollable] to bottom.
+/// Scrolls the provided [Scrollable] to the bottom.
 ///
 /// Examples:
 /// - Then I scroll `Menu` to bottom
 final StepDefinitionGeneric<CustomWorld> scrollToBottom =
     then1<WidgetKey, CustomWorld>(
   RegExp(r'I scroll {key} to bottom'),
-  (WidgetKey list, StepContext<CustomWorld> context) async {
-    await context.world.appDriver.waitForAppToSettle();
-
-    Finder scrollable = find.descendant(
-      of: find.byKey(Key(list.name)),
-      matching: find.byWidgetPredicate((widget) {
-        // TODO: Find a proper way to differentiate [Scrollable]s from
-        //       [TextField]s:
-        //       https://github.com/flutter/flutter/issues/76981
-        if (widget is Scrollable) {
-          return widget.restorationId == null;
-        }
-        return false;
-      }),
-    );
-
-    final ScrollableState state = context.world.appDriver.nativeDriver
-        .state(scrollable) as ScrollableState;
-    final ScrollPosition position = state.position;
-
-    position.jumpTo(position.maxScrollExtent);
-
-    await context.world.appDriver.waitForAppToSettle();
+  (WidgetKey key, StepContext<CustomWorld> context) async {
+    await _scrollScrollableTo(key, context, (p) => p.maxScrollExtent);
   },
 );
+
+/// Scrolls the provided [Scrollable] to the top.
+///
+/// Examples:
+/// - Then I scroll `Menu` to top
+final StepDefinitionGeneric<CustomWorld> scrollToTop =
+    then1<WidgetKey, CustomWorld>(
+  RegExp(r'I scroll {key} to top'),
+  (WidgetKey key, StepContext<CustomWorld> context) async {
+    await _scrollScrollableTo(key, context, (_) => 0);
+  },
+);
+
+/// Scrolls the [Scrollable] identified by its [key] to the specified in the
+/// [getPosition] position.
+Future<void> _scrollScrollableTo(
+  WidgetKey key,
+  StepContext<CustomWorld> context,
+  double Function(ScrollPosition) getPosition,
+) async {
+  await context.world.appDriver.waitForAppToSettle();
+
+  final Finder scrollable = find.descendant(
+    of: find.byKey(Key(key.name)),
+    matching: find.byWidgetPredicate((widget) {
+      // TODO: Find a proper way to differentiate [Scrollable]s from
+      //       [TextField]s:
+      //       https://github.com/flutter/flutter/issues/76981
+      if (widget is Scrollable) {
+        return widget.restorationId == null;
+      }
+      return false;
+    }),
+  );
+
+  final ScrollableState state =
+      context.world.appDriver.nativeDriver.state(scrollable) as ScrollableState;
+  final ScrollPosition position = state.position;
+
+  position.jumpTo(getPosition(position));
+
+  await context.world.appDriver.waitForAppToSettle();
+}
 
 /// Extension fixing the [AppDriverAdapter.scrollUntilVisible] by adding its
 /// replacement.

--- a/test_driver/integration_test_driver.dart
+++ b/test_driver/integration_test_driver.dart
@@ -38,5 +38,34 @@ Future<void> main() {
 
   return integration_test_driver.integrationDriver(
     timeout: const Duration(minutes: 30),
+    responseDataCallback: (data) async {
+      for (var e in data?.entries ?? <MapEntry<String, dynamic>>[]) {
+        if (e.value is! Map<String, dynamic>) {
+          continue;
+        }
+
+        final Timeline timeline = Timeline.fromJson(
+          e.value as Map<String, dynamic>,
+        );
+
+        // Convert the [Timeline] into a [TimelineSummary] that's easier to read
+        // and understand.
+        final summary = TimelineSummary.summarize(timeline);
+
+        // Then, write the entire timeline to disk in a json format.
+        //
+        // This file can be opened in the Chrome browser's tracing tools found
+        // by navigating to chrome://tracing.
+        //
+        // Optionally, save the summary to disk by setting `includeSummary` to
+        // `true`.
+        await summary.writeTimelineToFile(
+          e.key,
+          destinationDirectory: 'test/e2e/reports',
+          pretty: true,
+          includeSummary: true,
+        );
+      }
+    },
   );
 }


### PR DESCRIPTION
Requires #424




## Synopsis

Performance should be logged and measured.




## Solution

This PR adds such measurements for E2E tests. Each measurement is specific to scenario, and the generated reports are stored in the `test/e2e/reports` directory. Afterwards in the following PRs those reports should be gathered on the CI and somehow should be compared.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
