### PR TITLE
Fix `Dock.onReorder()` callback not including added `CallButton`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All user visible changes to this project will be documented in this file. This p
         - Missing bottom mobile paddings. ([#886], [#821])
     - Media panel:
         - Missing bottom mobile paddings in panel. ([#886], [#821])
+        - Call buttons positions not being persisted. ([#932])
     - Chat page:
         - Images displayed with vertical gaps on narrow screens. ([#901], [#888])
         - Messages marked as read when gallery is opened. ([#897], [#854])
@@ -73,6 +74,7 @@ All user visible changes to this project will be documented in this file. This p
 [#914]: /../../pull/914
 [#915]: /../../pull/915
 [#919]: /../../pull/919
+[#932]: /../../pull/932
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ All user visible changes to this project will be documented in this file. This p
         - Missing bottom mobile paddings. ([#886], [#821])
     - Media panel:
         - Missing bottom mobile paddings in panel. ([#886], [#821])
-        - Call buttons positions not being persisted. ([#932])
     - Chat page:
         - Images displayed with vertical gaps on narrow screens. ([#901], [#888])
         - Messages marked as read when gallery is opened. ([#897], [#854])
@@ -74,7 +73,6 @@ All user visible changes to this project will be documented in this file. This p
 [#914]: /../../pull/914
 [#915]: /../../pull/915
 [#919]: /../../pull/919
-[#932]: /../../pull/932
 
 
 

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -357,8 +357,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                 hinted: c.draggedButton.value == null,
               ),
               onReorder: (buttons) {
-                c.buttons.clear();
-                c.buttons.addAll(buttons);
+                c.buttons.value = buttons;
                 c.relocateSecondary();
               },
               onDragStarted: (b) {

--- a/lib/ui/page/call/widget/dock.dart
+++ b/lib/ui/page/call/widget/dock.dart
@@ -425,6 +425,7 @@ class _DockState<T extends Object> extends State<Dock<T>> {
               _items.insert(to, data);
               _populateExpandedKeys();
               widget.onDragEnded?.call(_items[to].item);
+              widget.onReorder?.call(_items.map((e) => e.item).toList());
             });
           }
         },
@@ -470,13 +471,12 @@ class _DockState<T extends Object> extends State<Dock<T>> {
               _items.insert(to, data);
               _populateExpandedKeys();
               _compressed = -1;
+              widget.onReorder?.call(_items.map((e) => e.item).toList());
             });
           }
         },
       );
     }
-
-    widget.onReorder?.call(_items.map((e) => e.item).toList());
   }
 
   /// Calculates the position to drop the provided item at.


### PR DESCRIPTION
## Synopsis

`Dock.onReorder()` reports invalid `CallButton`s: the new added ones are missing from that list. This causes `CallButton`s persistence to be buggy.




## Solution

This PR fixes the callback by moving its invoke after the `_animate()` is fired.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
