### PR TITLE
Prevent `media_kit` from copying `msvcp140.dll` to Windows build

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1225,10 +1225,11 @@ packages:
   media_kit_libs_windows_video:
     dependency: "direct main"
     description:
-      name: media_kit_libs_windows_video
-      sha256: "7bace5f35d9afcc7f9b5cdadb7541d2191a66bb3fc71bfa11c1395b3360f6122"
-      url: "https://pub.dev"
-    source: hosted
+      path: "libs/windows/media_kit_libs_windows_video"
+      ref: HEAD
+      resolved-ref: "65b5e81e8fb37e9039df7a6ef65874b1658e8750"
+      url: "https://github.com/SleepySquash/media-kit.git"
+    source: git
     version: "1.0.9"
   media_kit_native_event_loop:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -154,6 +154,12 @@ dependency_overrides:
       path: packages/image_picker/image_picker_ios
   # TODO: Remove when `medea_jason` updates.
   medea_flutter_webrtc: 0.10.0-dev+rev.56483212e465ddaaee4593a4e4b7cc828e3faeb3
+  # TODO: Remove, when `media_kit` removes `msvcp140` dlls from Windows libs:
+  #       https://github.com/media-kit/media-kit/issues/846
+  media_kit_libs_windows_video:
+    git:
+      url: https://github.com/SleepySquash/media-kit.git
+      path: libs/windows/media_kit_libs_windows_video
   # TODO: Remove when `medea_jason` updates.
   uuid: ^4.3.3
 


### PR DESCRIPTION
## Synopsis

Windows application won't run at all.




## Solution

The crash happens due to `msvcp140.dll` library being copied by `media_kit` during Windows build. For some reason using the copied library crashes the application during launch. Deleting the library forces Windows to use the `system32` hosted version of it, if installed, which fixes the issue.

This PR simply removes the library from being copied over.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
