### PR TITLE
Fix embedded resources missing `Cross-Origin-Embedder-Policy` header

### DIFF
--- a/helm/messenger/CHANGELOG.md
+++ b/helm/messenger/CHANGELOG.md
@@ -6,6 +6,18 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.1.4] · 2024-??-??
+[0.1.4]: https://github.com/team113/messenger/tree/helm%2Fmessenger%2F0.1.4/helm/messenger
+
+### Fixed
+
+- Embedded resources missing `Cross-Origin-Embedder-Policy` header. ([#1011])
+
+[#1011]: https://github.com/team113/messenger/pull/1011
+
+
+
+
 ## [0.1.3] · 2024-05-17
 [0.1.3]: https://github.com/team113/messenger/tree/helm%2Fmessenger%2F0.1.3/helm/messenger
 

--- a/helm/messenger/values.yaml
+++ b/helm/messenger/values.yaml
@@ -89,6 +89,8 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: "30m"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Cross-Origin-Embedder-Policy: require-corp";
 
 
 sftp:


### PR DESCRIPTION
Related to #996
Related to #998 
Related to #1002 




## Synopsis

We've added `Cross-Origin-Embedder-Policy` header in #1002 to support `drift` OPFS and WebAssembly building (those use the `SharedArrayBuffer`s available only on cross origin isolated sites). However, it turned out that not only the resource embedding other resources must have COEP header, but the embedded resources must have one as well:

<img width="1099" alt="Снимок экрана 2024-05-20 в 09 28 22" src="https://github.com/team113/messenger/assets/21217248/b8240147-e967-4e58-b394-f73e8ab53f1e">
<img width="1099" alt="Снимок экрана 2024-05-20 в 09 33 42" src="https://github.com/team113/messenger/assets/21217248/da5e4448-3cda-43d1-9bd9-6ee1c05a5b88">





## Solution

This PR adds COEP header to each nginx hosted resource (e.g. `drift_worker.dart.js`).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
