### PR TITLE
Blurred buttons when creating group on `Chats` tab (#947)

### DIFF
--- a/lib/ui/page/home/widget/shadowed_rounded_button.dart
+++ b/lib/ui/page/home/widget/shadowed_rounded_button.dart
@@ -53,6 +53,7 @@ class ShadowedRoundedButton extends StatelessWidget {
       shadows: [
         BoxShadow(blurRadius: 8, color: style.colors.onBackgroundOpacity13),
       ],
+      headline: const SizedBox(),
       child: child,
     );
   }


### PR DESCRIPTION
Resolves #947




## Synopsis

ногда при входе в режим создания группы в браузере рисуются размытыми кнопки в меню снизу.




## Solution

Проблема будет решена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
