### PR TITLE
Migrate `MyUser`s to `drift`

### DIFF
--- a/lib/api/backend/extension/my_user.dart
+++ b/lib/api/backend/extension/my_user.dart
@@ -21,7 +21,6 @@ import '/domain/model/my_user.dart';
 import '/domain/model/session.dart';
 import '/domain/model/user.dart';
 import '/provider/hive/blocklist.dart';
-import '/provider/hive/my_user.dart';
 import '/store/model/my_user.dart';
 import 'user.dart';
 
@@ -65,18 +64,18 @@ extension MyUserConversion on MyUserMixin {
             : null,
       );
 
-  /// Constructs a new [HiveMyUser] from this [MyUserMixin].
-  HiveMyUser toHive() => HiveMyUser(toModel(), ver);
+  /// Constructs a new [DtoMyUser] from this [MyUserMixin].
+  DtoMyUser toDto() => DtoMyUser(toModel(), ver);
 }
 
 /// Extension adding models construction from a
 /// [MyUserEvents$Subscription$MyUserEvents$MyUser].
 extension MyUserEventsMyUserConversion
     on MyUserEvents$Subscription$MyUserEvents$MyUser {
-  /// Constructs a new [HiveMyUser] from this
+  /// Constructs a new [DtoMyUser] from this
   /// [MyUserEvents$Subscription$MyUserEvents$MyUser].
-  HiveMyUser toHive() =>
-      HiveMyUser(toModel()..blocklistCount = blocklist.totalCount, ver);
+  DtoMyUser toDto() =>
+      DtoMyUser(toModel()..blocklistCount = blocklist.totalCount, ver);
 }
 
 /// Extension adding models construction from a [BlocklistRecordMixin].

--- a/lib/domain/model/mute_duration.dart
+++ b/lib/domain/model/mute_duration.dart
@@ -34,7 +34,7 @@ class MuteDuration {
   factory MuteDuration.until(PreciseDateTime until) =>
       MuteDuration(until: until);
 
-  /// Constructs a [User] from the provided [json].
+  /// Constructs a [MuteDuration] from the provided [json].
   factory MuteDuration.fromJson(Map<String, dynamic> json) =>
       _$MuteDurationFromJson(json);
 

--- a/lib/domain/model/mute_duration.dart
+++ b/lib/domain/model/mute_duration.dart
@@ -16,6 +16,7 @@
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
 import 'package:hive/hive.dart';
+import 'package:json_annotation/json_annotation.dart';
 
 import '../model_type_id.dart';
 import 'precise_date_time/precise_date_time.dart';
@@ -23,8 +24,20 @@ import 'precise_date_time/precise_date_time.dart';
 part 'mute_duration.g.dart';
 
 /// Mute duration of a [Chat] or [MyUser].
+@JsonSerializable()
 @HiveType(typeId: ModelTypeId.muteDuration)
 class MuteDuration {
+  MuteDuration({this.until, this.forever});
+
+  factory MuteDuration.forever() => MuteDuration(forever: true);
+
+  factory MuteDuration.until(PreciseDateTime until) =>
+      MuteDuration(until: until);
+
+  /// Constructs a [User] from the provided [json].
+  factory MuteDuration.fromJson(Map<String, dynamic> json) =>
+      _$MuteDurationFromJson(json);
+
   /// Mute duration until an exact [PreciseDateTime].
   ///
   /// Once this [PreciseDateTime] pasts (or is in the past already), it should
@@ -36,21 +49,13 @@ class MuteDuration {
   @HiveField(1)
   bool? forever;
 
-  @HiveField(2)
-  MuteDuration({
-    this.until,
-    this.forever,
-  });
-
-  factory MuteDuration.forever() => MuteDuration(forever: true);
-
-  factory MuteDuration.until(PreciseDateTime until) =>
-      MuteDuration(until: until);
-
   @override
   bool operator ==(Object other) =>
       other is MuteDuration && until == other.until && forever == other.forever;
 
   @override
   int get hashCode => Object.hash(until, forever);
+
+  /// Returns a [Map] representing this [MuteDuration].
+  Map<String, dynamic> toJson() => _$MuteDurationToJson(this);
 }

--- a/lib/domain/model/my_user.dart
+++ b/lib/domain/model/my_user.dart
@@ -46,8 +46,8 @@ class MyUser extends HiveObject {
     this.chatDirectLink,
     this.unreadChatsCount = 0,
     this.status,
-    this.callCover,
     this.avatar,
+    this.callCover,
     required this.presenceIndex,
     required this.online,
     this.muted,
@@ -191,6 +191,7 @@ class MyUser extends HiveObject {
 }
 
 /// List of [UserPhone]s associated with [MyUser].
+@JsonSerializable()
 @HiveType(typeId: ModelTypeId.myUserPhones)
 class MyUserPhones {
   MyUserPhones({

--- a/lib/domain/model/my_user.dart
+++ b/lib/domain/model/my_user.dart
@@ -17,6 +17,7 @@
 
 import 'package:get/get_utils/get_utils.dart';
 import 'package:hive/hive.dart';
+import 'package:json_annotation/json_annotation.dart';
 
 import '/api/backend/schema.dart';
 import '/domain/model/avatar.dart';
@@ -30,6 +31,7 @@ import 'user.dart';
 part 'my_user.g.dart';
 
 /// `User` of an application being currently signed-in.
+@JsonSerializable()
 @HiveType(typeId: ModelTypeId.myUser)
 class MyUser extends HiveObject {
   MyUser({
@@ -52,6 +54,9 @@ class MyUser extends HiveObject {
     this.blocklistCount,
     this.lastSeenAt,
   });
+
+  /// Constructs a [MyUser] from the provided [json].
+  factory MyUser.fromJson(Map<String, dynamic> json) => _$MyUserFromJson(json);
 
   /// Unique ID of this [MyUser].
   ///
@@ -180,6 +185,9 @@ class MyUser extends HiveObject {
         blocklistCount: blocklistCount,
         lastSeenAt: lastSeenAt,
       );
+
+  /// Returns a [Map] representing this [MyUser].
+  Map<String, dynamic> toJson() => _$MyUserToJson(this);
 }
 
 /// List of [UserPhone]s associated with [MyUser].
@@ -189,6 +197,10 @@ class MyUserPhones {
     required this.confirmed,
     this.unconfirmed,
   });
+
+  /// Constructs the [MyUserPhones] from the provided [json].
+  factory MyUserPhones.fromJson(Map<String, dynamic> json) =>
+      _$MyUserPhonesFromJson(json);
 
   /// List of already confirmed phone numbers.
   ///
@@ -210,15 +222,23 @@ class MyUserPhones {
   /// Returns a copy of these [MyUserPhones].
   MyUserPhones copyWith() =>
       MyUserPhones(confirmed: confirmed, unconfirmed: unconfirmed);
+
+  /// Returns a [Map] representing these [MyUserPhones].
+  Map<String, dynamic> toJson() => _$MyUserPhonesToJson(this);
 }
 
 /// List of [UserEmail]s associated with [MyUser].
+@JsonSerializable()
 @HiveType(typeId: ModelTypeId.myUserEmails)
 class MyUserEmails {
   MyUserEmails({
     required this.confirmed,
     this.unconfirmed,
   });
+
+  /// Constructs the [MyUserEmails] from the provided [json].
+  factory MyUserEmails.fromJson(Map<String, dynamic> json) =>
+      _$MyUserEmailsFromJson(json);
 
   /// List of already confirmed email addresses.
   ///
@@ -240,6 +260,9 @@ class MyUserEmails {
   /// Returns a copy of these [MyUserEmails].
   MyUserEmails copyWith() =>
       MyUserEmails(confirmed: confirmed, unconfirmed: unconfirmed);
+
+  /// Returns a [Map] representing these [MyUserEmails].
+  Map<String, dynamic> toJson() => _$MyUserEmailsToJson(this);
 }
 
 /// Confirmation code used by [MyUser].
@@ -257,6 +280,9 @@ class ConfirmationCode extends NewType<String> {
   /// Creates an object without any validation.
   const factory ConfirmationCode.unchecked(String val) = ConfirmationCode._;
 
+  /// Constructs a [ConfirmationCode] from the provided [val].
+  factory ConfirmationCode.fromJson(String val) = ConfirmationCode.unchecked;
+
   /// Parses the provided [val] as a [ConfirmationCode], if [val] meets the
   /// validation, or returns `null` otherwise.
   static ConfirmationCode? tryParse(String val) {
@@ -266,4 +292,7 @@ class ConfirmationCode extends NewType<String> {
       return null;
     }
   }
+
+  /// Returns a [String] representing this [ConfirmationCode].
+  String toJson() => val;
 }

--- a/lib/domain/model_type_id.dart
+++ b/lib/domain/model_type_id.dart
@@ -52,7 +52,7 @@ class ModelTypeId {
   static const user = 29;
   static const chatContact = 30;
   static const hiveChatContact = 31;
-  static const hiveMyUser = 32;
+  static const dtoMyUser = 32;
   static const chatContactsListVersion = 34;
   static const sessionData = 35;
   static const recentChatsCursor = 36;

--- a/lib/domain/repository/my_user.dart
+++ b/lib/domain/repository/my_user.dart
@@ -50,9 +50,6 @@ abstract class AbstractMyUserRepository {
   /// Disposes the repository.
   void dispose();
 
-  /// Deletes the stored [MyUser]s.
-  Future<void> clearCache();
-
   /// Updates [MyUser.name] field for the authenticated [MyUser].
   ///
   /// Resets [MyUser.name] field to `null` for the authenticated [MyUser] if

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'domain/service/auth.dart';
 import 'firebase_options.dart';
 import 'l10n/l10n.dart';
 import 'provider/drift/drift.dart';
+import 'provider/drift/my_user.dart';
 import 'provider/gql/exceptions.dart';
 import 'provider/gql/graphql.dart';
 import 'provider/hive/account.dart';
@@ -102,6 +103,8 @@ Future<void> main() async {
       ),
     );
 
+    final myUserProvider = Get.put(MyUserDriftProvider(Get.find()));
+
     await _initHive();
 
     if (PlatformUtils.isDesktop && !PlatformUtils.isWeb) {
@@ -128,7 +131,7 @@ Future<void> main() async {
 
     final authRepository = Get.put<AbstractAuthRepository>(AuthRepository(
       graphQlProvider,
-      Get.find(),
+      myUserProvider,
       Get.find(),
     ));
     final authService = Get.put(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -97,8 +97,8 @@ Future<void> main() async {
     WebUtils.setPathUrlStrategy();
 
     Get.put(
-      DriftProvider.from(
-        Get.putOrGet(() => AppDatabase(), permanent: true),
+      CommonDriftProvider.from(
+        Get.putOrGet(() => CommonDatabase(), permanent: true),
       ),
     );
 

--- a/lib/provider/drift/connection/ffi.dart
+++ b/lib/provider/drift/connection/ffi.dart
@@ -24,11 +24,15 @@ import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart';
 import 'package:sqlite3_flutter_libs/sqlite3_flutter_libs.dart';
 
+import '/domain/model/user.dart';
+
 /// Obtains a database connection for running `drift` in a Dart VM.
-QueryExecutor connect() {
+QueryExecutor connect([UserId? userId]) {
   return LazyDatabase(() async {
     final Directory dbFolder = await getApplicationDocumentsDirectory();
-    final File file = File(p.join(dbFolder.path, 'db.sqlite'));
+    final File file = File(
+      p.join(dbFolder.path, '${userId?.val ?? 'common'}.sqlite'),
+    );
 
     // Workaround limitations on old Android versions.
     if (Platform.isAndroid) {

--- a/lib/provider/drift/connection/interface.dart
+++ b/lib/provider/drift/connection/interface.dart
@@ -17,8 +17,10 @@
 
 import 'package:drift/drift.dart';
 
+import '/domain/model/user.dart';
+
 /// Obtains a database connection for running `drift`.
-QueryExecutor connect() {
+QueryExecutor connect([UserId? userId]) {
   throw UnsupportedError('`drift` isn\'t supported on this platform.');
 }
 

--- a/lib/provider/drift/drift.dart
+++ b/lib/provider/drift/drift.dart
@@ -247,7 +247,7 @@ final class ScopedDriftProvider extends DisposableInterface {
   }
 }
 
-/// [DriftProvider] with common helper and utility methods over it.
+/// [CommonDriftProvider] with common helper and utility methods over it.
 abstract class DriftProviderBase {
   const DriftProviderBase(this._provider);
 
@@ -267,7 +267,7 @@ abstract class DriftProviderBase {
   /// Runs the [callback] through a non-closed [CommonDatabase], or returns
   /// `null`.
   ///
-  /// [AppDatabase] may be closed, for example, between E2E tests.
+  /// [CommonDatabase] may be closed, for example, between E2E tests.
   Future<T?> safe<T>(Future<T> Function(CommonDatabase db) callback) async {
     if (db == null) {
       return null;
@@ -277,6 +277,7 @@ abstract class DriftProviderBase {
   }
 }
 
+/// [ScopedDriftProvider] with common helper and utility methods over it.
 abstract class DriftProviderBaseWithScope {
   const DriftProviderBaseWithScope(this._common, this._scoped);
 
@@ -301,10 +302,10 @@ abstract class DriftProviderBaseWithScope {
     await scoped?.transaction(action);
   }
 
-  /// Runs the [callback] through a non-closed [CommonDatabase], or returns
+  /// Runs the [callback] through a non-closed [ScopedDatabase], or returns
   /// `null`.
   ///
-  /// [AppDatabase] may be closed, for example, between E2E tests.
+  /// [ScopedDatabase] may be closed, for example, between E2E tests.
   Future<T?> safe<T>(Future<T> Function(ScopedDatabase db) callback) async {
     if (scoped == null) {
       return null;

--- a/lib/provider/drift/drift.dart
+++ b/lib/provider/drift/drift.dart
@@ -32,7 +32,7 @@ import 'user.dart';
 
 part 'drift.g.dart';
 
-/// [DriftDatabase] storing data locally.
+/// [DriftDatabase] storing common and shared between multiple [MyUser]s data.
 @DriftDatabase(tables: [MyUsers])
 class CommonDatabase extends _$CommonDatabase {
   CommonDatabase([QueryExecutor? e]) : super(e ?? connect());
@@ -86,7 +86,7 @@ class CommonDatabase extends _$CommonDatabase {
   }
 }
 
-/// [DriftDatabase] storing data locally.
+/// [DriftDatabase] storing [MyUser] scoped data.
 @DriftDatabase(
   tables: [Users, ChatItems, ChatItemViews, ChatMembers],
   queries: {
@@ -259,7 +259,7 @@ abstract class DriftProviderBase {
   /// `null` here means the database is closed.
   CommonDatabase? get db => _provider.db;
 
-  /// Completes the provided [action] as a transaction.
+  /// Completes the provided [action] as a [db] transaction.
   Future<void> txn<T>(Future<T> Function() action) async {
     await db?.transaction(action);
   }
@@ -297,7 +297,7 @@ abstract class DriftProviderBaseWithScope {
   /// `null` here means the database is closed.
   ScopedDatabase? get scoped => _scoped.db;
 
-  /// Completes the provided [action] as a transaction.
+  /// Completes the provided [action] as a [scoped] transaction.
   Future<void> txn<T>(Future<T> Function() action) async {
     await scoped?.transaction(action);
   }

--- a/lib/provider/drift/drift.dart
+++ b/lib/provider/drift/drift.dart
@@ -249,29 +249,67 @@ final class ScopedDriftProvider extends DisposableInterface {
 
 /// [DriftProvider] with common helper and utility methods over it.
 abstract class DriftProviderBase {
-  const DriftProviderBase(this._common);
+  const DriftProviderBase(this._provider);
 
   /// [CommonDriftProvider] itself.
-  final CommonDriftProvider _common;
+  final CommonDriftProvider _provider;
 
-  /// Returns the [AppDatabase].
+  /// Returns the [CommonDatabase].
   ///
   /// `null` here means the database is closed.
-  AppDatabase? get db => _provider.db;
+  CommonDatabase? get db => _provider.db;
 
   /// Completes the provided [action] as a transaction.
   Future<void> txn<T>(Future<T> Function() action) async {
     await db?.transaction(action);
   }
 
-  /// Runs the [callback] through a non-closed [AppDatabase], or returns `null`.
+  /// Runs the [callback] through a non-closed [CommonDatabase], or returns
+  /// `null`.
   ///
   /// [AppDatabase] may be closed, for example, between E2E tests.
-  Future<T?> safe<T>(Future<T> Function(AppDatabase db) callback) async {
+  Future<T?> safe<T>(Future<T> Function(CommonDatabase db) callback) async {
     if (db == null) {
       return null;
     }
 
     return await callback(db!);
+  }
+}
+
+abstract class DriftProviderBaseWithScope {
+  const DriftProviderBaseWithScope(this._common, this._scoped);
+
+  /// [CommonDriftProvider] itself.
+  final CommonDriftProvider _common;
+
+  /// [ScopedDriftProvider] itself.
+  final ScopedDriftProvider _scoped;
+
+  /// Returns the [CommonDatabase].
+  ///
+  /// `null` here means the database is closed.
+  CommonDatabase? get common => _common.db;
+
+  /// Returns the [ScopedDatabase].
+  ///
+  /// `null` here means the database is closed.
+  ScopedDatabase? get scoped => _scoped.db;
+
+  /// Completes the provided [action] as a transaction.
+  Future<void> txn<T>(Future<T> Function() action) async {
+    await scoped?.transaction(action);
+  }
+
+  /// Runs the [callback] through a non-closed [CommonDatabase], or returns
+  /// `null`.
+  ///
+  /// [AppDatabase] may be closed, for example, between E2E tests.
+  Future<T?> safe<T>(Future<T> Function(ScopedDatabase db) callback) async {
+    if (scoped == null) {
+      return null;
+    }
+
+    return await callback(scoped!);
   }
 }

--- a/lib/provider/drift/drift.dart
+++ b/lib/provider/drift/drift.dart
@@ -22,38 +22,23 @@ import 'package:log_me/log_me.dart';
 
 import '/domain/model/precise_date_time/precise_date_time.dart';
 import '/domain/model/sending_status.dart';
+import '/domain/model/user.dart';
 import 'chat_item.dart';
 import 'chat_member.dart';
 import 'common.dart';
 import 'connection/connection.dart';
+import 'my_user.dart';
 import 'user.dart';
 
 part 'drift.g.dart';
 
 /// [DriftDatabase] storing data locally.
-@DriftDatabase(
-  tables: [Users, ChatItems, ChatItemViews, ChatMembers],
-  queries: {
-    'chatItemsAround': ''
-        'SELECT * FROM '
-        '(SELECT * FROM chat_item_views '
-        'INNER JOIN chat_items ON chat_items.id = chat_item_views.chat_item_id '
-        'WHERE chat_item_views.chat_id = :chat_id AND at <= :at '
-        'ORDER BY at DESC LIMIT :before + 1) as a '
-        'UNION '
-        'SELECT * FROM '
-        '(SELECT * FROM chat_item_views '
-        'INNER JOIN chat_items ON chat_items.id = chat_item_views.chat_item_id '
-        'WHERE chat_item_views.chat_id = :chat_id AND at > :at '
-        'ORDER BY at ASC LIMIT :after) as b '
-        'ORDER BY at ASC;',
-  },
-)
-class AppDatabase extends _$AppDatabase {
-  AppDatabase([QueryExecutor? e]) : super(e ?? connect());
+@DriftDatabase(tables: [MyUsers])
+class CommonDatabase extends _$CommonDatabase {
+  CommonDatabase([QueryExecutor? e]) : super(e ?? connect());
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 1;
 
   @override
   MigrationStrategy get migration {
@@ -101,18 +86,92 @@ class AppDatabase extends _$AppDatabase {
   }
 }
 
-/// [AppDatabase] provider.
-final class DriftProvider extends DisposableInterface {
-  /// Constructs a [DriftProvider] with the in-memory database.
-  DriftProvider.memory() : db = AppDatabase(inMemory());
+/// [DriftDatabase] storing data locally.
+@DriftDatabase(
+  tables: [Users, ChatItems, ChatItemViews, ChatMembers],
+  queries: {
+    'chatItemsAround': ''
+        'SELECT * FROM '
+        '(SELECT * FROM chat_item_views '
+        'INNER JOIN chat_items ON chat_items.id = chat_item_views.chat_item_id '
+        'WHERE chat_item_views.chat_id = :chat_id AND at <= :at '
+        'ORDER BY at DESC LIMIT :before + 1) as a '
+        'UNION '
+        'SELECT * FROM '
+        '(SELECT * FROM chat_item_views '
+        'INNER JOIN chat_items ON chat_items.id = chat_item_views.chat_item_id '
+        'WHERE chat_item_views.chat_id = :chat_id AND at > :at '
+        'ORDER BY at ASC LIMIT :after) as b '
+        'ORDER BY at ASC;',
+  },
+)
+class ScopedDatabase extends _$ScopedDatabase {
+  ScopedDatabase(this.userId, [QueryExecutor? e]) : super(e ?? connect(userId));
 
-  /// Constructs a [DriftProvider] with the provided [db].
-  DriftProvider.from(this.db);
+  /// [UserId] this [ScopedDatabase] is linked to.
+  final UserId userId;
 
-  /// [AppDatabase] itself.
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration {
+    return MigrationStrategy(
+      onUpgrade: (m, a, b) async {
+        Log.info('MigrationStrategy.onUpgrade($a, $b)', '$runtimeType');
+
+        // TODO: Implement proper migrations.
+        if (a != b) {
+          for (var e in m.database.allTables) {
+            await m.deleteTable(e.actualTableName);
+          }
+        }
+
+        await m.createAll();
+      },
+      beforeOpen: (_) async {
+        Log.debug('MigrationStrategy.beforeOpen()', '$runtimeType');
+
+        await customStatement('PRAGMA foreign_keys = ON;');
+        await customStatement('PRAGMA journal_mode = WAL;');
+      },
+    );
+  }
+
+  /// Creates all tables, triggers, views, indexes and everything else defined
+  /// in the database, if they don't exist.
+  Future<void> create() async {
+    await createMigrator().createAll();
+  }
+
+  /// Resets everything, meaning dropping and re-creating every table.
+  Future<void> reset() async {
+    Log.debug('reset()', '$runtimeType');
+
+    for (var e in allSchemaEntities) {
+      if (e is TableInfo) {
+        await e.deleteAll();
+      } else {
+        await createMigrator().drop(e);
+      }
+    }
+
+    await createMigrator().createAll();
+  }
+}
+
+/// [CommonDatabase] provider.
+final class CommonDriftProvider extends DisposableInterface {
+  /// Constructs a [CommonDriftProvider] with the in-memory database.
+  CommonDriftProvider.memory() : db = CommonDatabase(inMemory());
+
+  /// Constructs a [CommonDriftProvider] with the provided [db].
+  CommonDriftProvider.from(this.db);
+
+  /// [CommonDatabase] itself.
   ///
   /// `null` here means the database is closed.
-  AppDatabase? db;
+  CommonDatabase? db;
 
   @override
   void onInit() async {
@@ -128,7 +187,7 @@ final class DriftProvider extends DisposableInterface {
     super.onClose();
   }
 
-  /// Closes this [DriftProvider].
+  /// Closes this [CommonDriftProvider].
   @visibleForTesting
   Future<void> close() async {
     final Future<void>? future = db?.close();
@@ -136,7 +195,51 @@ final class DriftProvider extends DisposableInterface {
     await future;
   }
 
-  /// Resets the [AppDatabase] and closes this [DriftProvider].
+  /// Resets the [CommonDatabase] and closes this [CommonDriftProvider].
+  Future<void> reset() async {
+    final Future<void>? future = db?.reset();
+    db = null;
+    await future;
+  }
+}
+
+/// [ScopedDatabase] provider.
+final class ScopedDriftProvider extends DisposableInterface {
+  /// Constructs a [ScopedDriftProvider] with the in-memory database.
+  ScopedDriftProvider.memory()
+      : db = ScopedDatabase(const UserId('me'), inMemory());
+
+  /// Constructs a [ScopedDriftProvider] with the provided [db].
+  ScopedDriftProvider.from(this.db);
+
+  /// [ScopedDatabase] itself.
+  ///
+  /// `null` here means the database is closed.
+  ScopedDatabase? db;
+
+  @override
+  void onInit() async {
+    Log.debug('onInit()', '$runtimeType');
+    await db?.create();
+    super.onInit();
+  }
+
+  @override
+  void onClose() async {
+    Log.debug('onClose()', '$runtimeType');
+    db = null;
+    super.onClose();
+  }
+
+  /// Closes this [ScopedDriftProvider].
+  @visibleForTesting
+  Future<void> close() async {
+    final Future<void>? future = db?.close();
+    db = null;
+    await future;
+  }
+
+  /// Resets the [ScopedDatabase] and closes this [ScopedDriftProvider].
   Future<void> reset() async {
     final Future<void>? future = db?.reset();
     db = null;
@@ -146,10 +249,10 @@ final class DriftProvider extends DisposableInterface {
 
 /// [DriftProvider] with common helper and utility methods over it.
 abstract class DriftProviderBase {
-  const DriftProviderBase(this._provider);
+  const DriftProviderBase(this._common);
 
-  /// [DriftProvider] itself.
-  final DriftProvider _provider;
+  /// [CommonDriftProvider] itself.
+  final CommonDriftProvider _common;
 
   /// Returns the [AppDatabase].
   ///

--- a/lib/provider/drift/my_user.dart
+++ b/lib/provider/drift/my_user.dart
@@ -75,10 +75,9 @@ class MyUserDriftProvider extends DriftProviderBase {
 
     final result = await safe((db) async {
       final DtoMyUser stored = _MyUserDb.fromDb(
-        await db.into(db.myUsers).insertReturning(
-              user.toDb(),
-              onConflict: DoUpdate((_) => user.toDb()),
-            ),
+        await db
+            .into(db.myUsers)
+            .insertReturning(user.toDb(), mode: InsertMode.insertOrReplace),
       );
 
       _controllers[stored.id]?.add(stored);

--- a/lib/provider/drift/my_user.dart
+++ b/lib/provider/drift/my_user.dart
@@ -1,0 +1,219 @@
+// Copyright © 2022-2024 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:async/async.dart';
+import 'package:drift/drift.dart';
+
+import '/domain/model/avatar.dart';
+import '/domain/model/chat.dart';
+import '/domain/model/user.dart';
+import '/domain/model/user_call_cover.dart';
+import '/store/model/my_user.dart';
+import '/store/model/user.dart';
+import 'common.dart';
+import 'drift.dart';
+
+/// [MyUser] to be stored in a [Table].
+@DataClassName('MyUserRow')
+class MyUsers extends Table {
+  @override
+  Set<Column> get primaryKey => {id};
+
+  TextColumn get id => text()();
+  TextColumn get num => text().unique()();
+  TextColumn get name => text().nullable()();
+  TextColumn get bio => text().nullable()();
+  TextColumn get avatar => text().nullable()();
+  TextColumn get callCover => text().nullable()();
+  IntColumn get mutualContactsCount =>
+      integer().withDefault(const Constant(0))();
+  BoolColumn get online => boolean().withDefault(const Constant(false))();
+  IntColumn get presenceIndex => integer().nullable()();
+  TextColumn get status => text().nullable()();
+  BoolColumn get isDeleted => boolean().withDefault(const Constant(false))();
+  TextColumn get dialog => text().nullable()();
+  TextColumn get isBlocked => text().nullable()();
+  IntColumn get lastSeenAt =>
+      integer().nullable().map(const PreciseDateTimeConverter())();
+  TextColumn get contacts => text().withDefault(const Constant('[]'))();
+  TextColumn get ver => text()();
+  TextColumn get blockedVer => text()();
+}
+
+/// [DriftProviderBase] for manipulating the persisted [User]s.
+class UserDriftProvider extends DriftProviderBase {
+  UserDriftProvider(super.database);
+
+  /// [StreamController] emitting [DtoUser]s in [watch].
+  final Map<UserId, StreamController<DtoUser?>> _controllers = {};
+
+  /// [DtoUser]s that have started the [upsert]ing, but not yet finished it.
+  final Map<UserId, DtoUser> _cache = {};
+
+  /// Creates or updates the provided [user] in the database.
+  Future<DtoUser> upsert(DtoUser user) async {
+    _cache[user.id] = user;
+
+    final result = await safe((db) async {
+      final DtoUser stored = UserDb.fromDb(
+        await db.into(db.users).insertReturning(
+              user.toDb(),
+              onConflict: DoUpdate((_) => user.toDb()),
+            ),
+      );
+
+      _controllers[stored.id]?.add(stored);
+
+      return stored;
+    });
+
+    _cache.remove(user.id);
+
+    return result ?? user;
+  }
+
+  /// Returns the [DtoUser] stored in the database by the provided [id], if
+  /// any.
+  Future<DtoUser?> read(UserId id) async {
+    final DtoUser? existing = _cache[id];
+    if (existing != null) {
+      return existing;
+    }
+
+    return await safe<DtoUser?>((db) async {
+      final stmt = db.select(db.users)..where((u) => u.id.equals(id.val));
+      final UserRow? row = await stmt.getSingleOrNull();
+
+      if (row == null) {
+        return null;
+      }
+
+      return UserDb.fromDb(row);
+    });
+  }
+
+  /// Deletes the [DtoUser] identified by the provided [id] from the database.
+  Future<void> delete(UserId id) async {
+    _cache.remove(id);
+
+    await safe((db) async {
+      final stmt = db.delete(db.users)..where((e) => e.id.equals(id.val));
+      await stmt.go();
+
+      _controllers[id]?.add(null);
+    });
+  }
+
+  /// Deletes all the [DtoUser]s stored in the database.
+  Future<void> clear() async {
+    _cache.clear();
+
+    await safe((db) async {
+      await db.delete(db.users).go();
+    });
+  }
+
+  /// Returns the [Stream] of real-time changes happening with the [DtoUser]
+  /// identified by the provided [id].
+  Stream<DtoUser?> watch(UserId id) {
+    if (db == null) {
+      return const Stream.empty();
+    }
+
+    final stmt = db!.select(db!.users)..where((u) => u.id.equals(id.val));
+
+    StreamController<DtoUser?>? controller = _controllers[id];
+    if (controller == null) {
+      controller = StreamController<DtoUser?>.broadcast(sync: true);
+      _controllers[id] = controller;
+    }
+
+    return StreamGroup.merge(
+      [
+        controller.stream,
+        stmt.watch().map((e) => e.isEmpty ? null : UserDb.fromDb(e.first)),
+      ],
+    );
+  }
+}
+
+/// Extension adding conversion methods from [UserRow] to [DtoUser].
+extension UserDb on DtoUser {
+  /// Constructs a [DtoUser] from the provided [UserRow].
+  static DtoUser fromDb(UserRow e) {
+    return DtoUser(
+      User(
+        UserId(e.id),
+        UserNum(e.num),
+        name: e.name == null ? null : UserName(e.name!),
+        bio: e.bio == null ? null : UserBio(e.bio!),
+        avatar: e.avatar == null
+            ? null
+            : UserAvatar.fromJson(jsonDecode(e.avatar!)),
+        callCover: e.callCover == null
+            ? null
+            : UserCallCover.fromJson(jsonDecode(e.callCover!)),
+        mutualContactsCount: e.mutualContactsCount,
+        online: e.online,
+        presenceIndex: e.presenceIndex,
+        status: e.status == null ? null : UserTextStatus(e.status!),
+        isDeleted: e.isDeleted,
+        dialog: e.dialog == null ? null : ChatId(e.dialog!),
+        isBlocked: e.isBlocked == null
+            ? null
+            : BlocklistRecord.fromJson(jsonDecode(e.isBlocked!)),
+        lastSeenAt: e.lastSeenAt,
+        contacts: (jsonDecode(e.contacts) as List)
+            .map((e) => NestedChatContact.fromJson(e))
+            .cast<NestedChatContact>()
+            .toList(),
+      ),
+      UserVersion(e.ver),
+      MyUserVersion(e.blockedVer),
+    );
+  }
+
+  /// Constructs a [UserRow] from this [DtoUser].
+  UserRow toDb() {
+    return UserRow(
+      id: value.id.val,
+      num: value.num.val,
+      name: value.name?.val,
+      bio: value.bio?.val,
+      avatar: value.avatar == null ? null : jsonEncode(value.avatar?.toJson()),
+      callCover: value.callCover == null
+          ? null
+          : jsonEncode(value.callCover?.toJson()),
+      mutualContactsCount: value.mutualContactsCount,
+      online: value.online,
+      presenceIndex: value.presenceIndex,
+      status: value.status?.val,
+      isDeleted: value.isDeleted,
+      dialog: value.dialog.val,
+      isBlocked: value.isBlocked == null
+          ? null
+          : jsonEncode(value.isBlocked?.toJson()),
+      lastSeenAt: value.lastSeenAt,
+      contacts: jsonEncode(value.contacts.map((e) => e.toJson()).toList()),
+      ver: ver.val,
+      blockedVer: blockedVer.val,
+    );
+  }
+}

--- a/lib/provider/drift/my_user.dart
+++ b/lib/provider/drift/my_user.dart
@@ -59,11 +59,11 @@ class MyUsers extends Table {
   TextColumn get ver => text()();
 }
 
-/// [DriftProviderBase] for manipulating the persisted [User]s.
+/// [DriftProviderBase] for manipulating the persisted [MyUser]s.
 class MyUserDriftProvider extends DriftProviderBase {
   MyUserDriftProvider(super.database);
 
-  /// [StreamController] emitting [DtoMyUser]s in [watch].
+  /// [StreamController] emitting [DtoMyUser]s in [watchSingle].
   final Map<UserId, StreamController<DtoMyUser?>> _controllers = {};
 
   /// [DtoMyUser]s that have started the [upsert]ing, but not yet finished it.
@@ -182,9 +182,9 @@ class MyUserDriftProvider extends DriftProviderBase {
   }
 }
 
-/// Extension adding conversion methods from [UserRow] to [DtoMyUser].
+/// Extension adding conversion methods from [MyUserRow] to [DtoMyUser].
 extension _MyUserDb on DtoMyUser {
-  /// Constructs a [DtoMyUser] from the provided [UserRow].
+  /// Constructs a [DtoMyUser] from the provided [MyUserRow].
   static DtoMyUser fromDb(MyUserRow e) {
     return DtoMyUser(
       MyUser(

--- a/lib/provider/drift/user.dart
+++ b/lib/provider/drift/user.dart
@@ -73,10 +73,9 @@ class UserDriftProvider extends DriftProviderBaseWithScope {
 
     final result = await safe((db) async {
       final DtoUser stored = UserDb.fromDb(
-        await db.into(db.users).insertReturning(
-              user.toDb(),
-              onConflict: DoUpdate((_) => user.toDb()),
-            ),
+        await db
+            .into(db.users)
+            .insertReturning(user.toDb(), mode: InsertMode.insertOrReplace),
       );
 
       _controllers[stored.id]?.add(stored);

--- a/lib/provider/drift/user.dart
+++ b/lib/provider/drift/user.dart
@@ -58,8 +58,8 @@ class Users extends Table {
 }
 
 /// [DriftProviderBase] for manipulating the persisted [User]s.
-class UserDriftProvider extends DriftProviderBase {
-  UserDriftProvider(super.database);
+class UserDriftProvider extends DriftProviderBaseWithScope {
+  UserDriftProvider(super.common, super.scoped);
 
   /// [StreamController] emitting [DtoUser]s in [watch].
   final Map<UserId, StreamController<DtoUser?>> _controllers = {};
@@ -133,11 +133,12 @@ class UserDriftProvider extends DriftProviderBase {
   /// Returns the [Stream] of real-time changes happening with the [DtoUser]
   /// identified by the provided [id].
   Stream<DtoUser?> watch(UserId id) {
-    if (db == null) {
+    if (scoped == null) {
       return const Stream.empty();
     }
 
-    final stmt = db!.select(db!.users)..where((u) => u.id.equals(id.val));
+    final stmt = scoped!.select(scoped!.users)
+      ..where((u) => u.id.equals(id.val));
 
     StreamController<DtoUser?>? controller = _controllers[id];
     if (controller == null) {

--- a/lib/provider/gql/components/user.dart
+++ b/lib/provider/gql/components/user.dart
@@ -427,10 +427,12 @@ mixin UserGraphQlMixin {
   /// This subscription could emit the same [EventUserDeleted] multiple times,
   /// so a client side is expected to handle it idempotently considering the
   /// `MyUser.ver`.
-  Stream<QueryResult> myUserEvents(MyUserVersion? Function() ver) {
+  Future<Stream<QueryResult>> myUserEvents(
+    Future<MyUserVersion?> Function() ver,
+  ) async {
     Log.debug('myUserEvents(ver)', '$runtimeType');
 
-    final variables = MyUserEventsArguments(ver: ver());
+    final variables = MyUserEventsArguments(ver: await ver());
     return client.subscribe(
       SubscriptionOptions(
         operationName: 'MyUserEvents',

--- a/lib/provider/hive/my_user.dart
+++ b/lib/provider/hive/my_user.dart
@@ -25,15 +25,12 @@ import '/domain/model/my_user.dart';
 import '/domain/model/precise_date_time/precise_date_time.dart';
 import '/domain/model/user.dart';
 import '/domain/model/user_call_cover.dart';
-import '/domain/model_type_id.dart';
 import '/store/model/my_user.dart';
 import '/util/log.dart';
 import 'base.dart';
 
-part 'my_user.g.dart';
-
 /// [Hive] storage for [MyUser].
-class MyUserHiveProvider extends HiveBaseProvider<HiveMyUser> {
+class MyUserHiveProvider extends HiveBaseProvider<DtoMyUser> {
   @override
   Stream<BoxEvent> get boxEvents => box.watch();
 
@@ -51,7 +48,7 @@ class MyUserHiveProvider extends HiveBaseProvider<HiveMyUser> {
     Hive.maybeRegisterAdapter(ChatDirectLinkSlugAdapter());
     Hive.maybeRegisterAdapter(ChatDirectLinkVersionAdapter());
     Hive.maybeRegisterAdapter(CropPointAdapter());
-    Hive.maybeRegisterAdapter(HiveMyUserAdapter());
+    Hive.maybeRegisterAdapter(DtoMyUserAdapter());
     Hive.maybeRegisterAdapter(ImageFileAdapter());
     Hive.maybeRegisterAdapter(MuteDurationAdapter());
     Hive.maybeRegisterAdapter(MyUserAdapter());
@@ -74,16 +71,16 @@ class MyUserHiveProvider extends HiveBaseProvider<HiveMyUser> {
   }
 
   /// Returns the stored [MyUser]s from [Hive].
-  Iterable<HiveMyUser> get myUsers => valuesSafe;
+  Iterable<DtoMyUser> get myUsers => valuesSafe;
 
   /// Saves the provided [MyUser] in [Hive].
-  Future<void> put(HiveMyUser user) async {
+  Future<void> put(DtoMyUser user) async {
     Log.trace('put($user)', '$runtimeType');
     await putSafe(user.value.id.val, user);
   }
 
   /// Returns the [MyUser] from [Hive] by its [id].
-  HiveMyUser? get(UserId id) {
+  DtoMyUser? get(UserId id) {
     Log.trace('get($id)', '$runtimeType');
     return getSafe(id.val);
   }
@@ -93,27 +90,4 @@ class MyUserHiveProvider extends HiveBaseProvider<HiveMyUser> {
     Log.trace('remove($id)', '$runtimeType');
     await deleteSafe(id.val);
   }
-}
-
-/// Persisted in [Hive] storage [MyUser]'s [value].
-@HiveType(typeId: ModelTypeId.hiveMyUser)
-class HiveMyUser extends HiveObject {
-  HiveMyUser(
-    this.value,
-    this.ver,
-  );
-
-  /// Persisted [MyUser] model.
-  @HiveField(0)
-  MyUser value;
-
-  /// Version of this [MyUser]'s state.
-  ///
-  /// It increases monotonically, so may be used (and is intended to) for
-  /// tracking state's actuality.
-  @HiveField(1)
-  MyUserVersion ver;
-
-  @override
-  String toString() => '$runtimeType($value, $ver)';
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -519,9 +519,12 @@ class AppRouterDelegate extends RouterDelegate<RouteConfiguration>
                 deps.put(MonologHiveProvider()).init(userId: me),
               ]);
 
-              deps.put(UserDriftProvider(Get.find()));
-              deps.put(ChatItemDriftProvider(Get.find()));
-              deps.put(ChatMemberDriftProvider(Get.find()));
+              final ScopedDriftProvider scoped = deps
+                  .put(ScopedDriftProvider.from(Get.put(ScopedDatabase(me))));
+
+              deps.put(UserDriftProvider(Get.find(), scoped));
+              deps.put(ChatItemDriftProvider(Get.find(), scoped));
+              deps.put(ChatMemberDriftProvider(Get.find(), scoped));
 
               AbstractSettingsRepository settingsRepository =
                   deps.put<AbstractSettingsRepository>(
@@ -659,11 +662,12 @@ class AppRouterDelegate extends RouterDelegate<RouteConfiguration>
               deps.put(MonologHiveProvider()).init(userId: me),
             ]);
 
-            deps.put(ScopedDriftProvider.from(Get.put(ScopedDatabase(me))));
+            final ScopedDriftProvider scoped =
+                deps.put(ScopedDriftProvider.from(Get.put(ScopedDatabase(me))));
 
-            deps.put(UserDriftProvider(Get.find()));
-            deps.put(ChatItemDriftProvider(Get.find()));
-            deps.put(ChatMemberDriftProvider(Get.find()));
+            deps.put(UserDriftProvider(Get.find(), scoped));
+            deps.put(ChatItemDriftProvider(Get.find(), scoped));
+            deps.put(ChatMemberDriftProvider(Get.find(), scoped));
 
             GraphQlProvider graphQlProvider = Get.find();
 

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -44,6 +44,7 @@ import 'l10n/l10n.dart';
 import 'main.dart' show handlePushNotification;
 import 'provider/drift/chat_item.dart';
 import 'provider/drift/chat_member.dart';
+import 'provider/drift/drift.dart';
 import 'provider/drift/user.dart';
 import 'provider/gql/graphql.dart';
 import 'provider/hive/application_settings.dart';
@@ -657,6 +658,8 @@ class AppRouterDelegate extends RouterDelegate<RouteConfiguration>
               deps.put(CallRectHiveProvider()).init(userId: me),
               deps.put(MonologHiveProvider()).init(userId: me),
             ]);
+
+            deps.put(ScopedDriftProvider.from(Get.put(ScopedDatabase(me))));
 
             deps.put(UserDriftProvider(Get.find()));
             deps.put(ChatItemDriftProvider(Get.find()));

--- a/lib/store/auth.dart
+++ b/lib/store/auth.dart
@@ -71,8 +71,7 @@ class AuthRepository extends DisposableInterface
   Credentials? _signUpCredentials;
 
   // TODO: Temporary solution, wait for support from backend.
-  /// [DtoMyUser] created with [signUpWithEmail] and put to [Hive] in
-  /// successful [confirmSignUpEmail].
+  /// [DtoMyUser] created with [signUpWithEmail].
   DtoMyUser? _signedUpUser;
 
   /// [StreamSubscription] for the [MyUserHiveProvider.boxEvents].
@@ -98,8 +97,6 @@ class AuthRepository extends DisposableInterface
 
   @override
   void onInit() {
-    // profiles.addAll(_myUserProvider.accounts.map((e) => e.value).toList());
-
     _profilesSubscription = _myUserProvider.watch().listen((ops) {
       for (var e in ops) {
         switch (e.op) {

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -121,10 +121,10 @@ class ChatRepository extends DisposableInterface
   /// [Chat]s local [Hive] storage.
   final ChatHiveProvider _chatLocal;
 
-  /// [ChatItem]s local [DriftProvider] storage.
+  /// [ChatItem]s local storage.
   final ChatItemDriftProvider _driftItems;
 
-  /// [ChatMember]s local [DriftProvider] storage.
+  /// [ChatMember]s local storage.
   final ChatMemberDriftProvider _driftMembers;
 
   /// [ChatId]s sorted by [PreciseDateTime] representing recent [Chat]s [Hive]

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -803,7 +803,7 @@ class RxChatImpl extends RxChat {
         // Don't await [put] here, as [get] should react as quick as possible.
         //
         // Also this may cause deadlocks during fetching around a [ChatItem] in
-        // [DriftProvider].
+        // [CommonDriftProvider].
         put(item);
       }
     }

--- a/lib/store/model/my_user.dart
+++ b/lib/store/model/my_user.dart
@@ -18,10 +18,35 @@
 import 'package:hive/hive.dart';
 
 import '/domain/model_type_id.dart';
+import '/domain/model/my_user.dart';
+import '/domain/model/user.dart';
 import '/util/new_type.dart';
 import 'version.dart';
 
 part 'my_user.g.dart';
+
+/// Persisted in [Hive] storage [MyUser]'s [value].
+@HiveType(typeId: ModelTypeId.dtoMyUser)
+class DtoMyUser extends HiveObject {
+  DtoMyUser(this.value, this.ver);
+
+  /// Persisted [MyUser] model.
+  @HiveField(0)
+  MyUser value;
+
+  /// Version of this [MyUser]'s state.
+  ///
+  /// It increases monotonically, so may be used (and is intended to) for
+  /// tracking state's actuality.
+  @HiveField(1)
+  MyUserVersion ver;
+
+  /// Returns the [UserId] of the [value].
+  UserId get id => value.id;
+
+  @override
+  String toString() => '$runtimeType($value, $ver)';
+}
 
 /// Version of [MyUser]'s state.
 @HiveType(typeId: ModelTypeId.myUserVersion)

--- a/lib/store/my_user.dart
+++ b/lib/store/my_user.dart
@@ -636,7 +636,7 @@ class MyUserRepository implements AbstractMyUserRepository {
 
     final UserId? id = _accountLocal.userId;
     if (id == null) {
-      Log.warning(
+      Log.debug(
         'Unexpected `null` when getting `_accountLocal.userId` for `_initLocalSubscription`',
         '$runtimeType',
       );

--- a/lib/store/my_user.dart
+++ b/lib/store/my_user.dart
@@ -34,6 +34,7 @@ import '/domain/model/user.dart';
 import '/domain/model/user_call_cover.dart';
 import '/domain/repository/my_user.dart';
 import '/domain/repository/user.dart';
+import '/provider/drift/my_user.dart';
 import '/provider/gql/exceptions.dart';
 import '/provider/gql/graphql.dart';
 import '/provider/hive/account.dart';
@@ -54,14 +55,14 @@ import 'user.dart';
 class MyUserRepository implements AbstractMyUserRepository {
   MyUserRepository(
     this._graphQlProvider,
-    this._myUserLocal,
+    this._driftMyUser,
     this._blocklistRepo,
     this._userRepo,
     this._accountLocal,
   );
 
   @override
-  late final Rx<MyUser?> myUser;
+  final Rx<MyUser?> myUser = Rx(null);
 
   @override
   final RxObsMap<UserId, Rx<MyUser>> profiles = RxObsMap();
@@ -75,8 +76,7 @@ class MyUserRepository implements AbstractMyUserRepository {
   /// GraphQL API provider.
   final GraphQlProvider _graphQlProvider;
 
-  /// [MyUser] local [Hive] storage.
-  final MyUserHiveProvider _myUserLocal;
+  final MyUserDriftProvider _driftMyUser;
 
   /// [Hive] storage providing the [UserId] of the currently active [MyUser].
   final AccountHiveProvider _accountLocal;
@@ -87,8 +87,7 @@ class MyUserRepository implements AbstractMyUserRepository {
   /// [User]s repository, used to put the fetched [MyUser] into it.
   final UserRepository _userRepo;
 
-  /// [MyUserHiveProvider.boxEvents] subscription.
-  StreamIterator<BoxEvent>? _localSubscription;
+  StreamSubscription? _localSubscription;
 
   /// [_myUserRemoteEvents] subscription.
   ///
@@ -109,10 +108,11 @@ class MyUserRepository implements AbstractMyUserRepository {
   /// [EventPool] debouncing [MyUserField] related [MyUserEvent]s handling.
   final EventPool<MyUserField> _pool = EventPool();
 
-  /// Returns the currently active [HiveMyUser] from [Hive].
-  HiveMyUser? get _active {
+  /// Returns the currently active [DtoMyUser] from [Hive].
+  Future<DtoMyUser?> get _active async {
     final UserId? userId = _accountLocal.userId;
-    final HiveMyUser? saved = userId != null ? _myUserLocal.get(userId) : null;
+    final DtoMyUser? saved =
+        userId != null ? await _driftMyUser.read(userId) : null;
 
     return saved;
   }
@@ -127,7 +127,7 @@ class MyUserRepository implements AbstractMyUserRepository {
     this.onPasswordUpdated = onPasswordUpdated;
     this.onUserDeleted = onUserDeleted;
 
-    myUser = Rx<MyUser?>(_active?.value);
+    myUser.value = (await _active)?.value;
 
     _initProfiles();
     _initLocalSubscription();
@@ -164,19 +164,13 @@ class MyUserRepository implements AbstractMyUserRepository {
   }
 
   @override
-  Future<void> clearCache() async {
-    Log.debug('clearCache()', '$runtimeType');
-    await _myUserLocal.clear();
-  }
-
-  @override
   Future<void> updateUserName(UserName? name) async {
     Log.debug('updateUserName($name)', '$runtimeType');
 
     await _debounce(
       field: MyUserField.name,
       current: () => myUser.value?.name,
-      saved: () => _active?.value.name,
+      saved: () async => (await _active)?.value.name,
       value: name,
       mutation: (v, _) => _graphQlProvider.updateUserName(v),
       update: (v, _) => myUser.update((u) => u?.name = v),
@@ -190,7 +184,7 @@ class MyUserRepository implements AbstractMyUserRepository {
     await _debounce(
       field: MyUserField.name,
       current: () => myUser.value?.status,
-      saved: () => _active?.value.status,
+      saved: () async => (await _active)?.value.status,
       value: status,
       mutation: (v, _) => _graphQlProvider.updateUserStatus(v),
       update: (v, _) => myUser.update((u) => u?.status = v),
@@ -204,7 +198,7 @@ class MyUserRepository implements AbstractMyUserRepository {
     await _debounce(
       field: MyUserField.bio,
       current: () => myUser.value?.bio,
-      saved: () => _active?.value.bio,
+      saved: () async => (await _active)?.value.bio,
       value: bio,
       mutation: (v, _) => _graphQlProvider.updateUserBio(v),
       update: (v, _) => myUser.update((u) => u?.bio = v),
@@ -227,7 +221,7 @@ class MyUserRepository implements AbstractMyUserRepository {
     await _debounce(
       field: MyUserField.presence,
       current: () => myUser.value?.presence,
-      saved: () => _active?.value.presence,
+      saved: () async => (await _active)?.value.presence,
       value: presence,
       mutation: (s, _) async =>
           await _graphQlProvider.updateUserPresence(s ?? presence),
@@ -271,7 +265,7 @@ class MyUserRepository implements AbstractMyUserRepository {
       await _debounce(
         field: MyUserField.email,
         current: () => myUser.value?.emails.unconfirmed,
-        saved: () => _active?.value.emails.unconfirmed,
+        saved: () async => (await _active)?.value.emails.unconfirmed,
         value: null,
         mutation: (value, previous) async {
           if (previous != null) {
@@ -315,7 +309,7 @@ class MyUserRepository implements AbstractMyUserRepository {
       await _debounce(
         field: MyUserField.phone,
         current: () => myUser.value?.phones.unconfirmed,
-        saved: () => _active?.value.phones.unconfirmed,
+        saved: () async => (await _active)?.value.phones.unconfirmed,
         value: null,
         mutation: (value, previous) async {
           if (previous != null) {
@@ -358,7 +352,7 @@ class MyUserRepository implements AbstractMyUserRepository {
     await _debounce(
       field: MyUserField.email,
       current: () => myUser.value?.emails.unconfirmed,
-      saved: () => _active?.value.emails.unconfirmed,
+      saved: () async => (await _active)?.value.emails.unconfirmed,
       value: email,
       mutation: (value, previous) async {
         if (previous != null) {
@@ -384,7 +378,7 @@ class MyUserRepository implements AbstractMyUserRepository {
     await _debounce(
       field: MyUserField.phone,
       current: () => myUser.value?.phones.unconfirmed,
-      saved: () => _active?.value.phones.unconfirmed,
+      saved: () async => (await _active)?.value.phones.unconfirmed,
       value: phone,
       mutation: (value, previous) async {
         if (previous != null) {
@@ -544,7 +538,7 @@ class MyUserRepository implements AbstractMyUserRepository {
     await _debounce(
       field: MyUserField.muted,
       current: () => myUser.value?.muted,
-      saved: () => _active?.value.muted,
+      saved: () async => (await _active)?.value.muted,
       value: mute,
       mutation: (duration, _) async {
         return await _graphQlProvider.toggleMyUserMute(
@@ -623,15 +617,15 @@ class MyUserRepository implements AbstractMyUserRepository {
     final response = await _graphQlProvider.getMyUser();
 
     if (response.myUser != null) {
-      _setMyUser(response.myUser!.toHive(), ignoreVersion: true);
+      _setMyUser(response.myUser!.toDto(), ignoreVersion: true);
     }
   }
 
   /// Populates the [profiles] with values stored in the [_myUserLocal].
-  void _initProfiles() {
+  Future<void> _initProfiles() async {
     Log.debug('_initProfiles()', '$runtimeType');
 
-    for (final HiveMyUser u in _myUserLocal.valuesSafe) {
+    for (final DtoMyUser u in await _driftMyUser.accounts()) {
       profiles[u.value.id] = Rx(u.value);
     }
   }
@@ -640,14 +634,20 @@ class MyUserRepository implements AbstractMyUserRepository {
   Future<void> _initLocalSubscription() async {
     Log.debug('_initLocalSubscription()', '$runtimeType');
 
-    _localSubscription = StreamIterator(_myUserLocal.boxEvents);
-    while (await _localSubscription!.moveNext()) {
-      final BoxEvent event = _localSubscription!.current;
+    final UserId? id = _accountLocal.userId;
+    if (id == null) {
+      Log.warning(
+        'Unexpected `null` when getting `_accountLocal.userId` for `_initLocalSubscription`',
+        '$runtimeType',
+      );
+      return;
+    }
 
-      final UserId id = UserId(event.key);
-      final bool isCurrent = id == (_active?.value ?? myUser.value)?.id;
+    _localSubscription = _driftMyUser.watchSingle(id).listen((e) {
+      final bool isCurrent =
+          (e?.id ?? id) == (myUser.value?.id ?? _accountLocal.userId);
 
-      if (event.deleted) {
+      if (e == null) {
         if (isCurrent) {
           myUser.value = null;
           _remoteSubscription?.close(immediate: true);
@@ -655,12 +655,7 @@ class MyUserRepository implements AbstractMyUserRepository {
 
         profiles.remove(id);
       } else {
-        if (event.value == null) {
-          Log.warning('Expected non-`null` value of `MyUser`', '$runtimeType');
-          return;
-        }
-
-        final MyUser user = event.value!.value;
+        final MyUser user = e.value;
 
         if (isCurrent) {
           // Copy [event.value], as it always contains the same [MyUser].
@@ -698,21 +693,21 @@ class MyUserRepository implements AbstractMyUserRepository {
           }
 
           myUser.value = value;
-          profiles[id]?.value = value;
+          profiles[e.id]?.value = value;
         }
 
         // This event is not of the currently active [MyUser], so just update
         // the [profiles].
         else {
-          final Rx<MyUser>? existing = profiles[id];
+          final Rx<MyUser>? existing = profiles[e.id];
           if (existing == null) {
-            profiles[id] = Rx(user);
+            profiles[e.id] = Rx(user);
           } else {
             existing.value = user;
           }
         }
       }
-    }
+    });
   }
 
   /// Initializes [_myUserRemoteEvents] subscription.
@@ -725,14 +720,14 @@ class MyUserRepository implements AbstractMyUserRepository {
 
     _remoteSubscription?.close(immediate: true);
     _remoteSubscription = StreamQueue(
-      _myUserRemoteEvents(() {
+      await _myUserRemoteEvents(() async {
         // Ask for initial [MyUser] event, if the stored [MyUser.blocklistCount]
         // is `null`, to retrieve it.
-        if (_active?.value.blocklistCount == null) {
+        if ((await _active)?.value.blocklistCount == null) {
           return null;
         }
 
-        return _active?.ver;
+        return (await _active)?.ver;
       }),
     );
 
@@ -759,26 +754,26 @@ class MyUserRepository implements AbstractMyUserRepository {
   }
 
   /// Saves the provided [user] in [Hive].
-  void _setMyUser(HiveMyUser user, {bool ignoreVersion = false}) {
+  Future<void> _setMyUser(DtoMyUser user, {bool ignoreVersion = false}) async {
     Log.debug('_setMyUser($user, $ignoreVersion)', '$runtimeType');
 
     // Update the stored [MyUser], if the provided [user] has non-`null`
     // blocklist count, which is different from the stored one.
     final bool blocklist = user.value.blocklistCount != null &&
-        user.value.blocklistCount != _active?.value.blocklistCount;
+        user.value.blocklistCount != (await _active)?.value.blocklistCount;
 
-    if (user.ver >= _active?.ver || blocklist || ignoreVersion) {
-      user.value.blocklistCount ??= _active?.value.blocklistCount;
-      _myUserLocal.put(user);
+    if (user.ver >= (await _active)?.ver || blocklist || ignoreVersion) {
+      user.value.blocklistCount ??= (await _active)?.value.blocklistCount;
+      _driftMyUser.upsert(user);
     }
   }
 
   /// Handles [MyUserEvent] from the [_myUserRemoteEvents] subscription.
-  void _myUserRemoteEvent(
+  Future<void> _myUserRemoteEvent(
     MyUserEventsVersioned versioned, {
     bool updateVersion = true,
-  }) {
-    final HiveMyUser? userEntity = _active;
+  }) async {
+    final DtoMyUser? userEntity = await _active;
 
     if (userEntity == null || versioned.ver < userEntity.ver) {
       Log.debug(
@@ -1028,16 +1023,17 @@ class MyUserRepository implements AbstractMyUserRepository {
       }
     }
 
-    _myUserLocal.put(userEntity);
+    await _driftMyUser.upsert(userEntity);
   }
 
   /// Subscribes to remote [MyUserEvent]s of the authenticated [MyUser].
-  Stream<MyUserEventsVersioned> _myUserRemoteEvents(
-    MyUserVersion? Function() ver,
-  ) {
+  Future<Stream<MyUserEventsVersioned>> _myUserRemoteEvents(
+    Future<MyUserVersion?> Function() ver,
+  ) async {
     Log.debug('_myUserRemoteEvents(ver)', '$runtimeType');
 
-    return _graphQlProvider.myUserEvents(ver).asyncExpand((event) async* {
+    return (await _graphQlProvider.myUserEvents(ver))
+        .asyncExpand((event) async* {
       Log.trace('_myUserRemoteEvents(ver): ${event.data}', '$runtimeType');
 
       var events = MyUserEvents$Subscription.fromJson(event.data!).myUserEvents;
@@ -1059,7 +1055,7 @@ class MyUserRepository implements AbstractMyUserRepository {
 
         events as MyUserEvents$Subscription$MyUserEvents$MyUser;
 
-        _setMyUser(events.toHive());
+        _setMyUser(events.toDto());
       } else if (events.$$typename == 'MyUserEventsVersioned') {
         var mixin = events as MyUserEventsVersionedMixin;
         yield MyUserEventsVersioned(
@@ -1200,7 +1196,7 @@ class MyUserRepository implements AbstractMyUserRepository {
   Future<void> _debounce<T>({
     required MyUserField field,
     required T? Function() current,
-    required T? Function() saved,
+    required Future<T?> Function() saved,
     T? value,
     required void Function(T? value, T? previous) update,
     required Future<MyUserEventsVersionedMixin?> Function(T? value, T? previous)
@@ -1230,20 +1226,20 @@ class MyUserRepository implements AbstractMyUserRepository {
 
             _myUserRemoteEvent(event, updateVersion: false);
 
-            // Wait for [Hive] to update the [HiveMyUser] from
+            // Wait for [Hive] to update the [DtoMyUser] from
             // [_myUserRemoteEvent].
             await Future.delayed(Duration.zero);
           }
 
           previous = value;
         } catch (_) {
-          update(saved(), value);
+          update(await saved(), value);
           rethrow;
         }
       },
-      values: [value, saved()],
-      repeat: () {
-        if (myUser.value != null && current() != saved()) {
+      values: [value, await saved()],
+      repeat: () async {
+        if (myUser.value != null && current() != await saved()) {
           value = current();
           return true;
         }

--- a/lib/store/pagination/drift.dart
+++ b/lib/store/pagination/drift.dart
@@ -24,7 +24,7 @@ import '/store/chat_rx.dart';
 import '/store/model/page_info.dart';
 import '/store/pagination.dart';
 
-/// [PageProvider] fetching items from the [DriftProvider].
+/// [PageProvider] fetching items from the [ScopedDriftProvider].
 class DriftPageProvider<T, C, K> extends PageProvider<T, C, K> {
   DriftPageProvider({
     required this.onKey,

--- a/lib/store/pagination/drift_graphql.dart
+++ b/lib/store/pagination/drift_graphql.dart
@@ -29,7 +29,7 @@ class DriftGraphQlPageProvider<T extends Object, C, K>
     required this.graphQlProvider,
   });
 
-  /// [DriftPageProvider] fetching elements from the [DriftProvider].
+  /// [DriftPageProvider] fetching elements from the [ScopedDriftProvider].
   final DriftPageProvider<T, C, K> driftProvider;
 
   /// [GraphQlPageProvider] fetching elements from the remote.

--- a/lib/store/user.dart
+++ b/lib/store/user.dart
@@ -71,7 +71,7 @@ class UserRepository extends DisposableInterface
   /// GraphQL API provider.
   final GraphQlProvider _graphQlProvider;
 
-  /// [User]s local [DriftProvider] storage.
+  /// [User]s local storage.
   final UserDriftProvider _userLocal;
 
   /// [Mutex]es guarding access to the [get] method.
@@ -234,7 +234,7 @@ class UserRepository extends DisposableInterface
     }
   }
 
-  /// Puts the provided [user] into the local [DriftProvider] storage.
+  /// Puts the provided [user] into the local storage.
   Future<void> put(DtoUser user, {bool ignoreVersion = false}) async {
     Log.trace('put(${user.value.id}, $ignoreVersion)', '$runtimeType');
 
@@ -372,7 +372,7 @@ class UserRepository extends DisposableInterface
     });
   }
 
-  /// Puts the provided [user] to [DriftProvider].
+  /// Puts the provided [user] to local storage.
   Future<void> _putUser(DtoUser user, {bool ignoreVersion = false}) async {
     Log.trace('_putUser($user, $ignoreVersion)', '$runtimeType');
 

--- a/lib/store/user_rx.dart
+++ b/lib/store/user_rx.dart
@@ -35,7 +35,7 @@ import '/util/new_type.dart';
 import '/util/stream_utils.dart';
 import 'model/user.dart';
 
-/// [RxUser] implementation backed by local [DriftProvider] storage.
+/// [RxUser] implementation backed by local [ScopedDriftProvider] storage.
 class RxUserImpl extends RxUser {
   RxUserImpl(
     this._userRepository,
@@ -102,7 +102,7 @@ class RxUserImpl extends RxUser {
   /// [UserRepository] providing the [UserEvent]s.
   final UserRepository _userRepository;
 
-  /// [User]s local [DriftProvider] storage.
+  /// [User]s local storage.
   final UserDriftProvider _userLocal;
 
   /// Reactive value of the [RxChat]-dialog with this [RxUser].

--- a/lib/util/event_pool.dart
+++ b/lib/util/event_pool.dart
@@ -15,6 +15,8 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'dart:async';
+
 import 'package:mutex/mutex.dart';
 
 /// Helper guarding synchronized access for processing [T] objects.
@@ -47,7 +49,7 @@ class EventPool<T> {
   Future<void> protect(
     T tag,
     Future<void> Function() callback, {
-    bool Function()? repeat,
+    FutureOr<bool> Function()? repeat,
     List<Object?> values = const [],
   }) async {
     _PoolMutex? mutex = _mutexes[tag];
@@ -60,7 +62,7 @@ class EventPool<T> {
       mutex.values = values;
       do {
         await mutex.protect(callback);
-      } while (!_disposed && repeat?.call() == true);
+      } while (!_disposed && await repeat?.call() == true);
     }
   }
 

--- a/lib/util/obs/obs.dart
+++ b/lib/util/obs/obs.dart
@@ -15,6 +15,8 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'map.dart';
+
 export 'list.dart';
 export 'map.dart';
 export 'rx_sorted_map.dart';
@@ -25,3 +27,39 @@ export 'sorted_map.dart';
 
 /// Possible operation kinds changing an observable iterable.
 enum OperationKind { added, removed, updated }
+
+/// Extension adding an ability to get [MapChangeNotification]s from [Stream].
+extension MapChangesExtension<K, T> on Stream<Map<K, T>> {
+  /// Gets [MapChangeNotification]s from [Stream].
+  Stream<List<MapChangeNotification<K, T>>> changes() {
+    Map<K, T> last = {};
+
+    return asyncExpand((e) async* {
+      final List<MapChangeNotification<K, T>> changed = [];
+
+      for (final MapEntry<K, T> entry in e.entries) {
+        final T? item = last[entry.key];
+        if (item == null) {
+          changed.add(MapChangeNotification.added(entry.key, entry.value));
+        } else {
+          if (entry.value != item) {
+            changed.add(
+              MapChangeNotification.updated(entry.key, entry.key, entry.value),
+            );
+          }
+        }
+      }
+
+      for (final MapEntry<K, T> entry in last.entries) {
+        final T? item = e[entry.key];
+        if (item == null) {
+          changed.add(MapChangeNotification.removed(entry.key, entry.value));
+        }
+      }
+
+      last = e;
+
+      yield changed;
+    });
+  }
+}

--- a/test/e2e/hook/reset_app.dart
+++ b/test/e2e/hook/reset_app.dart
@@ -44,7 +44,7 @@ class ResetAppHook extends Hook {
   ) async {
     FocusManager.instance.primaryFocus?.unfocus();
 
-    final drift = Get.findOrNull<DriftProvider>();
+    final drift = Get.findOrNull<CommonDriftProvider>();
     await drift?.reset();
 
     await Get.deleteAll();

--- a/test/mock/graphql_provider.dart
+++ b/test/mock/graphql_provider.dart
@@ -138,16 +138,20 @@ class MockedGraphQlProvider extends Fake implements GraphQlProvider {
       });
 
   @override
-  Stream<QueryResult> myUserEvents(MyUserVersion? Function()? getVer) =>
+  Future<Stream<QueryResult>> myUserEvents(
+    Future<MyUserVersion?> Function()? getVer,
+  ) async =>
       const Stream.empty();
 
   @override
   Stream<QueryResult> contactsEvents(
-          ChatContactsListVersion? Function()? getVer) =>
+    ChatContactsListVersion? Function()? getVer,
+  ) =>
       const Stream.empty();
 
   @override
   Stream<QueryResult> favoriteChatsEvents(
-          FavoriteChatsListVersion? Function()? getVer) =>
+    FavoriteChatsListVersion? Function()? getVer,
+  ) =>
       const Stream.empty();
 }

--- a/test/unit/chat_avatar_test.dart
+++ b/test/unit/chat_avatar_test.dart
@@ -31,6 +31,7 @@ import 'package:messenger/domain/service/chat.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
@@ -46,7 +47,6 @@ import 'package:messenger/provider/hive/favorite_chat.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/recent_chat.dart';
 import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/store/auth.dart';
@@ -63,7 +63,8 @@ import 'chat_avatar_test.mocks.dart';
 void main() async {
   setUp(Get.reset);
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_avatar_unit');
 
@@ -74,15 +75,13 @@ void main() async {
   Get.put<GraphQlProvider>(graphQlProvider);
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
 
-  var myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var chatHiveProvider = ChatHiveProvider();
   await chatHiveProvider.init();
   await chatHiveProvider.clear();
-  final userProvider = UserDriftProvider(database);
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   final callCredentialsProvider = CallCredentialsHiveProvider();
   await callCredentialsProvider.init();
   final chatCredentialsProvider = ChatCredentialsHiveProvider();
@@ -363,7 +362,7 @@ void main() async {
     ]);
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }
 
 final userData = {

--- a/test/unit/chat_delete_message_test.dart
+++ b/test/unit/chat_delete_message_test.dart
@@ -33,6 +33,7 @@ import 'package:messenger/domain/service/chat.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
@@ -45,7 +46,6 @@ import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/chat_credentials.dart';
 import 'package:messenger/provider/hive/draft.dart';
 import 'package:messenger/provider/hive/favorite_chat.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
@@ -65,7 +65,8 @@ import 'chat_delete_message_test.mocks.dart';
 void main() async {
   setUp(Get.reset);
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_delete_message_unit');
 
@@ -94,9 +95,10 @@ void main() async {
       const UserId('me'),
     ),
   );
-  final userProvider = UserDriftProvider(database);
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatProvider = ChatHiveProvider();
   await chatProvider.init();
   final callCredentialsProvider = CallCredentialsHiveProvider();
@@ -119,8 +121,6 @@ void main() async {
   await favoriteChatProvider.init();
   var sessionProvider = SessionDataHiveProvider();
   await sessionProvider.init();
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -372,5 +372,5 @@ void main() async {
     ));
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }

--- a/test/unit/chat_direct_link_test.dart
+++ b/test/unit/chat_direct_link_test.dart
@@ -71,7 +71,7 @@ void main() async {
     Get.put<GraphQlProvider>(graphQlProvider);
 
     when(graphQlProvider.myUserEvents(any)).thenAnswer(
-      (_) => Stream.fromIterable([
+      (_) async => Stream.fromIterable([
         QueryResult.internal(
           parserFn: (_) => null,
           source: null,

--- a/test/unit/chat_edit_message_test.dart
+++ b/test/unit/chat_edit_message_test.dart
@@ -33,6 +33,7 @@ import 'package:messenger/domain/service/chat.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
@@ -45,7 +46,6 @@ import 'package:messenger/provider/hive/call_rect.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/draft.dart';
 import 'package:messenger/provider/hive/favorite_chat.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
@@ -65,20 +65,20 @@ import 'chat_edit_message_test.mocks.dart';
 void main() async {
   setUp(Get.reset);
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_edit_message_unit');
 
   final graphQlProvider = MockGraphQlProvider();
   Get.put<GraphQlProvider>(graphQlProvider);
 
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
   var credentialsProvider = Get.put(CredentialsHiveProvider());
   await credentialsProvider.init();
-  var userProvider = Get.put(UserDriftProvider(database));
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatProvider = Get.put(ChatHiveProvider());
   await chatProvider.init();
   final callCredentialsProvider = CallCredentialsHiveProvider();
@@ -375,5 +375,5 @@ void main() async {
     ));
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }

--- a/test/unit/chat_hide_test.dart
+++ b/test/unit/chat_hide_test.dart
@@ -29,6 +29,7 @@ import 'package:messenger/domain/service/chat.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
@@ -41,7 +42,6 @@ import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/chat_credentials.dart';
 import 'package:messenger/provider/hive/draft.dart';
 import 'package:messenger/provider/hive/favorite_chat.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
@@ -62,7 +62,8 @@ import 'chat_hide_test.mocks.dart';
 void main() async {
   setUp(Get.reset);
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_hide_unit');
 
@@ -70,15 +71,14 @@ void main() async {
   Get.put<GraphQlProvider>(graphQlProvider);
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
 
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
   var chatProvider = Get.put(ChatHiveProvider());
   await chatProvider.init();
   var credentialsProvider = Get.put(CredentialsHiveProvider());
   await credentialsProvider.init();
-  final userProvider = UserDriftProvider(database);
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   final callCredentialsProvider = CallCredentialsHiveProvider();
   await callCredentialsProvider.init();
   final chatCredentialsProvider = ChatCredentialsHiveProvider();
@@ -357,5 +357,5 @@ void main() async {
     );
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }

--- a/test/unit/chat_members_test.dart
+++ b/test/unit/chat_members_test.dart
@@ -29,6 +29,7 @@ import 'package:messenger/domain/service/chat.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
@@ -41,7 +42,6 @@ import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/chat_credentials.dart';
 import 'package:messenger/provider/hive/draft.dart';
 import 'package:messenger/provider/hive/favorite_chat.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
@@ -61,7 +61,8 @@ import 'chat_members_test.mocks.dart';
 void main() async {
   setUp(Get.reset);
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_members_unit');
 
@@ -69,8 +70,6 @@ void main() async {
   Get.put<GraphQlProvider>(graphQlProvider);
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
 
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
   var credentialsProvider = Get.put(CredentialsHiveProvider());
   await credentialsProvider.init();
   var chatProvider = Get.put(ChatHiveProvider());
@@ -275,6 +274,11 @@ void main() async {
   );
 
   Future<ChatService> init(GraphQlProvider graphQlProvider) async {
+    final myUserProvider = Get.put(MyUserDriftProvider(common));
+    final userProvider = UserDriftProvider(common, scoped);
+    Get.put(ChatItemDriftProvider(common, scoped));
+    Get.put(ChatMemberDriftProvider(common, scoped));
+
     final AbstractSettingsRepository settingsRepository = Get.put(
       SettingsRepository(
         mediaSettingsProvider,
@@ -297,10 +301,6 @@ void main() async {
       ),
     );
     authService.init();
-
-    final userProvider = UserDriftProvider(database);
-    Get.put(ChatItemDriftProvider(database));
-    Get.put(ChatMemberDriftProvider(database));
 
     final UserRepository userRepository =
         Get.put(UserRepository(graphQlProvider, userProvider));
@@ -469,5 +469,5 @@ void main() async {
     ));
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }

--- a/test/unit/chat_rename_test.dart
+++ b/test/unit/chat_rename_test.dart
@@ -29,6 +29,7 @@ import 'package:messenger/domain/service/chat.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
@@ -41,7 +42,6 @@ import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/chat_credentials.dart';
 import 'package:messenger/provider/hive/draft.dart';
 import 'package:messenger/provider/hive/favorite_chat.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
@@ -61,7 +61,8 @@ import 'chat_rename_test.mocks.dart';
 void main() async {
   setUp(Get.reset);
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_rename_unit');
 
@@ -69,17 +70,16 @@ void main() async {
   Get.put<GraphQlProvider>(graphQlProvider);
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
 
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
   var chatProvider = ChatHiveProvider();
   await chatProvider.init();
   var credentialsProvider = Get.put(CredentialsHiveProvider());
   await credentialsProvider.init();
   var draftProvider = DraftHiveProvider();
   await draftProvider.init();
-  final userProvider = UserDriftProvider(database);
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   final callCredentialsProvider = CallCredentialsHiveProvider();
   await callCredentialsProvider.init();
   final chatCredentialsProvider = ChatCredentialsHiveProvider();
@@ -361,5 +361,5 @@ void main() async {
     ));
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }

--- a/test/unit/contact_rename_test.dart
+++ b/test/unit/contact_rename_test.dart
@@ -45,12 +45,13 @@ import 'contact_rename_test.mocks.dart';
 void main() async {
   Hive.init('./test/.temp_hive/contact_rename_unit');
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   var credentialsHiveProvider = Get.put(CredentialsHiveProvider());
   await credentialsHiveProvider.init();
   await credentialsHiveProvider.clear();
-  final userProvider = Get.put(UserDriftProvider(database));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
   var contactProvider = Get.put(ContactHiveProvider());
   await contactProvider.init();
   await contactProvider.clear();
@@ -263,5 +264,5 @@ void main() async {
     );
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }

--- a/test/unit/my_profile_emails_test.dart
+++ b/test/unit/my_profile_emails_test.dart
@@ -27,13 +27,13 @@ import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
 import 'package:messenger/provider/hive/blocklist.dart';
 import 'package:messenger/provider/hive/blocklist_sorting.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/store/auth.dart';
@@ -47,7 +47,8 @@ import 'my_profile_emails_test.mocks.dart';
 
 @GenerateMocks([GraphQlProvider])
 void main() async {
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/my_profile_emails_unit');
 
@@ -58,10 +59,8 @@ void main() async {
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
   await credentialsProvider.init();
 
-  var myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
-  final userProvider = UserDriftProvider(database);
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = UserDriftProvider(common, scoped);
   var blockedUsersProvider = BlocklistHiveProvider();
   await blockedUsersProvider.init();
   var sessionProvider = SessionDataHiveProvider();
@@ -95,7 +94,7 @@ void main() async {
     );
 
     when(graphQlProvider.addUserEmail(UserEmail('test@mail.ru'))).thenAnswer(
-      (_) => Future.value(AddUserEmail$Mutation.fromJson({
+      (_) async => AddUserEmail$Mutation.fromJson({
         'addUserEmail': {
           '__typename': 'MyUserEventsVersioned',
           'events': [
@@ -107,17 +106,17 @@ void main() async {
             }
           ],
           'myUser': myUserData,
-          'ver': '${(myUserProvider.valuesSafe.first.ver.internal)}',
+          'ver': '${((await myUserProvider.accounts()).first.ver.internal)}',
         }
       }).addUserEmail
-          as AddUserEmail$Mutation$AddUserEmail$MyUserEventsVersioned),
+          as AddUserEmail$Mutation$AddUserEmail$MyUserEventsVersioned,
     );
 
     when(graphQlProvider.resendEmail()).thenAnswer((_) => Future.value());
     when(graphQlProvider.keepOnline()).thenAnswer((_) => const Stream.empty());
 
     when(graphQlProvider.confirmEmailCode(ConfirmationCode('1234'))).thenAnswer(
-      (_) => Future.value(ConfirmUserEmail$Mutation.fromJson({
+      (_) async => ConfirmUserEmail$Mutation.fromJson({
         'confirmUserEmail': {
           '__typename': 'MyUserEventsVersioned',
           'events': [
@@ -130,14 +129,14 @@ void main() async {
           ],
           'myUser': myUserData,
           'ver':
-              '${(myUserProvider.valuesSafe.first.ver.internal + BigInt.one)}',
+              '${((await myUserProvider.accounts()).first.ver.internal + BigInt.one)}',
         }
       }).confirmUserEmail
-          as ConfirmUserEmail$Mutation$ConfirmUserEmail$MyUserEventsVersioned),
+          as ConfirmUserEmail$Mutation$ConfirmUserEmail$MyUserEventsVersioned,
     );
 
     when(graphQlProvider.deleteUserEmail(UserEmail('test@mail.ru'))).thenAnswer(
-      (_) => Future.value(DeleteUserEmail$Mutation.fromJson({
+      (_) async => DeleteUserEmail$Mutation.fromJson({
         'deleteUserEmail': {
           '__typename': 'MyUserEventsVersioned',
           'events': [
@@ -150,9 +149,9 @@ void main() async {
           ],
           'myUser': myUserData,
           'ver':
-              '${(myUserProvider.valuesSafe.first.ver.internal + BigInt.one)}',
+              '${((await myUserProvider.accounts()).first.ver.internal + BigInt.one)}',
         }
-      }).deleteUserEmail),
+      }).deleteUserEmail,
     );
 
     when(graphQlProvider.getBlocklist(
@@ -292,7 +291,7 @@ void main() async {
     ]);
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }
 
 final myUserData = {

--- a/test/unit/my_profile_emails_test.dart
+++ b/test/unit/my_profile_emails_test.dart
@@ -82,7 +82,7 @@ void main() async {
       'MyUserService successfully adds, removes, confirms email and resends confirmation code',
       () async {
     when(graphQlProvider.myUserEvents(any)).thenAnswer(
-      (_) => Stream.fromIterable([
+      (_) async => Stream.fromIterable([
         QueryResult.internal(
           parserFn: (_) => null,
           source: null,
@@ -216,7 +216,7 @@ void main() async {
       'MyUserService throws AddUserEmailException, ResendUserEmailConfirmationException, ConfirmUserEmailException',
       () async {
     when(graphQlProvider.myUserEvents(any)).thenAnswer(
-      (_) => Stream.fromIterable([
+      (_) async => Stream.fromIterable([
         QueryResult.internal(
           parserFn: (_) => null,
           source: null,

--- a/test/unit/my_profile_phones_test.dart
+++ b/test/unit/my_profile_phones_test.dart
@@ -82,7 +82,7 @@ void main() async {
       'MyUserService successfully adds, removes, confirms phone and resends confirmation code',
       () async {
     when(graphQlProvider.myUserEvents(any)).thenAnswer(
-      (_) => Stream.fromIterable([
+      (_) async => Stream.fromIterable([
         QueryResult.internal(
           parserFn: (_) => null,
           source: null,
@@ -219,7 +219,7 @@ void main() async {
       'MyUserService throws AddUserPhoneException, ResendUserPhoneConfirmationErrorCode, ConfirmUserPhoneException',
       () async {
     when(graphQlProvider.myUserEvents(any)).thenAnswer(
-      (_) => Stream.fromIterable([
+      (_) async => Stream.fromIterable([
         QueryResult.internal(
           parserFn: (_) => null,
           source: null,

--- a/test/unit/my_profile_phones_test.dart
+++ b/test/unit/my_profile_phones_test.dart
@@ -27,13 +27,13 @@ import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
 import 'package:messenger/provider/hive/blocklist.dart';
 import 'package:messenger/provider/hive/blocklist_sorting.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/store/auth.dart';
@@ -47,7 +47,8 @@ import 'my_profile_phones_test.mocks.dart';
 
 @GenerateMocks([GraphQlProvider])
 void main() async {
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/my_profile_phones_unit');
 
@@ -58,10 +59,8 @@ void main() async {
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
   await credentialsProvider.init();
 
-  var myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
-  final userProvider = UserDriftProvider(database);
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = UserDriftProvider(common, scoped);
   var blockedUsersProvider = BlocklistHiveProvider();
   await blockedUsersProvider.init();
   var sessionProvider = SessionDataHiveProvider();
@@ -97,7 +96,7 @@ void main() async {
     when(graphQlProvider.keepOnline()).thenAnswer((_) => const Stream.empty());
 
     when(graphQlProvider.addUserPhone(UserPhone('+380999999999'))).thenAnswer(
-      (_) => Future.value(AddUserPhone$Mutation.fromJson({
+      (_) async => AddUserPhone$Mutation.fromJson({
         'addUserPhone': {
           '__typename': 'MyUserEventsVersioned',
           'events': [
@@ -110,16 +109,16 @@ void main() async {
           ],
           'myUser': myUserData,
           'ver':
-              '${(myUserProvider.valuesSafe.firstOrNull?.ver.internal ?? BigInt.zero + BigInt.one)}',
+              '${((await myUserProvider.accounts()).firstOrNull?.ver.internal ?? BigInt.zero + BigInt.one)}',
         }
       }).addUserPhone
-          as AddUserPhone$Mutation$AddUserPhone$MyUserEventsVersioned),
+          as AddUserPhone$Mutation$AddUserPhone$MyUserEventsVersioned,
     );
 
     when(graphQlProvider.resendPhone()).thenAnswer((_) => Future.value());
 
     when(graphQlProvider.confirmPhoneCode(ConfirmationCode('1234'))).thenAnswer(
-      (_) => Future.value(ConfirmUserPhone$Mutation.fromJson({
+      (_) async => ConfirmUserPhone$Mutation.fromJson({
         'confirmUserPhone': {
           '__typename': 'MyUserEventsVersioned',
           'events': [
@@ -132,15 +131,15 @@ void main() async {
           ],
           'myUser': myUserData,
           'ver':
-              '${(myUserProvider.valuesSafe.first.ver.internal + BigInt.one)}',
+              '${((await myUserProvider.accounts()).first.ver.internal + BigInt.one)}',
         }
       }).confirmUserPhone
-          as ConfirmUserPhone$Mutation$ConfirmUserPhone$MyUserEventsVersioned),
+          as ConfirmUserPhone$Mutation$ConfirmUserPhone$MyUserEventsVersioned,
     );
 
     when(graphQlProvider.deleteUserPhone(UserPhone('+380999999999')))
         .thenAnswer(
-      (_) => Future.value(DeleteUserPhone$Mutation.fromJson({
+      (_) async => DeleteUserPhone$Mutation.fromJson({
         'deleteUserPhone': {
           '__typename': 'MyUserEventsVersioned',
           'events': [
@@ -153,9 +152,9 @@ void main() async {
           ],
           'myUser': myUserData,
           'ver':
-              '${(myUserProvider.valuesSafe.first.ver.internal + BigInt.one)}',
+              '${((await myUserProvider.accounts()).first.ver.internal + BigInt.one)}',
         }
-      }).deleteUserPhone),
+      }).deleteUserPhone,
     );
 
     when(graphQlProvider.getBlocklist(
@@ -303,7 +302,7 @@ void main() async {
     ]);
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }
 
 final myUserData = {

--- a/test/unit/my_user_muting_test.dart
+++ b/test/unit/my_user_muting_test.dart
@@ -78,7 +78,7 @@ void main() async {
 
   test('MyUserService successfully mutes and unmutes MyUser', () async {
     when(graphQlProvider.myUserEvents(any)).thenAnswer(
-      (_) => Stream.fromIterable([
+      (_) async => Stream.fromIterable([
         QueryResult.internal(
           parserFn: (_) => null,
           source: null,
@@ -161,7 +161,7 @@ void main() async {
   test('MyUserService throws ToggleMyUserMuteException when muting MyUser',
       () async {
     when(graphQlProvider.myUserEvents(any)).thenAnswer(
-      (_) => Stream.fromIterable([
+      (_) async => Stream.fromIterable([
         QueryResult.internal(
           parserFn: (_) => null,
           source: null,

--- a/test/unit/my_user_muting_test.dart
+++ b/test/unit/my_user_muting_test.dart
@@ -25,13 +25,13 @@ import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/my_user.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
 import 'package:messenger/provider/hive/blocklist.dart';
 import 'package:messenger/provider/hive/blocklist_sorting.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/store/auth.dart';
@@ -45,7 +45,8 @@ import 'my_user_muting_test.mocks.dart';
 
 @GenerateMocks([GraphQlProvider])
 void main() async {
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/my_user_muting_unit');
 
@@ -56,10 +57,8 @@ void main() async {
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
   await credentialsProvider.init();
 
-  var myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
-  final userProvider = UserDriftProvider(database);
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = UserDriftProvider(common, scoped);
   var blockedUsersProvider = BlocklistHiveProvider();
   await blockedUsersProvider.init();
   var sessionProvider = SessionDataHiveProvider();
@@ -219,7 +218,7 @@ void main() async {
     verify(graphQlProvider.toggleMyUserMute(null));
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }
 
 final myUserData = {

--- a/test/unit/toggle_chat_mute_test.dart
+++ b/test/unit/toggle_chat_mute_test.dart
@@ -29,6 +29,7 @@ import 'package:messenger/domain/service/chat.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
@@ -41,7 +42,6 @@ import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/chat_credentials.dart';
 import 'package:messenger/provider/hive/draft.dart';
 import 'package:messenger/provider/hive/favorite_chat.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
@@ -61,19 +61,19 @@ import 'toggle_chat_mute_test.mocks.dart';
 void main() async {
   setUp(Get.reset);
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/toggle_chat_mute');
 
   final graphQlProvider = MockGraphQlProvider();
 
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
   var credentialsProvider = Get.put(CredentialsHiveProvider());
   await credentialsProvider.init();
-  final userProvider = Get.put(UserDriftProvider(database));
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatHiveProvider = Get.put(ChatHiveProvider());
   await chatHiveProvider.init();
   final callCredentialsProvider = Get.put(CallCredentialsHiveProvider());
@@ -339,5 +339,5 @@ void main() async {
     ));
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }

--- a/test/widget/auth_test.dart
+++ b/test/widget/auth_test.dart
@@ -71,7 +71,8 @@ void main() async {
   Config.clsid = 'clsid';
   await L10n.init();
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/auth_widget');
 
@@ -204,7 +205,7 @@ void main() async {
     await Get.deleteAll(force: true);
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }
 
 class _FakeGraphQlProvider extends MockedGraphQlProvider {

--- a/test/widget/auth_test.dart
+++ b/test/widget/auth_test.dart
@@ -32,6 +32,7 @@ import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/notification.dart';
 import 'package:messenger/l10n/l10n.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
@@ -47,7 +48,6 @@ import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/provider/hive/draft.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/model/chat.dart';
@@ -82,15 +82,13 @@ void main() async {
 
   final accountProvider = AccountHiveProvider();
   await accountProvider.init();
-  var myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
 
   final graphQlProvider = _FakeGraphQlProvider();
 
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
   var contactProvider = ContactHiveProvider();
   await contactProvider.init(userId: const UserId('me'));
-  final userProvider = UserDriftProvider(database);
+  final userProvider = UserDriftProvider(common, scoped);
   var chatProvider = ChatHiveProvider();
   await chatProvider.init(userId: const UserId('me'));
   var settingsProvider = MediaSettingsHiveProvider();
@@ -202,6 +200,7 @@ void main() async {
 
     verify(router.go(Routes.home));
 
+    await Future.wait([common.close(), scoped.close()]);
     await Get.deleteAll(force: true);
   });
 

--- a/test/widget/chat_attachment_test.dart
+++ b/test/widget/chat_attachment_test.dart
@@ -45,6 +45,7 @@ import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
@@ -64,7 +65,6 @@ import 'package:messenger/provider/hive/favorite_contact.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/recent_chat.dart';
 import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/routes.dart';
@@ -288,7 +288,7 @@ void main() async {
   when(graphQlProvider.favoriteChatsEvents(any))
       .thenAnswer((_) => const Stream.empty());
   when(graphQlProvider.myUserEvents(any))
-      .thenAnswer((realInvocation) => const Stream.empty());
+      .thenAnswer((_) async => const Stream.empty());
   when(graphQlProvider.getUser(any))
       .thenAnswer((_) => Future.value(GetUser$Query.fromJson({'user': null})));
   when(graphQlProvider.getMonolog()).thenAnswer(
@@ -348,9 +348,10 @@ void main() async {
   var draftProvider = Get.put(DraftHiveProvider());
   await draftProvider.init();
   await draftProvider.clear();
-  final userProvider = Get.put(UserDriftProvider(database));
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatProvider = Get.put(ChatHiveProvider());
   await chatProvider.init();
   await chatProvider.clear();
@@ -363,9 +364,6 @@ void main() async {
   await backgroundProvider.init();
   var callRectProvider = CallRectHiveProvider();
   await callRectProvider.init();
-  var myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var blockedUsersProvider = BlocklistHiveProvider();
   await blockedUsersProvider.init();
   var monologProvider = MonologHiveProvider();
@@ -556,7 +554,7 @@ void main() async {
 
     expect(find.byKey(Key('File_$id2'), skipOffstage: false), findsOneWidget);
 
-    await database.close();
+    await Future.wait([common.close(), scoped.close()]);
     await Get.deleteAll(force: true);
 
     for (int i = 0; i < 25; i++) {

--- a/test/widget/chat_attachment_test.dart
+++ b/test/widget/chat_attachment_test.dart
@@ -94,7 +94,8 @@ void main() async {
   AudioUtils = AudioUtilsMock();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_attachment_widget');
 

--- a/test/widget/chat_direct_link_chat_test.dart
+++ b/test/widget/chat_direct_link_chat_test.dart
@@ -86,7 +86,8 @@ void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   Config.disableInfiniteAnimations = true;
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_direct_link_widget');
 

--- a/test/widget/chat_direct_link_chat_test.dart
+++ b/test/widget/chat_direct_link_chat_test.dart
@@ -40,6 +40,7 @@ import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
@@ -56,7 +57,6 @@ import 'package:messenger/provider/hive/contact_sorting.dart';
 import 'package:messenger/provider/hive/draft.dart';
 import 'package:messenger/provider/hive/favorite_chat.dart';
 import 'package:messenger/provider/hive/favorite_contact.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
@@ -94,14 +94,12 @@ void main() async {
   var graphQlProvider = Get.put(MockGraphQlProvider());
   when(graphQlProvider.disconnect()).thenAnswer((_) => Future.value);
 
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
   var credentialsProvider = Get.put(CredentialsHiveProvider());
   await credentialsProvider.init();
   await credentialsProvider.clear();
   final accountProvider = AccountHiveProvider();
   await accountProvider.init();
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
 
   accountProvider.set(const UserId('me'));
   credentialsProvider.put(
@@ -151,9 +149,9 @@ void main() async {
   var contactProvider = Get.put(ContactHiveProvider());
   await contactProvider.init();
   await contactProvider.clear();
-  final userProvider = Get.put(UserDriftProvider(database));
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatProvider = Get.put(ChatHiveProvider());
   await chatProvider.init();
   await chatProvider.clear();
@@ -329,7 +327,7 @@ void main() async {
         })));
 
     when(graphQlProvider.myUserEvents(any))
-        .thenAnswer((_) => const Stream.empty());
+        .thenAnswer((_) async => const Stream.empty());
 
     UserRepository userRepository =
         Get.put(UserRepository(graphQlProvider, userProvider));
@@ -428,7 +426,7 @@ void main() async {
       groupId: const ChatId('0d72d245-8425-467a-9ebd-082d4f47850b'),
     ));
 
-    await database.close();
+    await Future.wait([common.close(), scoped.close()]);
     await Get.deleteAll(force: true);
   });
 

--- a/test/widget/chat_edit_message_test.dart
+++ b/test/widget/chat_edit_message_test.dart
@@ -90,7 +90,8 @@ void main() async {
   AudioUtils = AudioUtilsMock();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_edit_message_text_widget');
 

--- a/test/widget/chat_hide_test.dart
+++ b/test/widget/chat_hide_test.dart
@@ -37,6 +37,7 @@ import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
@@ -56,7 +57,6 @@ import 'package:messenger/provider/hive/favorite_contact.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/recent_chat.dart';
 import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/routes.dart';
@@ -84,14 +84,12 @@ void main() async {
 
   Hive.init('./test/.temp_hive/chat_hide_widget');
 
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
   var credentialsProvider = Get.put(CredentialsHiveProvider());
   await credentialsProvider.init();
   await credentialsProvider.clear();
   final accountProvider = AccountHiveProvider();
   await accountProvider.init();
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
 
   var graphQlProvider = Get.put(MockGraphQlProvider());
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
@@ -113,7 +111,7 @@ void main() async {
   when(graphQlProvider.favoriteChatsEvents(any))
       .thenAnswer((_) => const Stream.empty());
   when(graphQlProvider.myUserEvents(any))
-      .thenAnswer((_) => const Stream.empty());
+      .thenAnswer((_) async => const Stream.empty());
 
   when(graphQlProvider.getUser(any))
       .thenAnswer((_) => Future.value(GetUser$Query.fromJson({'user': null})));
@@ -140,9 +138,9 @@ void main() async {
   var contactProvider = Get.put(ContactHiveProvider());
   await contactProvider.clear();
   await contactProvider.init();
-  final userProvider = Get.put(UserDriftProvider(database));
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatProvider = Get.put(ChatHiveProvider());
   await chatProvider.init();
   await chatProvider.clear();
@@ -417,7 +415,7 @@ void main() async {
       ),
     );
 
-    await database.close();
+    await Future.wait([common.close(), scoped.close()]);
     await Get.deleteAll(force: true);
   });
 

--- a/test/widget/chat_hide_test.dart
+++ b/test/widget/chat_hide_test.dart
@@ -79,7 +79,8 @@ import 'chat_hide_test.mocks.dart';
 void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_hide_widget');
 

--- a/test/widget/chat_rename_test.dart
+++ b/test/widget/chat_rename_test.dart
@@ -39,6 +39,7 @@ import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
@@ -56,7 +57,6 @@ import 'package:messenger/provider/hive/favorite_chat.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/recent_chat.dart';
 import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/routes.dart';
@@ -87,14 +87,12 @@ void main() async {
 
   Hive.init('./test/.temp_hive/chat_rename_widget');
 
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
   var credentialsProvider = Get.put(CredentialsHiveProvider());
   await credentialsProvider.init();
   await credentialsProvider.clear();
   final accountProvider = AccountHiveProvider();
   await accountProvider.init();
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
 
   accountProvider.set(const UserId('me'));
   credentialsProvider.put(
@@ -129,11 +127,7 @@ void main() async {
   );
 
   AuthService authService = AuthService(
-    AuthRepository(
-      graphQlProvider,
-      myUserProvider,
-      credentialsProvider,
-    ),
+    AuthRepository(graphQlProvider, myUserProvider, credentialsProvider),
     credentialsProvider,
     accountProvider,
   );
@@ -145,9 +139,9 @@ void main() async {
   var contactProvider = Get.put(ContactHiveProvider());
   await contactProvider.init();
   await contactProvider.clear();
-  final userProvider = Get.put(UserDriftProvider(database));
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatProvider = Get.put(ChatHiveProvider());
   await chatProvider.init();
   await chatProvider.clear();
@@ -309,7 +303,7 @@ void main() async {
     );
 
     when(graphQlProvider.myUserEvents(any))
-        .thenAnswer((_) => const Stream.empty());
+        .thenAnswer((_) async => const Stream.empty());
 
     AuthService authService = Get.put(
       AuthService(
@@ -423,7 +417,7 @@ void main() async {
 
     expect(find.text('newname'), findsNWidgets(2));
 
-    await database.close();
+    await Future.wait([common.close(), scoped.close()]);
     await Get.deleteAll(force: true);
   });
 

--- a/test/widget/chat_rename_test.dart
+++ b/test/widget/chat_rename_test.dart
@@ -82,7 +82,8 @@ void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   Config.disableInfiniteAnimations = true;
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_rename_widget');
 

--- a/test/widget/chat_reply_message_test.dart
+++ b/test/widget/chat_reply_message_test.dart
@@ -40,6 +40,7 @@ import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
@@ -59,7 +60,6 @@ import 'package:messenger/provider/hive/favorite_contact.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/recent_chat.dart';
 import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/routes.dart';
@@ -101,18 +101,20 @@ void main() async {
   when(graphQlProvider.getUser(const UserId('me')))
       .thenAnswer((_) => Future.value(GetUser$Query.fromJson(userData)));
 
-  when(graphQlProvider.recentChatsTopEvents(3)).thenAnswer((_) => Stream.value(
-        QueryResult.internal(
-          source: QueryResultSource.network,
-          data: {
-            'recentChatsTopEvents': {
-              '__typename': 'SubscriptionInitialized',
-              'ok': true
-            }
-          },
-          parserFn: (_) => null,
-        ),
-      ));
+  when(graphQlProvider.recentChatsTopEvents(3)).thenAnswer(
+    (_) => Stream.value(
+      QueryResult.internal(
+        source: QueryResultSource.network,
+        data: {
+          'recentChatsTopEvents': {
+            '__typename': 'SubscriptionInitialized',
+            'ok': true
+          }
+        },
+        parserFn: (_) => null,
+      ),
+    ),
+  );
 
   final StreamController<QueryResult> contactEvents = StreamController();
   when(
@@ -308,7 +310,7 @@ void main() async {
       .thenAnswer((_) => const Stream.empty());
 
   when(graphQlProvider.myUserEvents(any))
-      .thenAnswer((realInvocation) => const Stream.empty());
+      .thenAnswer((_) async => const Stream.empty());
 
   when(graphQlProvider.getBlocklist(
     first: anyNamed('first'),
@@ -345,15 +347,13 @@ void main() async {
   await credentialsProvider.clear();
   final accountProvider = AccountHiveProvider();
   await accountProvider.init();
-  final myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var contactProvider = Get.put(ContactHiveProvider());
   await contactProvider.init();
   await contactProvider.clear();
-  final userProvider = Get.put(UserDriftProvider(database));
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatProvider = Get.put(ChatHiveProvider());
   await chatProvider.init();
   await chatProvider.clear();
@@ -555,7 +555,7 @@ void main() async {
 
     expect(find.richText('reply message', skipOffstage: false), findsOneWidget);
 
-    await database.close();
+    await Future.wait([common.close(), scoped.close()]);
     await Get.deleteAll(force: true);
   });
 }

--- a/test/widget/chat_reply_message_test.dart
+++ b/test/widget/chat_reply_message_test.dart
@@ -89,7 +89,8 @@ void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   AudioUtils = AudioUtilsMock();
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_reply_message_widget');
 

--- a/test/widget/chat_update_attachments_test.dart
+++ b/test/widget/chat_update_attachments_test.dart
@@ -45,6 +45,7 @@ import 'package:messenger/domain/service/user.dart';
 import 'package:messenger/provider/drift/chat_item.dart';
 import 'package:messenger/provider/drift/chat_member.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
@@ -65,7 +66,6 @@ import 'package:messenger/provider/hive/favorite_contact.dart';
 import 'package:messenger/provider/hive/session_data.dart';
 import 'package:messenger/provider/hive/media_settings.dart';
 import 'package:messenger/provider/hive/monolog.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/provider/hive/recent_chat.dart';
 import 'package:messenger/provider/hive/credentials.dart';
 import 'package:messenger/routes.dart';
@@ -341,7 +341,7 @@ void main() async {
   when(graphQlProvider.favoriteChatsEvents(any))
       .thenAnswer((_) => const Stream.empty());
   when(graphQlProvider.myUserEvents(any))
-      .thenAnswer((realInvocation) => const Stream.empty());
+      .thenAnswer((_) async => const Stream.empty());
   when(graphQlProvider.getUser(any))
       .thenAnswer((_) => Future.value(GetUser$Query.fromJson({'user': null})));
   when(graphQlProvider.getMonolog()).thenAnswer(
@@ -384,9 +384,10 @@ void main() async {
   var draftProvider = Get.put(DraftHiveProvider());
   await draftProvider.init();
   await draftProvider.clear();
-  final userProvider = Get.put(UserDriftProvider(database));
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatProvider = Get.put(ChatHiveProvider());
   await chatProvider.init();
   await chatProvider.clear();
@@ -399,9 +400,6 @@ void main() async {
   await backgroundProvider.init();
   var callRectProvider = CallRectHiveProvider();
   await callRectProvider.init();
-  var myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
-  await myUserProvider.clear();
   var blockedUsersProvider = BlocklistHiveProvider();
   await blockedUsersProvider.init();
   var monologProvider = MonologHiveProvider();
@@ -581,7 +579,14 @@ void main() async {
 
     await tester.pumpAndSettle(const Duration(seconds: 2));
 
-    await tester.runAsync(() async => await database.close());
+    common.close();
+    scoped.close();
+
+    for (int i = 0; i < 20; i++) {
+      await tester.pump(const Duration(seconds: 2));
+      await tester.runAsync(() => Future.delayed(1.milliseconds));
+    }
+
     await Get.deleteAll(force: true);
   });
 }

--- a/test/widget/chat_update_attachments_test.dart
+++ b/test/widget/chat_update_attachments_test.dart
@@ -124,7 +124,8 @@ void main() async {
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/chat_update_image');
 

--- a/test/widget/password_recovery_test.dart
+++ b/test/widget/password_recovery_test.dart
@@ -26,13 +26,13 @@ import 'package:messenger/domain/repository/auth.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/l10n/l10n.dart';
 import 'package:messenger/provider/drift/drift.dart';
+import 'package:messenger/provider/drift/my_user.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/gql/graphql.dart';
 import 'package:messenger/provider/hive/account.dart';
 import 'package:messenger/provider/hive/chat.dart';
 import 'package:messenger/provider/hive/contact.dart';
 import 'package:messenger/provider/hive/credentials.dart';
-import 'package:messenger/provider/hive/my_user.dart';
 import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/themes.dart';
@@ -65,11 +65,10 @@ void main() async {
   await credentialsProvider.clear();
   final accountProvider = AccountHiveProvider();
   await accountProvider.init();
-  var myUserProvider = MyUserHiveProvider();
-  await myUserProvider.init();
   var contactProvider = ContactHiveProvider();
   await contactProvider.init();
-  final userProvider = UserDriftProvider(database);
+  final myUserProvider = Get.put(MyUserDriftProvider(common));
+  final userProvider = UserDriftProvider(common, scoped);
   var chatProvider = ChatHiveProvider();
   await chatProvider.init();
 
@@ -167,8 +166,7 @@ void main() async {
           ConfirmationCode('1234'), UserPassword('test123')),
     ]);
 
+    await Future.wait([common.close(), scoped.close()]);
     await Get.deleteAll(force: true);
   });
-
-  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }

--- a/test/widget/password_recovery_test.dart
+++ b/test/widget/password_recovery_test.dart
@@ -51,7 +51,8 @@ void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   Config.disableInfiniteAnimations = true;
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/password_recovery');
 
@@ -169,5 +170,5 @@ void main() async {
     await Get.deleteAll(force: true);
   });
 
-  tearDown(() async => await database.close());
+  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
 }

--- a/test/widget/user_profile_test.dart
+++ b/test/widget/user_profile_test.dart
@@ -78,7 +78,8 @@ import 'user_profile_test.mocks.dart';
 void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final DriftProvider database = DriftProvider.memory();
+  final CommonDriftProvider common = CommonDriftProvider.memory();
+  final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Hive.init('./test/.temp_hive/user_profile_widget');
 
@@ -120,9 +121,9 @@ void main() async {
   var contactProvider = ContactHiveProvider();
   await contactProvider.init();
   await contactProvider.clear();
-  final userProvider = UserDriftProvider(database);
-  final chatItemProvider = Get.put(ChatItemDriftProvider(database));
-  final chatMemberProvider = Get.put(ChatMemberDriftProvider(database));
+  final userProvider = Get.put(UserDriftProvider(common, scoped));
+  final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
+  final chatMemberProvider = Get.put(ChatMemberDriftProvider(common, scoped));
   var chatProvider = ChatHiveProvider();
   await chatProvider.init();
   await chatProvider.clear();


### PR DESCRIPTION
Part of #27 




## Synopsis

Hive is obsolete.




## Solution

This PR further migrate to `drift` by:
- moving `MyUser` persistence to `drift`;
- implementing `CommonDatabase` and `ScopedDatabase` concept for multiple `MyUser` accounts.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
