### PR TITLE
Fix `git describe` returning `-dirty` tags in `build` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,9 +168,9 @@ jobs:
 
       - run: make flutter.pub
 
-      # Running `build_runner` here ensures `PubspecBuilder` and its `git
-      # describe` returns the valid result without possible `-dirty` tag, that
-      # may happen during FCM configuration.
+      # Running `build_runner` here ensures `PubspecBuilder` and its
+      # `git describe` command returns the valid result without possible
+      # `--dirty` tag, that may happen during FCM configuration.
       - run: make flutter.gen overwrite=true
         if: ${{ contains('apk appbundle ios web', matrix.platform) }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
       # Running `build_runner` here ensures `PubspecBuilder` and its
       # `git describe` command returns the valid result without possible
-      # `--dirty` tag, that may happen during FCM configuration.
+      # `-dirty` part, that may happen during FCM configuration.
       - run: make flutter.gen overwrite=true
         if: ${{ contains('apk appbundle ios web', matrix.platform) }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,13 +155,6 @@ jobs:
               || (matrix.platform == 'windows'           && 'windows-latest')
               ||                                            'ubuntu-latest' }}
     steps:
-      # TODO: Remove, when subosito/flutter-action#278 is fixed:
-      #       https://github.com/subosito/flutter-action/issues/278
-      - name: Export pub environment variable on Windows
-        run: echo "PUB_CACHE=$LOCALAPPDATA\\Pub\\Cache" >> $GITHUB_ENV
-        shell: bash
-        if: ${{ matrix.platform == 'windows' }}
-
       - uses: actions/checkout@v4
         with:
           # Unshallow the repository in order for `PubspecBuilder` and its
@@ -172,14 +165,12 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
-      - run: flutter config --enable-${{ matrix.platform }}-desktop
-        if: ${{ contains('macos windows', matrix.platform) }}
 
       - run: make flutter.pub
 
-      # Running `build_runner` here ensures `git describe` returns the valid
-      # result without possible `-dirty` tag, that may happen during FCM
-      # configuration.
+      # Running `build_runner` here ensures `PubspecBuilder` and its `git
+      # describe` returns the valid result without possible `-dirty` tag, that
+      # may happen during FCM configuration.
       - run: make flutter.gen overwrite=true
         if: ${{ contains('apk appbundle ios web', matrix.platform) }}
 
@@ -351,7 +342,6 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VER }}
           channel: stable
           cache: true
-      - run: flutter config --enable-linux-desktop
 
       - name: Parse semver versions from Git tag
         id: semver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,12 @@ jobs:
 
       - run: make flutter.pub
 
+      # Running `build_runner` here ensures `git describe` returns the valid
+      # result without possible `-dirty` tag, that may happen during FCM
+      # configuration.
+      - run: make flutter.gen overwrite=true
+        if: ${{ contains('apk appbundle ios web', matrix.platform) }}
+
       - name: Configure FCM (Firebase Cloud Messaging)
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/service_account.json


### PR DESCRIPTION
## Synopsis

`git describe` returns `-dirty` in `build` CI job on Web.




## Solution

This PR fixes the issue by running the `make build` before the FCM configuration, as it modifies the files, making branch dirty. We can't `.gitignore` those files, as without them application won't build on Android/iOS at all. And to generate those files user must have Firebase authorization, which we can't grant to non-members of this team as well.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
