### PR TITLE
Set `Cross-Origin-Embedder-Policy` header to `credentialless`

### DIFF
--- a/helm/messenger/CHANGELOG.md
+++ b/helm/messenger/CHANGELOG.md
@@ -6,6 +6,18 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.1.3] · 2024-??-?? (unreleased)
+[0.1.3]: https://github.com/team113/messenger/tree/helm%2Fmessenger%2F0.1.3/helm/messenger
+
+### Added
+
+- `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers to [Nginx] configuration. ([#1002])
+
+[#1002]: https://github.com/team113/messenger/pull/1002
+
+
+
+
 ## [0.1.2] · 2024-04-19
 [0.1.2]: https://github.com/team113/messenger/tree/helm%2Fmessenger%2F0.1.2/helm/messenger
 

--- a/helm/messenger/conf/nginx.conf
+++ b/helm/messenger/conf/nginx.conf
@@ -63,9 +63,9 @@ server {
   }
 
   location / {
-    # Required for `SharedArrayBuffer` used by `drift` for OPFS (which is more
-    # performant than IndexedDB) to be accessible:
-    # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
+    # Required for `SharedArrayBuffer` to be accessible, which is used for:
+    # - WebAssemly rendering;
+    # - OPFS for `drift`.
     add_header   'Cross-Origin-Embedder-Policy' 'credentialless' always;
     add_header   'Cross-Origin-Opener-Policy' 'same-origin' always;
 

--- a/helm/messenger/conf/nginx.conf
+++ b/helm/messenger/conf/nginx.conf
@@ -135,7 +135,7 @@ server {
     add_header    'Access-Control-Allow-Origin' *;
     add_header    'Access-Control-Allow-Credentials' 'false' always;
     add_header    'Access-Control-Allow-Methods' 'GET, HEAD, OPTIONS' always;
-    add_header    'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,Range,User-Agent,X-Requested-With' always;
+    add_header    'Access-Control-Allow-Headers' 'Accept,Accept-Language,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,Range,User-Agent,X-Requested-With' always;
     add_header    'Cross-Origin-Resource-Policy' 'cross-origin' always;
   }
 

--- a/helm/messenger/conf/nginx.conf
+++ b/helm/messenger/conf/nginx.conf
@@ -64,10 +64,11 @@ server {
 
   location / {
     # Required for `SharedArrayBuffer` to be accessible, which is used for:
-    # - WebAssemly rendering;
+    # - WASM rendering.
     # - OPFS for `drift`.
-    add_header   'Cross-Origin-Embedder-Policy' 'credentialless' always;
-    add_header   'Cross-Origin-Opener-Policy' 'same-origin' always;
+    # See: https://resourcepolicy.fyi
+    add_header    'Cross-Origin-Embedder-Policy' 'require-corp' always;
+    add_header    'Cross-Origin-Opener-Policy' 'same-origin' always;
 
     try_files    $uri $uri/ /index.html;
   }
@@ -87,12 +88,12 @@ server {
   # These rules are for Docker Compose only and are never triggered in
   # Kubernetes Pod due to Ingress routing rules.
   location ^~ /api/ {
-    if ($request_method = OPTIONS ) {
+    if ($request_method = OPTIONS) {
       add_header    'Content-Length' 0;
       add_header    'Content-Type' 'text/plain';
       add_header    'Access-Control-Allow-Origin' * always;
-      add_header    'Access-Control-Allow-Credentials' 'true' always;
-      add_header    'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+      add_header    'Access-Control-Allow-Credentials' 'false' always;
+      add_header    'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS' always;
       add_header    'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,Range,User-Agent,X-Requested-With' always;
       return 200;
     }
@@ -105,8 +106,8 @@ server {
     proxy_set_header      Upgrade $http_upgrade;
     proxy_set_header      Connection $connection_upgrade;
     add_header            'Access-Control-Allow-Origin' * always;
-    add_header            'Access-Control-Allow-Credentials' 'true' always;
-    add_header            'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+    add_header            'Access-Control-Allow-Credentials' 'false' always;
+    add_header            'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS' always;
     add_header            'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,Range,User-Agent,X-Requested-With' always;
   }
   location ^~ /api/medea/ {
@@ -119,8 +120,8 @@ server {
     proxy_set_header      Upgrade $http_upgrade;
     proxy_set_header      Connection $connection_upgrade;
     add_header            'Access-Control-Allow-Origin' * always;
-    add_header            'Access-Control-Allow-Credentials' 'true' always;
-    add_header            'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+    add_header            'Access-Control-Allow-Credentials' 'false' always;
+    add_header            'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS' always;
     add_header            'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,Range,User-Agent,X-Requested-With' always;
   }
 
@@ -132,9 +133,10 @@ server {
     rewrite       ^/files/(.*) /$1  break;
     proxy_pass    http://$upstream$uri$is_args$args;
     add_header    'Access-Control-Allow-Origin' *;
-    add_header    'Access-Control-Allow-Credentials' 'true' always;
-    add_header    'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+    add_header    'Access-Control-Allow-Credentials' 'false' always;
+    add_header    'Access-Control-Allow-Methods' 'GET, HEAD, OPTIONS' always;
     add_header    'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,Range,User-Agent,X-Requested-With' always;
+    add_header    'Cross-Origin-Resource-Policy' 'cross-origin' always;
   }
 
   # Disable unnecessary access logs.

--- a/helm/messenger/conf/nginx.conf
+++ b/helm/messenger/conf/nginx.conf
@@ -63,15 +63,13 @@ server {
   }
 
   location / {
-    try_files    $uri $uri/ /index.html;
-  }
-
-  location = /index.html {
     # Required for `SharedArrayBuffer` used by `drift` for OPFS (which is more
     # performant than IndexedDB) to be accessible:
     # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
-    add_header   'Cross-Origin-Embedder-Policy' 'require-corp' always;
+    add_header   'Cross-Origin-Embedder-Policy' 'credentialless' always;
     add_header   'Cross-Origin-Opener-Policy' 'same-origin' always;
+
+    try_files    $uri $uri/ /index.html;
   }
 
   location = /conf.toml {


### PR DESCRIPTION
## Synopsis

WebAssembly and OPFS (`drift`) require application to be served with `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers set.

Note, that `drift` will use IndexedDB, if OPFS isn't available due to site missing the headers, or due to browser not supporting it (only Firefox supports OPFS as of now, and as tested `drift` indeed uses it there). 




## Solution

This PR sets `Cross-Origin-Embedder-Policy` to be `credentialless`:

```
Because your site has the Cross-Origin Embedder Policy (COEP) enabled, each resource must specify a suitable Cross-Origin Resource Policy (CORP). This behavior prevents a document from loading cross-origin resources which don’t explicitly grant permission to be loaded.

To solve this, add the following to the resource’ response header:
- Cross-Origin-Resource-Policy: same-site if the resource and your site are served from the same site.
- Cross-Origin-Resource-Policy: cross-origin if the resource is served from another location than your website. ⚠️If you set this header, any website can embed this resource.

Alternatively, the document can use the variant: Cross-Origin-Embedder-Policy: credentialless instead of require-corp. It allows loading the resource, despite the missing CORP header, at the cost of requesting it without credentials like Cookies.
```




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
