### PR TITLE
Remove l10n phrases of password recovery email

### DIFF
--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -299,11 +299,6 @@ email_confirmation_code =
     Valid until {$expiresAt}.
     {$domain}
 email_confirmation_code_subject = {$domain} confirmation code
-email_password_recovery =
-    {$domain} recovery code is: {$token}
-    Valid until {$expiresAt}.
-    {$domain}
-email_password_recovery_subject = {$domain} recovery code
 err_account_not_found = Indicated account is not found
 err_account_unavailable = This account is not available. Please, log in again.
 err_blocked = You've been added to the blocklist of this user.

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -299,11 +299,6 @@ email_confirmation_code =
     Действителен до {$expiresAt}.
     {$domain}
 email_confirmation_code_subject = Код подтверждения {$domain}
-email_password_recovery =
-    Код восстановления {$domain}: {$token}
-    Действителен до {$expiresAt}.
-    {$domain}
-email_password_recovery_subject = Код восстановления {$domain}
 err_account_not_found = Указанный аккаунт не найден
 err_account_unavailable = Этот аккаунт недоступен. Пожалуйста, повторите авторизацию.
 err_blocked = Пользователь добавил Вас в чёрный список.


### PR DESCRIPTION
## Synopsis

Since upcoming `0.1.0-beta.15` backend will use generic confirmation codes for all operations, these phrases are not required and are not used anymore.




## Solution

Removes `email_password_recovery` and `email_password_recovery_subject` l10n phrases.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
