### PR TITLE
Messages might stuck at last, not loading the rest, despite `Chat.lastItem` changed (#691)

### DIFF
--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -1554,7 +1554,7 @@ class HiveRxChat extends RxChat {
               '$runtimeType($id)',
             );
 
-            if(chatEntity != null && WebUtils.isPopup) {
+            if (chatEntity != null && WebUtils.isPopup) {
               chat.value = chatEntity.value;
             }
 

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -1554,8 +1554,11 @@ class HiveRxChat extends RxChat {
               '$runtimeType($id)',
             );
 
-            if (chatEntity != null && WebUtils.isPopup) {
-              chat.value = chatEntity.value;
+            // Be sure to keep the [chat] up to date with the [chatEntity], when
+            // in [WebUtils.isPopup], as in such cases local Hive subscriptions
+            // might not work due to Hive restrictions in multiple Web tabs.
+            if (WebUtils.isPopup) {
+              chat.value = chatEntity?.value ?? chat.value;
             }
 
             return;

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -1571,8 +1571,10 @@ class HiveRxChat extends RxChat {
 
           chatEntity.ver = versioned.ver;
 
-          // Update the [chat] value as popup window doesn't write to [Hive] and
-          // we should use [chat] value for synchronization.
+          // Use the [chat] value instead of [chatEntity], when in
+          // [WebUtils.isPopup], as in such cases we can't rely on [Hive] having
+          // actual data (especially when multiple events are received one after
+          // another).
           if (WebUtils.isPopup) {
             chatEntity.value = chat.value;
           }
@@ -1983,10 +1985,10 @@ class HiveRxChat extends RxChat {
 
   /// Puts the provided [chat] to the [Hive] using the provided [txn].
   Future<void> _putChat(HiveChat chat, HiveTransaction<HiveChat> txn) async {
-    // TODO: https://github.com/team113/messenger/issues/27
-    // Don't write to [Hive] from popup, as [Hive] doesn't support isolate
-    // synchronization, thus writes from multiple applications may lead to
-    // missing events.
+    // TODO: Don't write to [Hive] from popup, as [Hive] doesn't support isolate
+    //       synchronization, thus writes from multiple applications may lead to
+    //       missing events:
+    //       https://github.com/team113/messenger/issues/27
     if (WebUtils.isPopup) {
       this.chat.value = chat.value;
       this.chat.refresh();


### PR DESCRIPTION
Resolves #691




## Synopsis

Иногда новые сообщения могут не повиться в чате.




## Solution

Проблема будет исправлена.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
