### PR TITLE
Cover accounts switching with E2E tests

### DIFF
--- a/lib/ui/page/auth/view.dart
+++ b/lib/ui/page/auth/view.dart
@@ -150,6 +150,7 @@ class AuthView extends StatelessWidget {
                 return Padding(
                   padding: ModalPopup.padding(context),
                   child: ContactTile(
+                    key: Key('Account_${e.id}'),
                     myUser: e,
 
                     // TODO: Remove, when [MyUser]s will receive their updates
@@ -173,6 +174,7 @@ class AuthView extends StatelessWidget {
                     },
                     trailing: [
                       AnimatedButton(
+                        key: const Key('RemoveAccount'),
                         decorator: (child) => Padding(
                           padding: const EdgeInsets.fromLTRB(8, 8, 6, 8),
                           child: child,

--- a/lib/ui/page/home/tab/menu/accounts/view.dart
+++ b/lib/ui/page/home/tab/menu/accounts/view.dart
@@ -130,6 +130,7 @@ class AccountsView extends StatelessWidget {
 
               children = [
                 SignButton(
+                  key: const Key('PasswordButton'),
                   title: 'btn_password'.l10n,
                   onPressed: () =>
                       c.stage.value = AccountsViewStage.signInWithPassword,
@@ -340,6 +341,7 @@ class AccountsView extends StatelessWidget {
                     final bool active = c.me == myUser.id;
 
                     return ContactTile(
+                      key: Key('Account_${e.value.id}'),
                       myUser: myUser,
 
                       // TODO: Prompt to sign in to the non-[authorized].
@@ -368,6 +370,7 @@ class AccountsView extends StatelessWidget {
 
                       trailing: [
                         AnimatedButton(
+                          key: const Key('RemoveAccount'),
                           decorator: (child) => Padding(
                             padding: const EdgeInsets.fromLTRB(8, 8, 6, 8),
                             child: child,
@@ -455,6 +458,7 @@ class AccountsView extends StatelessWidget {
                 Padding(
                   padding: ModalPopup.padding(context),
                   child: PrimaryButton(
+                    key: const Key('AddAccountButton'),
                     onPressed: () => c.stage.value = AccountsViewStage.add,
                     title: 'btn_add_account'.l10n,
                   ),

--- a/lib/ui/page/home/tab/menu/view.dart
+++ b/lib/ui/page/home/tab/menu/view.dart
@@ -113,6 +113,7 @@ class MenuTabView extends StatelessWidget {
             leading: const [SizedBox(width: 20)],
             actions: [
               WidgetButton(
+                key: const Key('AccountsButton'),
                 behavior: HitTestBehavior.translucent,
                 onPressed: () => AccountsView.show(context),
                 child: Padding(

--- a/test/e2e/configuration.dart
+++ b/test/e2e/configuration.dart
@@ -51,6 +51,7 @@ import 'parameters/search_category.dart';
 import 'parameters/selection_status.dart';
 import 'parameters/sending_status.dart';
 import 'parameters/users.dart';
+import 'steps/accounts.dart';
 import 'steps/appcast.dart';
 import 'steps/attach_file.dart';
 import 'steps/change_chat_avatar.dart';
@@ -80,6 +81,7 @@ import 'steps/long_press_contact.dart';
 import 'steps/long_press_message.dart';
 import 'steps/long_press_widget.dart';
 import 'steps/monolog_availability.dart';
+import 'steps/name_is.dart';
 import 'steps/open_chat_info.dart';
 import 'steps/popup_windows.dart';
 import 'steps/reads_message.dart';
@@ -202,12 +204,15 @@ final FlutterTestConfiguration gherkinTestConfiguration =
         longPressMonolog,
         longPressWidget,
         monologAvailability,
+        myNameIs,
+        myNameIsNot,
         noInternetConnection,
         openChatInfo,
         pasteToField,
         popupWindows,
         readsAllMessages,
         readsMessage,
+        removeAccountInAccounts,
         removeGroupMember,
         renameContact,
         repliesToMessage,
@@ -219,6 +224,7 @@ final FlutterTestConfiguration gherkinTestConfiguration =
         scrollToBottom,
         scrollToTop,
         scrollUntilPresent,
+        seeAccountInAccounts,
         seeBlockedUsers,
         seeChatAsDismissed,
         seeChatAsFavorite,
@@ -259,6 +265,7 @@ final FlutterTestConfiguration gherkinTestConfiguration =
         setCredential,
         setMyCredential,
         signInAs,
+        tapAccountInAccounts,
         tapChat,
         tapContact,
         tapDropdownItem,
@@ -283,6 +290,7 @@ final FlutterTestConfiguration gherkinTestConfiguration =
         updateAvatar,
         updateName,
         user,
+        userWithPassword,
         waitForAppToSettle,
         waitUntilAttachmentStatus,
         waitUntilFileStatus,

--- a/test/e2e/features/auth/switch_account/.feature
+++ b/test/e2e/features/auth/switch_account/.feature
@@ -1,0 +1,84 @@
+# Copyright © 2022-2024 IT ENGINEERING MANAGEMENT INC,
+#                       <https://github.com/team113>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0 as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+# more details.
+#
+# You should have received a copy of the GNU Affero General Public License v3.0
+# along with this program. If not, see
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+Feature: Account switching
+
+  Scenario: User can switch accounts
+    Given I am Alice
+    And user Bob with their password set
+    And I wait until `HomeView` is present
+    And my name is indeed Alice
+
+    When I tap `MenuButton` button
+    And I tap `AccountsButton` button
+    And I tap `AddAccountButton` button
+    And I tap `StartButton` button
+    Then I wait for app to settle
+    And I wait until `IntroductionView` is present
+    And my name is not Alice
+
+    When I tap `ProceedButton` button
+    And I tap `MenuButton` button
+    And I tap `AccountsButton` button
+    And I tap `AddAccountButton` button
+    And I tap `SignInButton` button
+    And I tap `PasswordButton` button
+    And I fill `UsernameField` field with Bob's num
+    And I fill `PasswordField` field with "123"
+    And I tap `LoginButton` button
+    Then I wait for app to settle
+    And my name is indeed Bob
+    And I pause for 1 second
+
+  Scenario: User can sign into added account
+    Given I am Alice
+    And I wait until `HomeView` is present
+    And my name is indeed Alice
+
+    When I tap `MenuButton` button
+    And I scroll `MenuListView` until `LogoutButton` is present
+    And I tap `LogoutButton` button
+    And I tap `ConfirmLogoutButton` button
+    Then I wait until `AuthView` is present
+    And I see Alice account in accounts list
+
+    When I tap on Alice account in accounts list
+    Then I wait until `LoginView` is present
+
+    When I tap `PasswordButton` button
+    And I fill `UsernameField` field with Alice's num
+    And I fill `PasswordField` field with "123"
+    And I tap `LoginButton` button
+    Then I wait for app to settle
+    And I wait until `HomeView` is present
+    And my name is indeed Alice
+
+  Scenario: User can remove added account
+    Given I am Alice
+    And I wait until `HomeView` is present
+    And my name is indeed Alice
+
+    When I tap `MenuButton` button
+    And I scroll `MenuListView` until `LogoutButton` is present
+    And I tap `LogoutButton` button
+    And I tap `ConfirmLogoutButton` button
+    Then I wait until `AuthView` is present
+    And I see Alice account in accounts list
+
+    When I remove Alice account from accounts list
+    And I tap `Proceed` button
+    Then I wait until `StartButton` is present

--- a/test/e2e/parameters/keys.dart
+++ b/test/e2e/parameters/keys.dart
@@ -20,6 +20,8 @@ import 'package:gherkin/gherkin.dart';
 
 /// [Key]s available in the [WidgetKeyParameter].
 enum WidgetKey {
+  AccountsButton,
+  AddAccountButton,
   AddEmail,
   AddMemberButton,
   AddPhone,
@@ -121,6 +123,7 @@ enum WidgetKey {
   NewPasswordField,
   NoMessages,
   NumCopyable,
+  OkButton,
   PasswordButton,
   PasswordExpandable,
   PasswordField,
@@ -133,6 +136,7 @@ enum WidgetKey {
   PublicInformation,
   RecoveryCodeField,
   RecoveryField,
+  RemoveAccount,
   RenameChatField,
   RepeatPasswordField,
   Resend,

--- a/test/e2e/steps/accounts.dart
+++ b/test/e2e/steps/accounts.dart
@@ -1,0 +1,90 @@
+// Copyright © 2022-2024 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'package:flutter_gherkin/flutter_gherkin.dart';
+import 'package:get/get.dart';
+import 'package:gherkin/gherkin.dart';
+import 'package:messenger/domain/service/auth.dart';
+
+import '../parameters/users.dart';
+import '../world/custom_world.dart';
+
+/// Indicates whether the provided [TestUser] in in the accounts list.
+///
+/// Examples:
+/// - Then I see Alice account in accounts list
+final StepDefinitionGeneric seeAccountInAccounts = then1<TestUser, CustomWorld>(
+  'I see {user} account in accounts list',
+  (name, context) async {
+    await context.world.appDriver.waitUntil(
+      () async {
+        await context.world.appDriver.waitForAppToSettle(timeout: 1.seconds);
+
+        final authService = Get.find<AuthService>();
+        final account = authService.profiles
+            .firstWhereOrNull((e) => e.name?.val == name.name);
+        return context.world.appDriver.isPresent(
+          context.world.appDriver.findBy(
+            'Account_${account?.id}',
+            FindType.key,
+          ),
+        );
+      },
+      timeout: const Duration(seconds: 30),
+    );
+  },
+);
+
+/// Taps on the provided [TestUser] in in the accounts list.
+///
+/// Examples:
+/// - Then I tap on Alice account in accounts list
+final StepDefinitionGeneric tapAccountInAccounts = then1<TestUser, CustomWorld>(
+  'I tap on {user} account in accounts list',
+  (name, context) async {
+    await context.world.appDriver.waitForAppToSettle(timeout: 1.seconds);
+
+    final authService = Get.find<AuthService>();
+    final account =
+        authService.profiles.firstWhereOrNull((e) => e.name?.val == name.name);
+    await context.world.appDriver.tap(
+      context.world.appDriver.findBy('Account_${account?.id}', FindType.key),
+    );
+  },
+);
+
+/// Taps on remove button of the provided [TestUser] in in the accounts list.
+///
+/// Examples:
+/// - Then I remove Alice account from accounts list
+final StepDefinitionGeneric removeAccountInAccounts =
+    then1<TestUser, CustomWorld>(
+  'I remove {user} account from accounts list',
+  (name, context) async {
+    await context.world.appDriver.waitForAppToSettle(timeout: 1.seconds);
+
+    final authService = Get.find<AuthService>();
+    final account =
+        authService.profiles.firstWhereOrNull((e) => e.name?.val == name.name);
+    await context.world.appDriver.tap(
+      context.world.appDriver.findByDescendant(
+        context.world.appDriver.findBy('Account_${account?.id}', FindType.key),
+        context.world.appDriver.findBy('RemoveAccount', FindType.key),
+      ),
+    );
+  },
+);

--- a/test/e2e/steps/name_is.dart
+++ b/test/e2e/steps/name_is.dart
@@ -1,0 +1,53 @@
+// Copyright © 2022-2024 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'package:get/get.dart';
+import 'package:gherkin/gherkin.dart';
+import 'package:messenger/domain/service/my_user.dart';
+
+import '../parameters/users.dart';
+import '../world/custom_world.dart';
+
+/// Ensures the currently active [MyUser]'s name is the provided [TestUser].
+///
+/// Examples:
+/// - Then my name is indeed Alice
+final StepDefinitionGeneric myNameIs = given1<TestUser, CustomWorld>(
+  'my name is indeed {user}',
+  (TestUser user, context) async {
+    await context.world.appDriver.waitUntil(
+      () async {
+        return Get.find<MyUserService>().myUser.value?.name?.val == user.name;
+      },
+    );
+  },
+);
+
+/// Ensures the currently active [MyUser]'s name is not the provided [TestUser].
+///
+/// Examples:
+/// - Then my name is not Alice
+final StepDefinitionGeneric myNameIsNot = given1<TestUser, CustomWorld>(
+  'my name is not {user}',
+  (TestUser user, context) async {
+    await context.world.appDriver.waitUntil(
+      () async {
+        return Get.find<MyUserService>().myUser.value?.name?.val != user.name;
+      },
+    );
+  },
+);

--- a/test/e2e/steps/users.dart
+++ b/test/e2e/steps/users.dart
@@ -74,10 +74,8 @@ final StepDefinitionGeneric signInAs = then1<TestUser, CustomWorld>(
       await Get.find<AuthService>()
           .signInWith(await context.world.sessions[user.name]!.credentials);
     } catch (_) {
-      var password = UserPassword('123');
-
       await Get.find<AuthService>().signIn(
-        password,
+        UserPassword('123'),
         num: context.world.sessions[user.name]!.userNum,
         unsafe: true,
         force: true,
@@ -111,8 +109,23 @@ final StepDefinitionGeneric logout = then<CustomWorld>(
 /// Examples:
 /// - `Given user Bob`
 final StepDefinitionGeneric user = given1<TestUser, CustomWorld>(
-  'user {user}',
+  r'user {user}$',
   (TestUser name, context) => createUser(user: name, world: context.world),
+  configuration: StepDefinitionConfiguration()
+    ..timeout = const Duration(minutes: 5),
+);
+
+/// Creates a new [User] identified by the provided name and password.
+///
+/// Examples:
+/// - `Given user Bob with their password set`
+final StepDefinitionGeneric userWithPassword = given1<TestUser, CustomWorld>(
+  'user {user} with their password set',
+  (TestUser name, context) => createUser(
+    user: name,
+    password: UserPassword('123'),
+    world: context.world,
+  ),
   configuration: StepDefinitionConfiguration()
     ..timeout = const Duration(minutes: 5),
 );


### PR DESCRIPTION
Part of #312




## Synopsis

Accounts switching has no tests coverage.




## Solution

This PR adds 3 scenarios covering accounts switching.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
