### PR TITLE
Display `ImageFilter.blur`ed images in narrow `MediaAttachment`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Chat page:
         - Redesigned editing mode and actions. ([#868])
+        - Blurred previews under wide/narrow images. ([#934])
     - User page:
         - Redesigned editing mode and actions. ([#868])
     - Profile page:
@@ -73,6 +74,7 @@ All user visible changes to this project will be documented in this file. This p
 [#914]: /../../pull/914
 [#915]: /../../pull/915
 [#919]: /../../pull/919
+[#934]: /../../pull/934
 
 
 

--- a/lib/provider/hive/application_settings.dart
+++ b/lib/provider/hive/application_settings.dart
@@ -42,14 +42,14 @@ class ApplicationSettingsHiveProvider
 
   /// Saves the provided [ApplicationSettings] in [Hive].
   Future<void> set(ApplicationSettings settings) async {
-    Log.debug('set($settings)', '$runtimeType');
+    Log.trace('set($settings)', '$runtimeType');
     await putSafe(0, settings);
   }
 
   /// Stores a new [enabled] value of [ApplicationSettings.enablePopups] to
   /// [Hive].
   Future<void> setPopupsEnabled(bool enabled) async {
-    Log.debug('setPopupsEnabled($enabled)', '$runtimeType');
+    Log.trace('setPopupsEnabled($enabled)', '$runtimeType');
 
     await putSafe(
       0,
@@ -59,14 +59,14 @@ class ApplicationSettingsHiveProvider
 
   /// Stores a new [locale] value of [ApplicationSettings.locale] to [Hive].
   Future<void> setLocale(String locale) async {
-    Log.debug('setLocale($locale)', '$runtimeType');
+    Log.trace('setLocale($locale)', '$runtimeType');
     await putSafe(0, (box.get(0) ?? ApplicationSettings())..locale = locale);
   }
 
   /// Stores a new [show] value of [ApplicationSettings.showIntroduction] to
   /// [Hive].
   Future<void> setShowIntroduction(bool show) async {
-    Log.debug('setShowIntroduction($show)', '$runtimeType');
+    Log.trace('setShowIntroduction($show)', '$runtimeType');
 
     await putSafe(
       0,
@@ -77,7 +77,7 @@ class ApplicationSettingsHiveProvider
   /// Stores a new [width] value of [ApplicationSettings.sideBarWidth] to
   /// [Hive].
   Future<void> setSideBarWidth(double width) async {
-    Log.debug('setSideBarWidth($width)', '$runtimeType');
+    Log.trace('setSideBarWidth($width)', '$runtimeType');
 
     await putSafe(
       0,
@@ -88,7 +88,7 @@ class ApplicationSettingsHiveProvider
   /// Stores a new [buttons] value of [ApplicationSettings.callButtons] to
   /// [Hive].
   Future<void> setCallButtons(List<String> buttons) async {
-    Log.debug('setCallButtons($buttons)', '$runtimeType');
+    Log.trace('setCallButtons($buttons)', '$runtimeType');
 
     await putSafe(
       0,
@@ -99,7 +99,7 @@ class ApplicationSettingsHiveProvider
   /// Stores a new [show] value of
   /// [ApplicationSettings.showDragAndDropVideosHint] to [Hive].
   Future<void> setShowDragAndDropVideosHint(bool show) async {
-    Log.debug('setShowDragAndDropVideosHint($show)', '$runtimeType');
+    Log.trace('setShowDragAndDropVideosHint($show)', '$runtimeType');
 
     await putSafe(
       0,
@@ -110,7 +110,7 @@ class ApplicationSettingsHiveProvider
   /// Stores a new [show] value of
   /// [ApplicationSettings.showDragAndDropButtonsHint] to [Hive].
   Future<void> setShowDragAndDropButtonsHint(bool show) async {
-    Log.debug('setShowDragAndDropButtonsHint($show)', '$runtimeType');
+    Log.trace('setShowDragAndDropButtonsHint($show)', '$runtimeType');
 
     await putSafe(
       0,
@@ -121,7 +121,7 @@ class ApplicationSettingsHiveProvider
   /// Stores a new [buttons] value of [ApplicationSettings.pinnedActions] to
   /// [Hive].
   Future<void> setPinnedActions(List<String> buttons) async {
-    Log.debug('setPinnedActions($buttons)', '$runtimeType');
+    Log.trace('setPinnedActions($buttons)', '$runtimeType');
 
     await putSafe(
       0,
@@ -132,7 +132,7 @@ class ApplicationSettingsHiveProvider
   /// Stores a new [position] value of
   /// [ApplicationSettings.callButtonsPosition] to [Hive].
   Future<void> setCallButtonsPosition(CallButtonsPosition position) async {
-    Log.debug('setCallButtonsPosition($position)', '$runtimeType');
+    Log.trace('setCallButtonsPosition($position)', '$runtimeType');
 
     await putSafe(
       0,
@@ -143,7 +143,7 @@ class ApplicationSettingsHiveProvider
   /// Stores a new [enabled] value of [ApplicationSettings.workWithUsTabEnabled]
   /// to [Hive].
   Future<void> setWorkWithUsTabEnabled(bool enabled) async {
-    Log.debug('setWorkWithUsTabEnabled($enabled)', '$runtimeType');
+    Log.trace('setWorkWithUsTabEnabled($enabled)', '$runtimeType');
 
     await putSafe(
       0,

--- a/lib/provider/hive/background.dart
+++ b/lib/provider/hive/background.dart
@@ -44,13 +44,13 @@ class BackgroundHiveProvider extends HiveBaseProvider<HiveBackground> {
 
   /// Saves the provided [Uint8List] to [Hive].
   Future<void> set(Uint8List bytes) async {
-    Log.debug('set(${bytes.length})', '$runtimeType');
+    Log.trace('set(${bytes.length})', '$runtimeType');
     await putSafe(0, HiveBackground(bytes));
   }
 
   /// Deletes the stored [Uint8List].
   Future<void> delete() async {
-    Log.debug('delete()', '$runtimeType');
+    Log.trace('delete()', '$runtimeType');
     await deleteSafe(0);
   }
 }

--- a/lib/provider/hive/blocklist.dart
+++ b/lib/provider/hive/blocklist.dart
@@ -55,19 +55,19 @@ class BlocklistHiveProvider extends HiveLazyProvider<HiveBlocklistRecord>
 
   @override
   Future<void> put(HiveBlocklistRecord record) async {
-    Log.debug('put($record)', '$runtimeType');
+    Log.trace('put($record)', '$runtimeType');
     await putSafe(record.value.userId.val, record);
   }
 
   @override
   Future<HiveBlocklistRecord?> get(UserId id) async {
-    Log.debug('get($id)', '$runtimeType');
+    Log.trace('get($id)', '$runtimeType');
     return getSafe(id.val);
   }
 
   @override
   Future<void> remove(UserId id) async {
-    Log.debug('remove($id)', '$runtimeType');
+    Log.trace('remove($id)', '$runtimeType');
     await deleteSafe(id.val);
   }
 }

--- a/lib/provider/hive/blocklist_sorting.dart
+++ b/lib/provider/hive/blocklist_sorting.dart
@@ -46,7 +46,7 @@ class BlocklistSortingHiveProvider extends HiveBaseProvider<UserId> {
 
   /// Puts the provided [UserId] by the provided [key] to [Hive].
   Future<void> put(PreciseDateTime key, UserId item) async {
-    Log.debug('put($key, $item)', '$runtimeType');
+    Log.trace('put($key, $item)', '$runtimeType');
 
     final String i = '${key.toUtc().toString()}_$item';
 
@@ -64,7 +64,7 @@ class BlocklistSortingHiveProvider extends HiveBaseProvider<UserId> {
 
   /// Removes the provided [UserId] from [Hive].
   Future<void> remove(UserId item) async {
-    Log.debug('remove($item)', '$runtimeType');
+    Log.trace('remove($item)', '$runtimeType');
 
     await _mutex.protect(() async {
       final int index = values.toList().indexOf(item);

--- a/lib/provider/hive/call_credentials.dart
+++ b/lib/provider/hive/call_credentials.dart
@@ -44,21 +44,21 @@ class CallCredentialsHiveProvider
 
   /// Puts the provided [ChatCallCredentials] to [Hive].
   Future<void> put(ChatItemId id, ChatCallCredentials creds) async {
-    Log.debug('put($id, $creds)', '$runtimeType');
+    Log.trace('put($id, $creds)', '$runtimeType');
     await putSafe(id.val, creds);
   }
 
   /// Returns the [ChatCallCredentials] from [Hive] by the provided
   /// [ChatItemId].
   ChatCallCredentials? get(ChatItemId id) {
-    Log.debug('get($id)', '$runtimeType');
+    Log.trace('get($id)', '$runtimeType');
     return getSafe(id.val);
   }
 
   /// Removes the [ChatCallCredentials] from [Hive] by the provided
   /// [ChatItemId].
   Future<void> remove(ChatItemId id) async {
-    Log.debug('remove($id)', '$runtimeType');
+    Log.trace('remove($id)', '$runtimeType');
     await deleteSafe(id.val);
   }
 }

--- a/lib/provider/hive/call_rect.dart
+++ b/lib/provider/hive/call_rect.dart
@@ -38,13 +38,13 @@ class CallRectHiveProvider extends HiveBaseProvider<Rect> {
 
   /// Puts the provided [Rect] preferences to [Hive].
   Future<void> put(ChatId chatId, Rect prefs) async {
-    Log.debug('put($chatId, $prefs)', '$runtimeType');
+    Log.trace('put($chatId, $prefs)', '$runtimeType');
     await putSafe(chatId.val, prefs);
   }
 
   /// Returns the [Rect] preferences from [Hive] by its [id].
   Rect? get(ChatId id) {
-    Log.debug('get($id)', '$runtimeType');
+    Log.trace('get($id)', '$runtimeType');
     return getSafe(id.val);
   }
 }

--- a/lib/provider/hive/chat.dart
+++ b/lib/provider/hive/chat.dart
@@ -113,19 +113,19 @@ class ChatHiveProvider extends HiveLazyProvider<HiveChat>
 
   @override
   Future<void> put(HiveChat item) async {
-    Log.debug('put($item)', '$runtimeType');
+    Log.trace('put($item)', '$runtimeType');
     await putSafe(item.value.id.val, item);
   }
 
   @override
   Future<HiveChat?> get(ChatId key) async {
-    Log.debug('get($key)', '$runtimeType');
+    Log.trace('get($key)', '$runtimeType');
     return await getSafe(key.val);
   }
 
   @override
   Future<void> remove(ChatId key) async {
-    Log.debug('remove($key)', '$runtimeType');
+    Log.trace('remove($key)', '$runtimeType');
     await deleteSafe(key.val);
   }
 }

--- a/lib/provider/hive/chat_credentials.dart
+++ b/lib/provider/hive/chat_credentials.dart
@@ -41,19 +41,19 @@ class ChatCredentialsHiveProvider
 
   /// Puts the provided [ChatCallCredentials] to [Hive].
   Future<void> put(ChatId chatId, ChatCallCredentials creds) async {
-    Log.debug('put($chatId, $creds)', '$runtimeType');
+    Log.trace('put($chatId, $creds)', '$runtimeType');
     await putSafe(chatId.val, creds);
   }
 
   /// Returns the [ChatCallCredentials] from [Hive] by the provided [ChatId].
   ChatCallCredentials? get(ChatId chatId) {
-    Log.debug('get($chatId)', '$runtimeType');
+    Log.trace('get($chatId)', '$runtimeType');
     return getSafe(chatId.val);
   }
 
   /// Removes the [ChatCallCredentials] from [Hive] by the provided [ChatId].
   Future<void> remove(ChatId chatId) async {
-    Log.debug('remove($chatId)', '$runtimeType');
+    Log.trace('remove($chatId)', '$runtimeType');
     await deleteSafe(chatId.val);
   }
 }

--- a/lib/provider/hive/chat_item.dart
+++ b/lib/provider/hive/chat_item.dart
@@ -51,7 +51,7 @@ class ChatItemHiveProvider extends HiveLazyProvider<HiveChatItem>
 
   @override
   void registerAdapters() {
-    Log.debug('registerAdapters()', '$runtimeType');
+    Log.debug('registerAdapters($id)', '$runtimeType');
 
     Hive.maybeRegisterAdapter(AttachmentIdAdapter());
     Hive.maybeRegisterAdapter(ChatCallAdapter());

--- a/lib/provider/hive/chat_item.dart
+++ b/lib/provider/hive/chat_item.dart
@@ -97,19 +97,19 @@ class ChatItemHiveProvider extends HiveLazyProvider<HiveChatItem>
 
   @override
   Future<void> put(HiveChatItem item) async {
-    Log.debug('put($item)', '$runtimeType');
+    Log.trace('put($item)', '$runtimeType');
     await putSafe(item.value.id.toString(), item);
   }
 
   @override
   Future<HiveChatItem?> get(ChatItemId key) async {
-    Log.debug('get($key)', '$runtimeType');
+    Log.trace('get($key)', '$runtimeType');
     return await getSafe(key.toString());
   }
 
   @override
   Future<void> remove(ChatItemId key) async {
-    Log.debug('remove($key)', '$runtimeType');
+    Log.trace('remove($key)', '$runtimeType');
     await deleteSafe(key.toString());
   }
 }

--- a/lib/provider/hive/chat_item_sorting.dart
+++ b/lib/provider/hive/chat_item_sorting.dart
@@ -51,13 +51,13 @@ class ChatItemSortingHiveProvider extends HiveBaseProvider<ChatItemId> {
 
   /// Puts the provided [key] to [Hive].
   Future<void> put(ChatItemKey key) async {
-    Log.debug('put($key))', '$runtimeType');
+    Log.trace('put($key))', '$runtimeType');
     await putSafe(key.toString(), key.id);
   }
 
   /// Removes the provided [ChatItemKey] from [Hive].
   Future<void> remove(ChatItemKey key) async {
-    Log.debug('remove($key)', '$runtimeType');
+    Log.trace('remove($key)', '$runtimeType');
     await deleteSafe(key.toString());
   }
 }

--- a/lib/provider/hive/chat_item_sorting.dart
+++ b/lib/provider/hive/chat_item_sorting.dart
@@ -37,7 +37,7 @@ class ChatItemSortingHiveProvider extends HiveBaseProvider<ChatItemId> {
 
   @override
   void registerAdapters() {
-    Log.debug('registerAdapters()', '$runtimeType');
+    Log.debug('registerAdapters($id)', '$runtimeType');
 
     Hive.maybeRegisterAdapter(ChatItemIdAdapter());
   }

--- a/lib/provider/hive/chat_member.dart
+++ b/lib/provider/hive/chat_member.dart
@@ -69,19 +69,19 @@ class ChatMemberHiveProvider extends HiveLazyProvider<HiveChatMember>
 
   @override
   Future<void> put(HiveChatMember member) async {
-    Log.debug('put($member)', '$runtimeType');
+    Log.trace('put($member)', '$runtimeType');
     await putSafe(member.value.user.id.val, member);
   }
 
   @override
   Future<HiveChatMember?> get(UserId id) {
-    Log.debug('get($id)', '$runtimeType');
+    Log.trace('get($id)', '$runtimeType');
     return getSafe(id.val);
   }
 
   @override
   Future<void> remove(UserId id) async {
-    Log.debug('remove($id)', '$runtimeType');
+    Log.trace('remove($id)', '$runtimeType');
     await deleteSafe(id.val);
   }
 }

--- a/lib/provider/hive/chat_member.dart
+++ b/lib/provider/hive/chat_member.dart
@@ -45,7 +45,7 @@ class ChatMemberHiveProvider extends HiveLazyProvider<HiveChatMember>
 
   @override
   void registerAdapters() {
-    Log.debug('registerAdapters()', '$runtimeType');
+    Log.debug('registerAdapters($id)', '$runtimeType');
 
     Hive.maybeRegisterAdapter(BlocklistReasonAdapter());
     Hive.maybeRegisterAdapter(BlocklistRecordAdapter());

--- a/lib/provider/hive/chat_member_sorting.dart
+++ b/lib/provider/hive/chat_member_sorting.dart
@@ -39,7 +39,7 @@ class ChatMemberSortingHiveProvider extends HiveBaseProvider<UserId> {
 
   @override
   void registerAdapters() {
-    Log.debug('registerAdapters()', '$runtimeType');
+    Log.debug('registerAdapters($id)', '$runtimeType');
     Hive.maybeRegisterAdapter(UserIdAdapter());
   }
 

--- a/lib/provider/hive/chat_member_sorting.dart
+++ b/lib/provider/hive/chat_member_sorting.dart
@@ -48,13 +48,13 @@ class ChatMemberSortingHiveProvider extends HiveBaseProvider<UserId> {
 
   /// Puts the provided [UserId] by the provided [time] to [Hive].
   Future<void> put(PreciseDateTime time, UserId id) async {
-    Log.debug('put($time, $id)', '$runtimeType');
+    Log.trace('put($time, $id)', '$runtimeType');
     await putSafe('${time.toUtc().toString()}_$id', id);
   }
 
   /// Removes the provided [UserId] from [Hive].
   Future<void> remove(UserId id) async {
-    Log.debug('remove($id)', '$runtimeType');
+    Log.trace('remove($id)', '$runtimeType');
 
     final int index = valuesSafe.toList().indexOf(id);
     if (index != -1) {

--- a/lib/provider/hive/contact.dart
+++ b/lib/provider/hive/contact.dart
@@ -65,19 +65,19 @@ class ContactHiveProvider extends HiveLazyProvider<HiveChatContact>
 
   @override
   Future<void> put(HiveChatContact contact) async {
-    Log.debug('put($contact)', '$runtimeType');
+    Log.trace('put($contact)', '$runtimeType');
     await putSafe(contact.value.id.val, contact);
   }
 
   @override
   Future<HiveChatContact?> get(ChatContactId id) {
-    Log.debug('get($id)', '$runtimeType');
+    Log.trace('get($id)', '$runtimeType');
     return getSafe(id.val);
   }
 
   @override
   Future<void> remove(ChatContactId id) async {
-    Log.debug('remove($id)', '$runtimeType');
+    Log.trace('remove($id)', '$runtimeType');
     await deleteSafe(id.val);
   }
 }

--- a/lib/provider/hive/contact_sorting.dart
+++ b/lib/provider/hive/contact_sorting.dart
@@ -46,7 +46,7 @@ class ContactSortingHiveProvider extends HiveBaseProvider<ChatContactId> {
 
   /// Puts the provided [ChatContactId] by the provided [name] to [Hive].
   Future<void> put(UserName name, ChatContactId item) async {
-    Log.debug('put($name, $item)', '$runtimeType');
+    Log.trace('put($name, $item)', '$runtimeType');
 
     final String key = '${name}_$item';
 
@@ -64,7 +64,7 @@ class ContactSortingHiveProvider extends HiveBaseProvider<ChatContactId> {
 
   /// Removes the provided [ChatContactId] from [Hive].
   Future<void> remove(ChatContactId item) async {
-    Log.debug('remove($item)', '$runtimeType');
+    Log.trace('remove($item)', '$runtimeType');
 
     await _mutex.protect(() async {
       final int index = values.toList().indexOf(item);

--- a/lib/provider/hive/credentials.dart
+++ b/lib/provider/hive/credentials.dart
@@ -47,13 +47,13 @@ class CredentialsHiveProvider extends HiveBaseProvider<Credentials> {
 
   /// Returns the stored [Credentials] from [Hive].
   Credentials? get() {
-    Log.debug('getCredentials()', '$runtimeType');
+    Log.trace('getCredentials()', '$runtimeType');
     return getSafe(0);
   }
 
   /// Stores new [Credentials] to [Hive].
   Future<void> set(Credentials credentials) async {
-    Log.debug('setCredentials($credentials)', '$runtimeType');
+    Log.trace('setCredentials($credentials)', '$runtimeType');
     await putSafe(0, credentials);
   }
 }

--- a/lib/provider/hive/download.dart
+++ b/lib/provider/hive/download.dart
@@ -38,19 +38,19 @@ class DownloadHiveProvider extends HiveLazyProvider<String> {
 
   /// Puts the provided [File.path] to [Hive].
   Future<void> put(String checksum, String path) async {
-    Log.debug('put($checksum, $path)', '$runtimeType');
+    Log.trace('put($checksum, $path)', '$runtimeType');
     await putSafe(checksum, path);
   }
 
   /// Returns a [File.path] from [Hive] by its [checksum].
   Future<String?> get(String checksum) async {
-    Log.debug('get($checksum)', '$runtimeType');
+    Log.trace('get($checksum)', '$runtimeType');
     return await getSafe(checksum);
   }
 
   /// Removes an [File.path] from [Hive] by its [checksum].
   Future<void> remove(String checksum) async {
-    Log.debug('remove($checksum)', '$runtimeType');
+    Log.trace('remove($checksum)', '$runtimeType');
     await deleteSafe(checksum);
   }
 }

--- a/lib/provider/hive/draft.dart
+++ b/lib/provider/hive/draft.dart
@@ -103,25 +103,25 @@ class DraftHiveProvider extends HiveBaseProvider<ChatMessage> {
 
   /// Puts the provided [ChatMessage] to [Hive].
   Future<void> put(ChatId id, ChatMessage draft) async {
-    Log.debug('put($id, $draft)', '$runtimeType');
+    Log.trace('put($id, $draft)', '$runtimeType');
     await putSafe(id.val, draft);
   }
 
   /// Returns a [ChatMessage] from [Hive] by the provided [id].
   ChatMessage? get(ChatId id) {
-    Log.debug('get($id)', '$runtimeType');
+    Log.trace('get($id)', '$runtimeType');
     return getSafe(id.val);
   }
 
   /// Removes a [ChatMessage] from [Hive] by the provided [id].
   Future<void> remove(ChatId id) async {
-    Log.debug('remove($id)', '$runtimeType');
+    Log.trace('remove($id)', '$runtimeType');
     await deleteSafe(id.val);
   }
 
   /// Moves the [ChatMessage] at the [oldKey] to the [newKey].
   Future<void> move(ChatId oldKey, ChatId newKey) async {
-    Log.debug('move($oldKey, $newKey)', '$runtimeType');
+    Log.trace('move($oldKey, $newKey)', '$runtimeType');
 
     final ChatMessage? value = get(oldKey);
     if (value != null) {

--- a/lib/provider/hive/favorite_chat.dart
+++ b/lib/provider/hive/favorite_chat.dart
@@ -45,7 +45,7 @@ class FavoriteChatHiveProvider extends HiveBaseProvider<ChatId> {
 
   /// Puts the provided [ChatId] by the provided [key] to [Hive].
   Future<void> put(ChatFavoritePosition key, ChatId item) async {
-    Log.debug('put($key, $item)', '$runtimeType');
+    Log.trace('put($key, $item)', '$runtimeType');
 
     final String i = '${key.toPlainString()}_$item';
 
@@ -63,7 +63,7 @@ class FavoriteChatHiveProvider extends HiveBaseProvider<ChatId> {
 
   /// Removes the provided [ChatId] from [Hive].
   Future<void> remove(ChatId item) async {
-    Log.debug('remove($item)', '$runtimeType');
+    Log.trace('remove($item)', '$runtimeType');
 
     await _mutex.protect(() async {
       final int index = values.toList().indexOf(item);

--- a/lib/provider/hive/favorite_contact.dart
+++ b/lib/provider/hive/favorite_contact.dart
@@ -46,7 +46,7 @@ class FavoriteContactHiveProvider extends HiveBaseProvider<ChatContactId> {
 
   /// Puts the provided [ChatContactId] by the provided [key] to [Hive].
   Future<void> put(ChatContactFavoritePosition key, ChatContactId item) async {
-    Log.debug('put($key, $item)', '$runtimeType');
+    Log.trace('put($key, $item)', '$runtimeType');
 
     final String i = '${key.toPlainString()}_$item';
 
@@ -64,7 +64,7 @@ class FavoriteContactHiveProvider extends HiveBaseProvider<ChatContactId> {
 
   /// Removes the provided [ChatContactId] from [Hive].
   Future<void> remove(ChatContactId item) async {
-    Log.debug('remove($item)', '$runtimeType');
+    Log.trace('remove($item)', '$runtimeType');
 
     await _mutex.protect(() async {
       final int index = values.toList().indexOf(item);

--- a/lib/provider/hive/media_settings.dart
+++ b/lib/provider/hive/media_settings.dart
@@ -40,25 +40,25 @@ class MediaSettingsHiveProvider extends HiveBaseProvider<MediaSettings> {
 
   /// Saves the provided [MediaSettings] in [Hive].
   Future<void> set(MediaSettings mediaSettings) async {
-    Log.debug('set($mediaSettings)', '$runtimeType');
+    Log.trace('set($mediaSettings)', '$runtimeType');
     await putSafe(0, mediaSettings);
   }
 
   /// Stores a new video device [id] to [Hive].
   Future<void> setVideoDevice(String id) async {
-    Log.debug('setVideoDevice($id)', '$runtimeType');
+    Log.trace('setVideoDevice($id)', '$runtimeType');
     await putSafe(0, (box.get(0) ?? MediaSettings())..videoDevice = id);
   }
 
   /// Stores a new audio device [id] to [Hive].
   Future<void> setAudioDevice(String id) async {
-    Log.debug('setAudioDevice($id)', '$runtimeType');
+    Log.trace('setAudioDevice($id)', '$runtimeType');
     await putSafe(0, (box.get(0) ?? MediaSettings())..audioDevice = id);
   }
 
   /// Stores a new output device [id] to [Hive].
   Future<void> setOutputDevice(String id) async {
-    Log.debug('setOutputDevice($id)', '$runtimeType');
+    Log.trace('setOutputDevice($id)', '$runtimeType');
     await putSafe(0, (box.get(0) ?? MediaSettings())..outputDevice = id);
   }
 }

--- a/lib/provider/hive/monolog.dart
+++ b/lib/provider/hive/monolog.dart
@@ -38,13 +38,13 @@ class MonologHiveProvider extends HiveBaseProvider<ChatId> {
 
   /// Returns the stored [ChatId] from [Hive].
   ChatId? get() {
-    Log.debug('get()', '$runtimeType');
+    Log.trace('get()', '$runtimeType');
     return getSafe(0);
   }
 
   /// Saves the provided [ChatId] to [Hive].
   Future<void> set(ChatId id) async {
-    Log.debug('set($id)', '$runtimeType');
+    Log.trace('set($id)', '$runtimeType');
     await putSafe(0, id);
   }
 }

--- a/lib/provider/hive/my_user.dart
+++ b/lib/provider/hive/my_user.dart
@@ -76,7 +76,7 @@ class MyUserHiveProvider extends HiveBaseProvider<HiveMyUser> {
 
   /// Saves the provided [MyUser] in [Hive].
   Future<void> set(HiveMyUser user) async {
-    Log.debug('set($user)', '$runtimeType');
+    Log.trace('set($user)', '$runtimeType');
     await putSafe(0, user);
   }
 }

--- a/lib/provider/hive/recent_chat.dart
+++ b/lib/provider/hive/recent_chat.dart
@@ -46,7 +46,7 @@ class RecentChatHiveProvider extends HiveBaseProvider<ChatId> {
 
   /// Puts the provided [ChatId] by the provided [key] to [Hive].
   Future<void> put(PreciseDateTime key, ChatId item) async {
-    Log.debug('put($key, $item)', '$runtimeType');
+    Log.trace('put($key, $item)', '$runtimeType');
 
     final String i = '${key.toUtc().toString()}_$item';
 
@@ -64,7 +64,7 @@ class RecentChatHiveProvider extends HiveBaseProvider<ChatId> {
 
   /// Removes the provided [ChatId] from [Hive].
   Future<void> remove(ChatId item) async {
-    Log.debug('remove($item)', '$runtimeType');
+    Log.trace('remove($item)', '$runtimeType');
 
     await _mutex.protect(() async {
       final int index = values.toList().indexOf(item);

--- a/lib/provider/hive/session_data.dart
+++ b/lib/provider/hive/session_data.dart
@@ -43,44 +43,44 @@ class SessionDataHiveProvider extends HiveBaseProvider<SessionData> {
 
   /// Returns the stored [FavoriteChatsListVersion] from [Hive].
   FavoriteChatsListVersion? getFavoriteChatsListVersion() {
-    Log.debug('getFavoriteChatsListVersion()', '$runtimeType');
+    Log.trace('getFavoriteChatsListVersion()', '$runtimeType');
     return getSafe(0)?.favoriteChatsListVersion;
   }
 
   /// Returns the stored indicator whether all favorite [Chat]s are stored
   /// locally.
   bool? getFavoriteChatsSynchronized() {
-    Log.debug('getFavoriteChatsSynchronized()', '$runtimeType');
+    Log.trace('getFavoriteChatsSynchronized()', '$runtimeType');
     return getSafe(0)?.favoriteChatsSynchronized;
   }
 
   /// Returns the stored [ChatContactsListVersion] from [Hive].
   ChatContactsListVersion? getChatContactsListVersion() {
-    Log.debug('getChatContactsListVersion()', '$runtimeType');
+    Log.trace('getChatContactsListVersion()', '$runtimeType');
     return getSafe(0)?.chatContactsListVersion;
   }
 
   /// Returns the stored [SessionData.favoriteContactsSynchronized] from [Hive].
   bool? getFavoriteContactsSynchronized() {
-    Log.debug('getFavoriteContactsSynchronized()', '$runtimeType');
+    Log.trace('getFavoriteContactsSynchronized()', '$runtimeType');
     return getSafe(0)?.favoriteContactsSynchronized;
   }
 
   /// Returns the stored [SessionData.contactsSynchronized] from [Hive].
   bool? getContactsSynchronized() {
-    Log.debug('getContactsSynchronized()', '$runtimeType');
+    Log.trace('getContactsSynchronized()', '$runtimeType');
     return getSafe(0)?.contactsSynchronized;
   }
 
   /// Returns the stored [SessionData.blocklistSynchronized] from [Hive].
   bool? getBlocklistSynchronized() {
-    Log.debug('getBlocklistSynchronized()', '$runtimeType');
+    Log.trace('getBlocklistSynchronized()', '$runtimeType');
     return getSafe(0)?.blocklistSynchronized;
   }
 
   /// Stores a new [FavoriteChatsListVersion] to [Hive].
   Future<void> setFavoriteChatsListVersion(FavoriteChatsListVersion ver) {
-    Log.debug('setChatContactsListVersion($ver)', '$runtimeType');
+    Log.trace('setChatContactsListVersion($ver)', '$runtimeType');
     return putSafe(
       0,
       (box.get(0) ?? SessionData())..favoriteChatsListVersion = ver,
@@ -89,7 +89,7 @@ class SessionDataHiveProvider extends HiveBaseProvider<SessionData> {
 
   /// Stores a new [SessionData.favoriteChatsSynchronized] to [Hive].
   Future<void> setFavoriteChatsSynchronized(bool val) {
-    Log.debug('setFavoriteChatsSynchronized($val)', '$runtimeType');
+    Log.trace('setFavoriteChatsSynchronized($val)', '$runtimeType');
     return putSafe(
       0,
       (box.get(0) ?? SessionData())..favoriteChatsSynchronized = val,
@@ -98,7 +98,7 @@ class SessionDataHiveProvider extends HiveBaseProvider<SessionData> {
 
   /// Stores a new [ChatContactsListVersion] to [Hive].
   Future<void> setChatContactsListVersion(ChatContactsListVersion ver) async {
-    Log.debug('setChatContactsListVersion($ver)', '$runtimeType');
+    Log.trace('setChatContactsListVersion($ver)', '$runtimeType');
     await putSafe(
       0,
       (box.get(0) ?? SessionData())..chatContactsListVersion = ver,
@@ -107,7 +107,7 @@ class SessionDataHiveProvider extends HiveBaseProvider<SessionData> {
 
   /// Stores a new [SessionData.favoriteContactsSynchronized] to [Hive].
   Future<void> setFavoriteContactsSynchronized(bool val) async {
-    Log.debug('setFavoriteContactsSynchronized($val)', '$runtimeType');
+    Log.trace('setFavoriteContactsSynchronized($val)', '$runtimeType');
     await putSafe(
       0,
       (box.get(0) ?? SessionData())..favoriteContactsSynchronized = val,
@@ -116,7 +116,7 @@ class SessionDataHiveProvider extends HiveBaseProvider<SessionData> {
 
   /// Stores a new [SessionData.contactsSynchronized] to [Hive].
   Future<void> setContactsSynchronized(bool val) async {
-    Log.debug('setContactsSynchronized($val)', '$runtimeType');
+    Log.trace('setContactsSynchronized($val)', '$runtimeType');
     await putSafe(
       0,
       (box.get(0) ?? SessionData())..contactsSynchronized = val,
@@ -125,7 +125,7 @@ class SessionDataHiveProvider extends HiveBaseProvider<SessionData> {
 
   /// Stores a new [SessionData.blocklistSynchronized] to [Hive].
   Future<void> setBlocklistSynchronized(bool val) async {
-    Log.debug('setBlocklistSynchronized()', '$runtimeType');
+    Log.trace('setBlocklistSynchronized()', '$runtimeType');
     await putSafe(
       0,
       (box.get(0) ?? SessionData())..blocklistSynchronized = val,

--- a/lib/provider/hive/skipped_version.dart
+++ b/lib/provider/hive/skipped_version.dart
@@ -35,13 +35,13 @@ class SkippedVersionHiveProvider extends HiveBaseProvider<String> {
 
   /// Returns the skipped version from [Hive].
   String? get() {
-    Log.debug('get()', '$runtimeType');
+    Log.trace('get()', '$runtimeType');
     return getSafe(0);
   }
 
   /// Stores the new skipped version to [Hive].
   Future<void> set(String version) async {
-    Log.debug('set($version)', '$runtimeType');
+    Log.trace('set($version)', '$runtimeType');
     await putSafe(0, version);
   }
 }

--- a/lib/provider/hive/user.dart
+++ b/lib/provider/hive/user.dart
@@ -69,19 +69,19 @@ class UserHiveProvider extends HiveBaseProvider<HiveUser> {
 
   /// Puts the provided [User] to [Hive].
   Future<void> put(HiveUser user) async {
-    Log.debug('put($user)', '$runtimeType');
+    Log.trace('put($user)', '$runtimeType');
     await putSafe(user.value.id.val, user);
   }
 
   /// Returns a [User] from [Hive] by its [id].
   HiveUser? get(UserId id) {
-    Log.debug('get($id)', '$runtimeType');
+    Log.trace('get($id)', '$runtimeType');
     return getSafe(id.val);
   }
 
   /// Removes an [User] from [Hive] by its [id].
   Future<void> remove(UserId id) async {
-    Log.debug('remove($id)', '$runtimeType');
+    Log.trace('remove($id)', '$runtimeType');
     await deleteSafe(id.val);
   }
 }

--- a/lib/provider/hive/window.dart
+++ b/lib/provider/hive/window.dart
@@ -39,13 +39,13 @@ class WindowPreferencesHiveProvider
 
   /// Returns the stored [WindowPreferences] from [Hive].
   WindowPreferences? get() {
-    Log.debug('get()', '$runtimeType');
+    Log.trace('get()', '$runtimeType');
     return getSafe(0);
   }
 
   /// Stores the new [WindowPreferences] to [Hive].
   void set({Size? size, Offset? position}) {
-    Log.debug('set($size, $position)', '$runtimeType');
+    Log.trace('set($size, $position)', '$runtimeType');
 
     final WindowPreferences? stored = get();
     putSafe(

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -1289,7 +1289,7 @@ class HiveRxChat extends RxChat {
 
   /// Updates the [members] and [title] fields based on the [chat] state.
   Future<void> _updateFields({Chat? previous}) async {
-    Log.debug('_updateFields($previous)', '$runtimeType($id)');
+    Log.trace('_updateFields($previous)', '$runtimeType($id)');
 
     if (!chat.value.isDialog) {
       avatar.value = chat.value.avatar;

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -17,6 +17,7 @@
 
 import 'dart:math';
 import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -86,6 +87,8 @@ class _MediaAttachmentState extends State<MediaAttachment> {
     final bool isImage = (attachment is ImageAttachment ||
         (attachment is LocalAttachment && attachment.file.isImage));
 
+    bool narrow = false;
+
     final Widget child;
 
     if (isImage) {
@@ -110,7 +113,7 @@ class _MediaAttachmentState extends State<MediaAttachment> {
               final Size? dimensions = attachment.file.dimensions.value;
               final double ratio =
                   (dimensions?.width ?? 300) / (dimensions?.height ?? 300);
-              final bool narrow = ratio > 3 || ratio < 0.33;
+              narrow = ratio > 3 || ratio < 0.33;
 
               return Image.memory(
                 attachment.file.bytes.value!,
@@ -125,7 +128,7 @@ class _MediaAttachmentState extends State<MediaAttachment> {
       } else {
         final ImageFile file = attachment.original as ImageFile;
         final double ratio = (file.width ?? 300) / (file.height ?? 300);
-        final bool narrow = ratio > 3 || ratio < 0.33;
+        narrow = ratio > 3 || ratio < 0.33;
 
         child = RetryImage.attachment(
           attachment as ImageAttachment,
@@ -182,6 +185,25 @@ class _MediaAttachmentState extends State<MediaAttachment> {
     return Stack(
       fit: StackFit.passthrough,
       children: [
+        if (isImage && narrow)
+          Positioned.fill(
+            child: attachment is LocalAttachment
+                ? attachment.file.bytes.value != null && !attachment.file.isSvg
+                    ? Image.memory(
+                        attachment.file.bytes.value!,
+                        fit: BoxFit.cover,
+                        width: double.infinity,
+                        height: double.infinity,
+                      )
+                    : const SizedBox()
+                : RetryImage.attachment(
+                    attachment as ImageAttachment,
+                    filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                    fit: BoxFit.cover,
+                    width: double.infinity,
+                    height: double.infinity,
+                  ),
+          ),
         child,
         Obx(() {
           if (attachment.isDownloading) {

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -17,7 +17,7 @@
 
 import 'dart:math';
 import 'dart:typed_data';
-import 'dart:ui';
+import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -87,12 +87,37 @@ class _MediaAttachmentState extends State<MediaAttachment> {
     final bool isImage = (attachment is ImageAttachment ||
         (attachment is LocalAttachment && attachment.file.isImage));
 
-    bool narrow = false;
-
-    final Widget child;
+    Widget? preview;
+    Widget? child;
 
     if (isImage) {
       if (attachment is LocalAttachment) {
+        // Indicates whether the provided [dimensions] are considered too narrow
+        // or too wide.
+        bool isNarrow(Size? dimensions) {
+          final double ratio =
+              (dimensions?.width ?? 300) / (dimensions?.height ?? 300);
+          return ratio > 3 || ratio < 0.33;
+        }
+
+        preview = Obx(() {
+          if (attachment.file.bytes.value != null &&
+              !attachment.file.isSvg &&
+              isNarrow(attachment.file.dimensions.value)) {
+            return ImageFiltered(
+              imageFilter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+              child: Image.memory(
+                attachment.file.bytes.value!,
+                fit: BoxFit.cover,
+                width: double.infinity,
+                height: double.infinity,
+              ),
+            );
+          }
+
+          return const SizedBox();
+        });
+
         child = Obx(() {
           if (attachment.file.bytes.value == null) {
             return const Center(
@@ -111,9 +136,7 @@ class _MediaAttachmentState extends State<MediaAttachment> {
               );
             } else {
               final Size? dimensions = attachment.file.dimensions.value;
-              final double ratio =
-                  (dimensions?.width ?? 300) / (dimensions?.height ?? 300);
-              narrow = ratio > 3 || ratio < 0.33;
+              final bool narrow = isNarrow(dimensions);
 
               return Image.memory(
                 attachment.file.bytes.value!,
@@ -125,13 +148,40 @@ class _MediaAttachmentState extends State<MediaAttachment> {
             }
           }
         });
-      } else {
+      } else if (attachment is ImageAttachment) {
         final ImageFile file = attachment.original as ImageFile;
         final double ratio = (file.width ?? 300) / (file.height ?? 300);
-        narrow = ratio > 3 || ratio < 0.33;
+        final bool narrow = ratio > 3 || ratio < 0.33;
+
+        if (narrow) {
+          final ThumbHash? thumbhash =
+              (attachment.original as ImageFile).thumbhash ??
+                  attachment.big.thumbhash ??
+                  attachment.medium.thumbhash ??
+                  attachment.small.thumbhash;
+
+          // Display only the [ThumbHash], if [attachment] has any, to reduce
+          // possible overhead caused by a [RetryImage].
+          if (thumbhash != null) {
+            preview = Image(
+              image: CacheWorker.instance.getThumbhashProvider(thumbhash),
+              height: double.infinity,
+              width: double.infinity,
+              fit: BoxFit.cover,
+            );
+          } else {
+            preview = RetryImage.attachment(
+              attachment,
+              filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+              fit: BoxFit.cover,
+              width: double.infinity,
+              height: double.infinity,
+            );
+          }
+        }
 
         child = RetryImage.attachment(
-          attachment as ImageAttachment,
+          attachment,
           fit: widget.fit ?? (narrow ? BoxFit.contain : BoxFit.cover),
           width: widget.width,
           minWidth: 75,
@@ -185,31 +235,8 @@ class _MediaAttachmentState extends State<MediaAttachment> {
     return Stack(
       fit: StackFit.passthrough,
       children: [
-        if (isImage && narrow)
-          Positioned.fill(
-            child: attachment is LocalAttachment
-                ? attachment.file.bytes.value != null && !attachment.file.isSvg
-                    ? ImageFiltered(
-                        imageFilter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                        child: Image.memory(
-                          attachment.file.bytes.value!,
-                          fit: BoxFit.cover,
-                          width: double.infinity,
-                          height: double.infinity,
-                        ),
-                      )
-                    : const SizedBox()
-
-                // TODO: Perhaps only use `small` images and/or `thumbhash`?
-                : RetryImage.attachment(
-                    attachment as ImageAttachment,
-                    filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                    fit: BoxFit.cover,
-                    width: double.infinity,
-                    height: double.infinity,
-                  ),
-          ),
-        child,
+        if (preview != null) Positioned.fill(child: preview),
+        if (child != null) child,
         Obx(() {
           if (attachment.isDownloading) {
             return Positioned(

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -189,11 +189,14 @@ class _MediaAttachmentState extends State<MediaAttachment> {
           Positioned.fill(
             child: attachment is LocalAttachment
                 ? attachment.file.bytes.value != null && !attachment.file.isSvg
-                    ? Image.memory(
-                        attachment.file.bytes.value!,
-                        fit: BoxFit.cover,
-                        width: double.infinity,
-                        height: double.infinity,
+                    ? ImageFiltered(
+                        imageFilter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                        child: Image.memory(
+                          attachment.file.bytes.value!,
+                          fit: BoxFit.cover,
+                          width: double.infinity,
+                          height: double.infinity,
+                        ),
                       )
                     : const SizedBox()
                 : RetryImage.attachment(

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -199,6 +199,8 @@ class _MediaAttachmentState extends State<MediaAttachment> {
                         ),
                       )
                     : const SizedBox()
+
+                // TODO: Perhaps only use `small` images and/or `thumbhash`?
                 : RetryImage.attachment(
                     attachment as ImageAttachment,
                     filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),

--- a/lib/ui/page/home/widget/retry_image.dart
+++ b/lib/ui/page/home/widget/retry_image.dart
@@ -89,7 +89,10 @@ class RetryImage extends StatefulWidget {
     return RetryImage(
       image.url,
       checksum: image.checksum,
-      thumbhash: image.thumbhash ?? attachment.big.thumbhash,
+      thumbhash: image.thumbhash ??
+          attachment.big.thumbhash ??
+          attachment.medium.thumbhash ??
+          attachment.small.thumbhash,
       fit: fit,
       height: height,
       width: width,


### PR DESCRIPTION
## Synopsis

Narrow `ImageAttachment`s are displayed in `contain` mode, causing empty spaces to appear. Looks not really nice.




## Solution

This PR adds blurred previews under such images.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
