### PR TITLE
Bump up `messenger` Helm chart version to 0.1.3

### DIFF
--- a/helm/messenger/CHANGELOG.md
+++ b/helm/messenger/CHANGELOG.md
@@ -6,7 +6,7 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## [0.1.3] · 2024-??-?? (unreleased)
+## [0.1.3] · 2024-05-16
 [0.1.3]: https://github.com/team113/messenger/tree/helm%2Fmessenger%2F0.1.3/helm/messenger
 
 ### Added

--- a/helm/messenger/CHANGELOG.md
+++ b/helm/messenger/CHANGELOG.md
@@ -6,7 +6,7 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## [0.1.3] · 2024-05-16
+## [0.1.3] · 2024-05-17
 [0.1.3]: https://github.com/team113/messenger/tree/helm%2Fmessenger%2F0.1.3/helm/messenger
 
 ### Added

--- a/helm/messenger/CHANGELOG.md
+++ b/helm/messenger/CHANGELOG.md
@@ -6,6 +6,18 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.1.3] · 2024-??-?? (unreleased)
+[0.1.3]: https://github.com/team113/messenger/tree/helm%2Fmessenger%2F0.1.3/helm/messenger
+
+### Added
+
+- `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers to [Nginx] configuration. ([#1002])
+
+[#1002]: https://github.com/team113/messenger/pull/1002
+
+
+
+
 ## [0.1.2] · 2024-04-19
 [0.1.2]: https://github.com/team113/messenger/tree/helm%2Fmessenger%2F0.1.2/helm/messenger
 

--- a/helm/messenger/Chart.yaml
+++ b/helm/messenger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: messenger
 description: Open-source front-end part of messenger by team113.
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.1.0-alpha.13.5
 type: application
 sources:

--- a/helm/messenger/conf/nginx.conf
+++ b/helm/messenger/conf/nginx.conf
@@ -63,9 +63,9 @@ server {
   }
 
   location / {
-    # Required for `SharedArrayBuffer` used by `drift` for OPFS (which is more
-    # performant than IndexedDB) to be accessible:
-    # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
+    # Required for `SharedArrayBuffer` to be accessible, which is used for:
+    # - WebAssemly rendering;
+    # - OPFS for `drift`.
     add_header   'Cross-Origin-Embedder-Policy' 'credentialless' always;
     add_header   'Cross-Origin-Opener-Policy' 'same-origin' always;
 

--- a/helm/messenger/conf/nginx.conf
+++ b/helm/messenger/conf/nginx.conf
@@ -63,15 +63,13 @@ server {
   }
 
   location / {
-    try_files    $uri $uri/ /index.html;
-  }
-
-  location = /index.html {
     # Required for `SharedArrayBuffer` used by `drift` for OPFS (which is more
     # performant than IndexedDB) to be accessible:
     # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
-    add_header   'Cross-Origin-Embedder-Policy' 'require-corp' always;
+    add_header   'Cross-Origin-Embedder-Policy' 'credentialless' always;
     add_header   'Cross-Origin-Opener-Policy' 'same-origin' always;
+
+    try_files    $uri $uri/ /index.html;
   }
 
   location = /conf.toml {


### PR DESCRIPTION
Prepares 0.1.3 `messenger` Helm chart release.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Name contains milestone reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entries][l:3] are verified and corrected
        - [x] [Deployment instructions][l:3] are verified and corrected (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
