### PR TITLE
Multiple `updateUserPassword` queries being sent when changing or setting password (#949)

### DIFF
--- a/lib/domain/service/my_user.dart
+++ b/lib/domain/service/my_user.dart
@@ -109,7 +109,13 @@ class MyUserService extends DisposableService {
   }) async {
     Log.debug('updateUserPassword(***, ***)', '$runtimeType');
 
+    final bool locked = _passwordChangeGuard.isLocked;
+
     await _passwordChangeGuard.protect(() async {
+      if (locked) {
+        return;
+      }
+
       // TODO: Make sure [AuthService] doesn't its `refreshSession` during that.
       await _userRepo.updateUserPassword(oldPassword, newPassword);
       await _auth.signIn(newPassword, num: myUser.value?.num);

--- a/lib/ui/page/home/page/my_profile/password/controller.dart
+++ b/lib/ui/page/home/page/my_profile/password/controller.dart
@@ -155,13 +155,10 @@ class ChangePasswordController extends GetxController {
   Future<void> changePassword() async {
     if (myUser.value?.hasPassword == true) {
       oldPassword.focus.unfocus();
-      oldPassword.submit();
     }
 
     newPassword.focus.unfocus();
-    newPassword.submit();
     repeatPassword.focus.unfocus();
-    repeatPassword.submit();
 
     if (myUser.value?.hasPassword == true) {
       if (oldPassword.error.value != null) {


### PR DESCRIPTION
Resolves #949




## Synopsis

При установке или смене пароля почему-то несколько раз стреляет запрос на `updateUserPassword`.




## Solution

Проблема будет исправлена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
