### PR TITLE
Fix sound when empty area pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All user visible changes to this project will be documented in this file. This p
         - Replied calls displaying irrelevant information. ([#919], [#455])
     - Gapopa ID displaying incorrectly in notifications. ([#910], [#909])
     - Incoming call notification duplicating. ([#914])
+    - Sound playing when an empty area pressing. ([#937])
 - Web:
     - Missing blurred image previews in gallery. ([#880])
 
@@ -75,6 +76,7 @@ All user visible changes to this project will be documented in this file. This p
 [#915]: /../../pull/915
 [#919]: /../../pull/919
 [#934]: /../../pull/934
+[#937]: /../../pull/937
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ All user visible changes to this project will be documented in this file. This p
         - Replied calls displaying irrelevant information. ([#919], [#455])
     - Gapopa ID displaying incorrectly in notifications. ([#910], [#909])
     - Incoming call notification duplicating. ([#914])
-    - Sound playing when an empty area pressing. ([#937])
+    - Home page:
+        - Alarm sound when clicking on empty right space. ([#937])
 - Web:
     - Missing blurred image previews in gallery. ([#880])
 

--- a/lib/ui/widget/custom_page.dart
+++ b/lib/ui/widget/custom_page.dart
@@ -83,7 +83,7 @@ class _CupertinoPageRoute<T> extends PageRoute<T> {
 
     return ClipRect(
       child: ColoredBox(
-        color: style.colors.almostTransparent,
+        color: style.colors.transparent,
         child: matchingBuilder.buildTransitions(
           this,
           context,

--- a/lib/ui/widget/custom_page.dart
+++ b/lib/ui/widget/custom_page.dart
@@ -18,6 +18,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
+import '/themes.dart';
 import '/util/platform_utils.dart';
 
 /// [Page] with the [_CupertinoPageRoute] as its [Route].
@@ -78,13 +79,18 @@ class _CupertinoPageRoute<T> extends PageRoute<T> {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
+    final style = Theme.of(context).style;
+
     return ClipRect(
-      child: matchingBuilder.buildTransitions(
-        this,
-        context,
-        animation,
-        secondaryAnimation,
-        child,
+      child: ColoredBox(
+        color: style.colors.almostTransparent,
+        child: matchingBuilder.buildTransitions(
+          this,
+          context,
+          animation,
+          secondaryAnimation,
+          child,
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Synopsis

Если нажать на пустое пространство справа от навигации, будет воспроизведен звук ошибки.




## Solution

Проблема будет исправлена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
