### PR TITLE
Move `Contacts` tab button to `AppBar` of `Chats` tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ All user visible changes to this project will be documented in this file. This p
 
 - UI:
     - Home page:
-        - Contacts button moved to chats tab app bar. ([#969])
+        - Contacts button moved to chats tab app bar. ([#970])
 
-[#967]: /../../pull/969
+[#970]: /../../pull/970
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,39 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.1.0-alpha.14] · 2024-??-??
+[0.1.0-alpha.14]: /../../tree/v0.1.0-alpha.14
+
+[Diff](/../../compare/v0.1.0-alpha.13.3...v0.1.0-alpha.14) | [Milestone](/../../milestone/22)
+
+### Changed
+
+- UI:
+    - Home page:
+        - Contacts button moved to chats tab app bar. ([#969])
+
+[#967]: /../../pull/969
+
+
+
+
 ## [0.1.0-alpha.13.3] · 2024-04-19
 [0.1.0-alpha.13.3]: /../../tree/v0.1.0-alpha.13.3
 
 [Diff](/../../compare/v0.1.0-alpha.13.2...v0.1.0-alpha.13.3) | [Milestone](/../../milestone/21)
+
+### Added
+
+- UI:
+    - Account deletion page. ([#961])
+    - "Terms and conditions" page. ([#961])
+    - "Privacy policy" page. ([#961])
 
 ### Fixed
 
 - UI:
     - Chats tab:
         - Dialogs missing their avatars in some cases. ([#967], [#964])
-    - Account deletion page. ([#961])
-    - "Terms and conditions" page. ([#961])
-    - "Privacy policy" page. ([#961])
 
 [#961]: /../../pull/961
 [#964]: /../../issues/964

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -336,6 +336,19 @@ class ChatsTabView extends StatelessWidget {
                       return Row(
                         children: [
                           AnimatedButton(
+                            key: const Key('ContactsButton'),
+                            onPressed: () => router.tab = HomeTab.contacts,
+                            decorator: (child) {
+                              return Container(
+                                padding:
+                                    const EdgeInsets.only(left: 20, right: 12),
+                                height: double.infinity,
+                                child: child,
+                              );
+                            },
+                            child: const SvgIcon(SvgIcons.contactsSwitch),
+                          ),
+                          AnimatedButton(
                             key: const Key('SearchButton'),
                             onPressed: () => c.startSearch(),
                             decorator: (child) {
@@ -346,13 +359,7 @@ class ChatsTabView extends StatelessWidget {
                                 child: child,
                               );
                             },
-                            child: SizedBox(
-                              width: 20,
-                              child: SafeAnimatedSwitcher(
-                                duration: 250.milliseconds,
-                                child: const SvgIcon(SvgIcons.search),
-                              ),
-                            ),
+                            child: const SvgIcon(SvgIcons.search),
                           ),
                           ContextMenuRegion(
                             key: const Key('ChatsMenu'),

--- a/lib/ui/page/home/tab/contacts/view.dart
+++ b/lib/ui/page/home/tab/contacts/view.dart
@@ -208,6 +208,18 @@ class ContactsTabView extends StatelessWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     AnimatedButton(
+                      key: const Key('ChatsButton'),
+                      onPressed: () => router.tab = HomeTab.chats,
+                      decorator: (child) {
+                        return Container(
+                          padding: const EdgeInsets.only(left: 20, right: 8),
+                          height: double.infinity,
+                          child: child,
+                        );
+                      },
+                      child: const SvgIcon(SvgIcons.chatsSwitch),
+                    ),
+                    AnimatedButton(
                       key: const Key('SearchButton'),
                       onPressed: () => c.toggleSearch(),
                       decorator: (child) => Container(
@@ -215,16 +227,7 @@ class ContactsTabView extends StatelessWidget {
                         height: double.infinity,
                         child: child,
                       ),
-                      child: SizedBox(
-                        width: 20,
-                        child: SafeAnimatedSwitcher(
-                          duration: 250.milliseconds,
-                          child: const SvgIcon(
-                            SvgIcons.search,
-                            key: Key('Search'),
-                          ),
-                        ),
-                      ),
+                      child: const SvgIcon(SvgIcons.search, key: Key('Search')),
                     ),
                     ContextMenuRegion(
                       key: const Key('ContactsMenu'),

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -212,72 +212,72 @@ class _HomeViewState extends State<HomeView> {
                     extendBody: true,
                     bottomNavigationBar: SafeArea(
                       child: Obx(() {
+                        final List<HomeTab> tabs =
+                            c.tabs.where((e) => e != HomeTab.contacts).toList();
+
                         return AnimatedSlider(
                           duration: 300.milliseconds,
                           isOpen: router.navigation.value,
                           beginOffset: const Offset(0.0, 5),
                           translate: false,
-                          child: Obx(() {
-                            return CustomNavigationBar(
-                              key: c.panelKey,
-                              items: c.tabs.map((e) {
-                                switch (e) {
-                                  case HomeTab.work:
-                                    return const CustomNavigationBarItem.work();
+                          child: CustomNavigationBar(
+                            key: c.panelKey,
+                            items: tabs.map((e) {
+                              switch (e) {
+                                case HomeTab.work:
+                                  return const CustomNavigationBarItem.work();
 
-                                  case HomeTab.contacts:
-                                    return const CustomNavigationBarItem
-                                        .contacts();
+                                case HomeTab.contacts:
+                                  return const CustomNavigationBarItem
+                                      .contacts();
 
-                                  case HomeTab.chats:
-                                    return Obx(() {
-                                      return CustomNavigationBarItem.chats(
-                                        unread: c.unreadChats.value.toString(),
-                                        danger: c.myUser.value?.muted == null,
-                                        selector: c.chatsKey,
-                                        onMute: c.toggleMute,
-                                      );
-                                    });
+                                case HomeTab.chats:
+                                  return Obx(() {
+                                    return CustomNavigationBarItem.chats(
+                                      unread: c.unreadChats.value.toString(),
+                                      danger: c.myUser.value?.muted == null,
+                                      selector: c.chatsKey,
+                                      onMute: c.toggleMute,
+                                    );
+                                  });
 
-                                  case HomeTab.menu:
-                                    return Obx(() {
-                                      return CustomNavigationBarItem.menu(
-                                        acceptAuxiliary:
-                                            style.colors.acceptAuxiliary,
-                                        warning: style.colors.warning,
-                                        onPresence: c.setPresence,
-                                        onAvatar: c.updateAvatar,
-                                        selector: c.panelKey,
-                                        myUser: c.myUser.value,
-                                        actions: [
-                                          ContextMenuBuilder(
-                                            (_) => Obx(() {
-                                              final hasWork = c.settings.value
-                                                      ?.workWithUsTabEnabled ==
-                                                  true;
+                                case HomeTab.menu:
+                                  return Obx(() {
+                                    return CustomNavigationBarItem.menu(
+                                      acceptAuxiliary:
+                                          style.colors.acceptAuxiliary,
+                                      warning: style.colors.warning,
+                                      onPresence: c.setPresence,
+                                      onAvatar: c.updateAvatar,
+                                      selector: c.panelKey,
+                                      myUser: c.myUser.value,
+                                      actions: [
+                                        ContextMenuBuilder(
+                                          (_) => Obx(() {
+                                            final hasWork = c.settings.value
+                                                    ?.workWithUsTabEnabled ==
+                                                true;
 
-                                              return ContextMenuTile(
-                                                asset: SvgIcons.partner,
-                                                label:
-                                                    'label_work_with_us'.l10n,
-                                                pinned: hasWork,
-                                                onPressed: (_) =>
-                                                    c.setWorkWithUsTabEnabled(
-                                                  !hasWork,
-                                                ),
-                                              );
-                                            }),
-                                          ),
-                                          const ContextMenuDivider(),
-                                        ],
-                                      );
-                                    });
-                                }
-                              }).toList(),
-                              currentIndex: c.tabs.indexOf(router.tab),
-                              onTap: (i) => c.pages.jumpToPage(c.tabs[i].index),
-                            );
-                          }),
+                                            return ContextMenuTile(
+                                              asset: SvgIcons.partner,
+                                              label: 'label_work_with_us'.l10n,
+                                              pinned: hasWork,
+                                              onPressed: (_) =>
+                                                  c.setWorkWithUsTabEnabled(
+                                                !hasWork,
+                                              ),
+                                            );
+                                          }),
+                                        ),
+                                        const ContextMenuDivider(),
+                                      ],
+                                    );
+                                  });
+                              }
+                            }).toList(),
+                            currentIndex: tabs.indexOf(router.tab),
+                            onTap: (i) => c.pages.jumpToPage(tabs[i].index),
+                          ),
                         );
                       }),
                     ),

--- a/lib/ui/widget/svg/svgs.dart
+++ b/lib/ui/widget/svg/svgs.dart
@@ -180,8 +180,8 @@ class SvgIcons {
 
   static const SvgData contactsSwitch = SvgData(
     'assets/icons/contacts_switch.svg',
-    width: 27.01,
-    height: 23.36,
+    width: 22.4,
+    height: 20.8,
   );
 
   static const SvgData register = SvgData(


### PR DESCRIPTION
## Synopsis

It was decided that contacts tab button should be moved to the app bar of chats tab.




## Solution

This PR moves the button from bottom navigation bar to the app bar of chats tab.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
