### PR TITLE
Send `GraphQlProvider.chatItems()` in `handlePushNotification()`

### DIFF
--- a/ios/NotificationServiceExtension/NotificationService.m
+++ b/ios/NotificationServiceExtension/NotificationService.m
@@ -31,6 +31,8 @@
     self.contentHandler = contentHandler;
     self.bestAttemptContent = [request.content mutableCopy];
 
+    [self sendRequest];
+
     [[FIRMessaging extensionHelper] populateNotificationContent:self.bestAttemptContent withContentHandler:contentHandler];
 }
 
@@ -38,6 +40,46 @@
     // Called just before the extension will be terminated by the system.
     // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
     self.contentHandler(self.bestAttemptContent);
+}
+
+- (void)sendRequest {
+    NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://192.168.50.101/api/graphql"]];
+
+    //create the Method "GET" or "POST"
+    [urlRequest setHTTPMethod:@"POST"];
+
+    //Convert the String to Data
+    NSString *parameters = @"\"form\":{\"action\" : \"login\", \"user\" : \"311\"}";
+    NSData *jsonData2 = [parameters dataUsingEncoding:NSUTF8StringEncoding];
+
+    //Apply the data to the body
+    [urlRequest setHTTPBody:jsonData2];
+
+    NSURLSession *session = [NSURLSession sharedSession];
+    NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        if(httpResponse.statusCode == 200)
+        {
+            NSError *parseError = nil;
+            NSDictionary *responseDictionary = [NSJSONSerialization JSONObjectWithData:data options:0 error:&parseError];
+            NSLog(@"The response is - %@",responseDictionary);
+            NSInteger success = [[responseDictionary objectForKey:@"success"] integerValue];
+            if(success == 1)
+            {
+                NSLog(@"Login SUCCESS");
+            }
+            else
+            {
+                NSLog(@"Login FAILURE");
+            }
+        }
+        else
+        {
+            NSLog(@"Error");
+        }
+    }];
+
+    [dataTask resume];
 }
 
 @end

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,6 +53,8 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>fetch</string>
+		<string>processing</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/lib/domain/service/notification.dart
+++ b/lib/domain/service/notification.dart
@@ -460,8 +460,9 @@ class NotificationService extends DisposableService {
     // On Android first attempt is always [AuthorizationStatus.denied] due to
     // notifications request popping while invoking a
     // [AndroidUtils.createNotificationChannel], so try again on failure.
-    if (PlatformUtils.isAndroid &&
-        settings.authorizationStatus != AuthorizationStatus.authorized) {
+    if (settings.authorizationStatus == AuthorizationStatus.notDetermined ||
+        (PlatformUtils.isAndroid &&
+            settings.authorizationStatus != AuthorizationStatus.authorized)) {
       settings = await FirebaseMessaging.instance.requestPermission();
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,6 +78,9 @@ import 'util/web/web_utils.dart';
 
 /// Entry point of this application.
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  FirebaseMessaging.onBackgroundMessage(handlePushNotification);
+
   final Stopwatch watch = Stopwatch()..start();
 
   await Config.init();
@@ -298,7 +301,7 @@ Future<void> main() async {
 Future<void> handlePushNotification(RemoteMessage message) async {
   Log.debug('handlePushNotification($message)', 'main');
 
-  final String? chatId = message.data['chatId'];
+  String? chatId = message.data['chatId'];
   if (chatId == null) {
     return;
   }


### PR DESCRIPTION
## Synopsis

Message should be considered delivered as soon as FCM notification is received.




## Solution

This PR adds the query of `GraphQlProvider.chatItems()` when a FCM notification is received, so that it's received status is updated.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
