### PR TITLE
Fix `AudioUtils.once` pausing background music in iOS Safari (#968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,19 @@ All user visible changes to this project will be documented in this file. This p
     - Chat page:
         - Direct links in messages opening within application. ([#1012], [#800])
 
+### Fixed
+
+- Web:
+    - Audio playback stopping when receiving or sending message on iOS. ([#1039], [#968])
+
 [#799]: /../../issues/799
 [#800]: /../../issues/800
 [#896]: /../../issues/896
+[#968]: /../../issues/968
 [#973]: /../../pull/973
 [#1012]: /../../pull/1012
 [#1035]: /../../pull/1035
+[#1039]: /../../pull/1039
 
 
 

--- a/lib/util/audio_utils.dart
+++ b/lib/util/audio_utils.dart
@@ -93,7 +93,7 @@ class AudioUtilsImpl {
       };
 
       if (url.isNotEmpty) {
-        await WebUtils.playSound(url);
+        await WebUtils.play(url);
       }
     } else if (_isMobile) {
       await _jaPlayer?.setAudioSource(sound.source);

--- a/lib/util/audio_utils.dart
+++ b/lib/util/audio_utils.dart
@@ -25,6 +25,7 @@ import 'package:mutex/mutex.dart';
 import '/util/media_utils.dart';
 import 'log.dart';
 import 'platform_utils.dart';
+import 'web/web_utils.dart';
 
 /// Global variable to access [AudioUtilsImpl].
 ///
@@ -84,7 +85,17 @@ class AudioUtilsImpl {
   Future<void> once(AudioSource sound) async {
     ensureInitialized();
 
-    if (_isMobile) {
+    if (PlatformUtils.isWeb) {
+      final String url = switch (sound.kind) {
+        AudioSourceKind.asset => (sound as AssetAudioSource).asset,
+        AudioSourceKind.file => '',
+        AudioSourceKind.url => (sound as UrlAudioSource).url,
+      };
+
+      if (url.isNotEmpty) {
+        await WebUtils.playSound(url);
+      }
+    } else if (_isMobile) {
       await _jaPlayer?.setAudioSource(sound.source);
       await _jaPlayer?.play();
     } else {

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -287,7 +287,7 @@ class WebUtils {
   }
 
   /// Plays the provided [asset].
-  static Future<void> playSound(String asset) async {
+  static Future<void> play(String asset) async {
     // No-op.
   }
 

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -286,6 +286,11 @@ class WebUtils {
     }
   }
 
+  /// Plays the provided [asset].
+  static Future<void> playSound(String asset) async {
+    // No-op.
+  }
+
   /// Returns the `User-Agent` header to put in the network queries.
   static Future<String> get userAgent async {
     final DeviceInfoPlugin device = DeviceInfoPlugin();

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -753,6 +753,25 @@ class WebUtils {
     // No-op.
   }
 
+  /// Plays the provided [asset].
+  static Future<void> play(String asset) async {
+    final web.AudioContext context = web.AudioContext();
+    final web.AudioBufferSourceNode source = context.createBufferSource();
+
+    final Response bytes = await (await PlatformUtils.dio).get(
+      'assets/assets/$asset',
+      options: Options(responseType: ResponseType.bytes),
+    );
+
+    final JSPromise<web.AudioBuffer> audioBuffer = context.decodeAudioData(
+      (bytes.data as Uint8List).buffer.toJS,
+    );
+
+    source.buffer = await audioBuffer.toDart;
+    source.connect(context.destination);
+    source.start();
+  }
+
   /// Returns the `User-Agent` header to put in the network queries.
   static Future<String> get userAgent async {
     final info = await DeviceInfoPlugin().webBrowserInfo;


### PR DESCRIPTION
Resolves #968




## Synopsis

New messages cause background music to pause.




## Solution

This PR uses Web Audio API for `AudioUtils.once`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
