### PR TITLE
Use `git rev-list HEAD --count` for `--build-number` in `flutter.build` Makefile command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,7 +426,7 @@ jobs:
     container: debian:bullseye
     steps:
       - name: Install Git
-        run: apt-get install -y git
+        run: apt-get update && apt-get install -y git
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,9 +225,16 @@ jobs:
           regex: '^refs/tags/v(((([0-9]+)\.[0-9]+)\.[0-9]+)(-.+)?)$'
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
+      - name: Retrieve commits count
+        id: commits
+        run: |
+          echo "count=$(git rev-list HEAD --count)" \
+          >> $GITHUB_OUTPUT
+
       # TODO: Remove `profile=yes`, when self-hosted Sentry supports source
       #       maps reading.
       - run: make flutter.build platform=${{ matrix.platform }} profile=yes
+                  build=${{ steps.commits.outputs.count }}
                   dart-env='SOCAPP_FCM_VAPID_KEY=${{ secrets.FCM_VAPID_KEY }}
                             SOCAPP_LINK_PREFIX=${{ startsWith(github.ref, 'refs/tags/v') && secrets.LINK_STABLE || secrets.LINK_MAIN }}
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}'
@@ -248,6 +255,7 @@ jobs:
       #       https://github.com/getsentry/sentry-dart/issues/433
       #       https://github.com/getsentry/sentry-dart/issues/896
       - run: make flutter.build platform=${{ matrix.platform }}
+                  build=${{ steps.commits.outputs.count }}
                   dart-env='SOCAPP_HTTP_URL=${{ secrets.BACKEND_URL }}
                             SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }}
                             SOCAPP_WS_URL=${{ secrets.BACKEND_WS }}
@@ -464,11 +472,18 @@ jobs:
           regex: '^refs/tags/v(((([0-9]+)\.[0-9]+)\.[0-9]+)(-.+)?)$'
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
+      - name: Retrieve commits count
+        id: commits
+        run: |
+          echo "count=$(git rev-list HEAD --count)" \
+          >> $GITHUB_OUTPUT
+
       - run: make flutter.pub
 
       # TODO: Use `split-debug-info` when Sentry supports Linux debug symbols.
       #       https://github.com/getsentry/sentry-dart/issues/433
       - run: make flutter.build platform=linux
+                  build=${{ steps.commits.outputs.count }}
                   dart-env='SOCAPP_HTTP_URL=${{ secrets.BACKEND_URL }}
                             SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }}
                             SOCAPP_WS_URL=${{ secrets.BACKEND_WS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,9 @@ jobs:
     # Pin glibc to 2.31 version for better compatibility.
     container: debian:bullseye
     steps:
+      - name: Install Git
+        run: sudo apt-get install -y git
+
       - uses: actions/checkout@v4
         with:
           # Unshallow the repository in order for `PubspecBuilder` and its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,7 +426,7 @@ jobs:
     container: debian:bullseye
     steps:
       - name: Install Git
-        run: sudo apt-get install -y git
+        run: apt-get install -y git
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,9 +472,6 @@ jobs:
     # Pin glibc to 2.31 version for better compatibility.
     container: debian:bullseye
     steps:
-      - name: Install Git
-        run: apt-get update && apt-get install -y git
-
       - uses: actions/checkout@v4
         with:
           # Unshallow the repository in order for `PubspecBuilder` and its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,16 +225,9 @@ jobs:
           regex: '^refs/tags/v(((([0-9]+)\.[0-9]+)\.[0-9]+)(-.+)?)$'
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Retrieve commits count
-        id: commits
-        run: |
-          echo "count=$(git rev-list HEAD --count)" \
-          >> $GITHUB_OUTPUT
-
       # TODO: Remove `profile=yes`, when self-hosted Sentry supports source
       #       maps reading.
       - run: make flutter.build platform=${{ matrix.platform }} profile=yes
-                  build=${{ steps.commits.outputs.count }}
                   dart-env='SOCAPP_FCM_VAPID_KEY=${{ secrets.FCM_VAPID_KEY }}
                             SOCAPP_LINK_PREFIX=${{ startsWith(github.ref, 'refs/tags/v') && secrets.LINK_STABLE || secrets.LINK_MAIN }}
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}'
@@ -255,7 +248,6 @@ jobs:
       #       https://github.com/getsentry/sentry-dart/issues/433
       #       https://github.com/getsentry/sentry-dart/issues/896
       - run: make flutter.build platform=${{ matrix.platform }}
-                  build=${{ steps.commits.outputs.count }}
                   dart-env='SOCAPP_HTTP_URL=${{ secrets.BACKEND_URL }}
                             SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }}
                             SOCAPP_WS_URL=${{ secrets.BACKEND_WS }}
@@ -472,18 +464,11 @@ jobs:
           regex: '^refs/tags/v(((([0-9]+)\.[0-9]+)\.[0-9]+)(-.+)?)$'
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Retrieve commits count
-        id: commits
-        run: |
-          echo "count=$(git rev-list HEAD --count)" \
-          >> $GITHUB_OUTPUT
-
       - run: make flutter.pub
 
       # TODO: Use `split-debug-info` when Sentry supports Linux debug symbols.
       #       https://github.com/getsentry/sentry-dart/issues/433
       - run: make flutter.build platform=linux
-                  build=${{ steps.commits.outputs.count }}
                   dart-env='SOCAPP_HTTP_URL=${{ secrets.BACKEND_URL }}
                             SOCAPP_HTTP_PORT=${{ secrets.BACKEND_PORT }}
                             SOCAPP_WS_URL=${{ secrets.BACKEND_WS }}

--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,6 @@ appcast-item-ver = $(or $(version),\
 appcast-item-notes = $(foreach xml,$(wildcard release_notes/*.md),<description xml:lang=\"$(shell echo $(xml) | rev | cut -d"/" -f1 | rev | cut -d"." -f1)\"><![CDATA[$$(cat $(xml))]]></description>)
 
 appcast.xml.item:
-	@echo $(appcast-item-ver)
 	@echo "<item><title>$(appcast-item-ver)</title>$(if $(call eq,$(notes),),$(appcast-item-notes),<description>$(notes)</description>)<pubDate>$(shell date -R)</pubDate>$(call appcast.xml.item.release,"macos","messenger-macos.zip")$(call appcast.xml.item.release,"windows","messenger-windows.zip")$(call appcast.xml.item.release,"linux","messenger-linux.zip")$(call appcast.xml.item.release,"android","messenger-android.zip")$(call appcast.xml.item.release,"ios","messenger-ios.zip")</item>" \
 	> $(or $(out),appcast/$(appcast-item-ver).xml)
 define appcast.xml.item.release

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ endif
 # Usage:
 #	make flutter.build [( [platform=apk] [split-per-abi=(no|yes)]
 #	                    | platform=(appbundle|web|linux|macos|windows|ios) )]
+#	                   [build=<build-number>]
 #	                   [dart-env=<VAR1>=<VAL1>[,<VAR2>=<VAL2>...]]
 #	                   [dockerized=(no|yes)]
 #	                   [profile=(no|yes)]
@@ -161,7 +162,8 @@ else
 		$(if $(call eq,$(or $(platform),apk),apk),\
 			$(if $(call eq,$(split-per-abi),yes),--split-per-abi,),) \
 		$(foreach v,$(subst $(comma), ,$(dart-env)),--dart-define=$(v)) \
-		$(if $(call eq,$(platform),ios),--no-codesign,)
+		$(if $(call eq,$(platform),ios),--no-codesign,) \
+		$(if $(call eq,$(build),),,--build-number=$(build))
 endif
 
 
@@ -358,7 +360,7 @@ endef
 #	                      [out=(appcast/<version>.xml|<output-file>)
 
 appcast-item-ver = $(or $(version),\
-	$(shell git describe --tags --dirty --match "v*" --always))
+	$(shell git describe --tags --abbrev=0 --match "v*" --always))
 appcast-item-notes = $(foreach xml,$(wildcard release_notes/*.md),<description xml:lang=\"$(shell echo $(xml) | rev | cut -d"/" -f1 | rev | cut -d"." -f1)\"><![CDATA[$$(cat $(xml))]]></description>)
 
 appcast.xml.item:

--- a/Makefile
+++ b/Makefile
@@ -362,10 +362,11 @@ endef
 #	                      [out=(appcast/<version>.xml|<output-file>)
 
 appcast-item-ver = $(or $(version),\
-	$(shell git describe --tags --abbrev=0 --match "v*" --always))
+	$(shell git describe --tags --abbrev=0 --match "v*" --always)+$(shell git rev-list HEAD --count))
 appcast-item-notes = $(foreach xml,$(wildcard release_notes/*.md),<description xml:lang=\"$(shell echo $(xml) | rev | cut -d"/" -f1 | rev | cut -d"." -f1)\"><![CDATA[$$(cat $(xml))]]></description>)
 
 appcast.xml.item:
+	@echo $(appcast-item-ver)
 	@echo "<item><title>$(appcast-item-ver)</title>$(if $(call eq,$(notes),),$(appcast-item-notes),<description>$(notes)</description>)<pubDate>$(shell date -R)</pubDate>$(call appcast.xml.item.release,"macos","messenger-macos.zip")$(call appcast.xml.item.release,"windows","messenger-windows.zip")$(call appcast.xml.item.release,"linux","messenger-linux.zip")$(call appcast.xml.item.release,"android","messenger-android.zip")$(call appcast.xml.item.release,"ios","messenger-ios.zip")</item>" \
 	> $(or $(out),appcast/$(appcast-item-ver).xml)
 define appcast.xml.item.release

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,13 @@ endif
 # Usage:
 #	make flutter.build [( [platform=apk] [split-per-abi=(no|yes)]
 #	                    | platform=(appbundle|web|linux|macos|windows|ios) )]
-#	                   [build=<build-number>]
+#	                   [build=($(git rev-list HEAD --count)|<build-number>)]
 #	                   [dart-env=<VAR1>=<VAL1>[,<VAR2>=<VAL2>...]]
 #	                   [dockerized=(no|yes)]
 #	                   [profile=(no|yes)]
 #	                   [split-debug-info=(no|yes)]
+
+flutter-build-number=$(or $(build),$(shell git rev-list HEAD --count))
 
 flutter.build:
 ifeq ($(wildcard lib/api/backend/*.graphql.dart),)
@@ -151,7 +153,7 @@ else
 		ghcr.io/instrumentisto/flutter:$(FLUTTER_VER) \
 			make flutter.build platform=$(platform) dart-env='$(dart-env)' \
 			                   split-debug-info=$(split-debug-info) \
-			                   profile=$(profile) \
+			                   build=$(build) profile=$(profile) \
 			                   dockerized=no
 endif
 else
@@ -163,7 +165,7 @@ else
 			$(if $(call eq,$(split-per-abi),yes),--split-per-abi,),) \
 		$(foreach v,$(subst $(comma), ,$(dart-env)),--dart-define=$(v)) \
 		$(if $(call eq,$(platform),ios),--no-codesign,) \
-		$(if $(call eq,$(build),),,--build-number=$(build))
+		--build-number=$(flutter-build-number)
 endif
 
 

--- a/test/unit/version_test.dart
+++ b/test/unit/version_test.dart
@@ -210,6 +210,11 @@ void main() {
           VersionExtension.parse('0.1.0-alpha.14'),
       true,
     );
+
+    expect(Version(0, 1, 0) < Version(0, 1, 0, build: '1'), true);
+    expect(Version(0, 1, 0, build: '1') == Version(0, 1, 0, build: '1'), true);
+    expect(Version(0, 1, 0, build: '1') < Version(0, 1, 0, build: '2'), true);
+    expect(Version(1, 0, 0, build: '502') > Version(1, 0, 0, build: '9'), true);
   });
 
   test('Version correctly detects the critical versions', () async {
@@ -294,6 +299,16 @@ void main() {
       Version(0, 1, 0, pre: 'alpha.1')
           .isCritical(Version(0, 1, 0, pre: 'alpha.1', build: '1')),
       false,
+    );
+    expect(Version(0, 1, 0).isCritical(Version(0, 1, 0, build: '1')), false);
+    expect(
+      Version(0, 1, 0, build: '1').isCritical(Version(0, 1, 0, build: '2')),
+      false,
+    );
+    expect(Version(1, 0, 0).isCritical(Version(1, 0, 0, build: '524')), false);
+    expect(
+      Version(0, 1, 0, build: '1').isCritical(Version(0, 2, 0, build: '2')),
+      true,
     );
   });
 }


### PR DESCRIPTION
Required for #1046




## Synopsis

Currently we use the following versioning semantics: `0.1.0-alpha.13.5-commit-hash-14`. Build number is always `1`. However, both Google Play and App Store require application to have build number that increments over time. While Apple allows duplicate build number for different builds, Google Play does not - it identifies the uniqueness strictly by the number, so it MUST always increment when a new build is submitted.

Note, that draft builds can be removed, but the reviewed and active ones cannot.




## Solution

This PR replaces the commit hashes with commit counts and uses the count in the `flutter.build` Makefile command.

In order for `appcast.xml` to properly propagate the updates, we need two components:
1) The `appcast.xml.item` command should produce the correct results for the version: `$(git-tag)+$(git-commits-count)`. This is done in Makefile:
```Makefile
appcast-item-ver = $(git describe --tags --abbrev=0 --match "v*" --always)+$(git rev-list HEAD --count)
```

-> produces `0.1.0-alpha.13.5+530`

2) The client should have its version set in the `PubspecBuilder` correctly, since the `Pubspec.ref` is used to compare whatever is hosted in the `appcast.xml` against it. `PubspecBuilder` thus should form the `Pubspec.ref` to be exactly the described above value. This is done by invoking two `Process.run`s:
```dart
final ProcessResult git = await Process.run(
  'git',
  ['describe', '--tags', '--abbrev=0', '--dirty', '--match', 'v*'],
);

final ProcessResult rev =
    await Process.run('git', ['rev-list', 'HEAD', '--count']);

buffer.write('  static const String ref = \'${ref.stdout.toString()}+${count.stdout.toString()}\';\n');
```

-> produces `static const String ref = '0.1.0-alpha.13.5+530';`

Regarding iOS and Android applications: we need to pass the `--build-number` parameter to override the `pubspec.yaml` build number being used (`version: 0.1.0-alpha.13.5` -> means build number is 1, because it contains no `+N` after the build name). This is done in Makefile in the `build` command:
```Makefile
flutter-build-number=$(or $(build),$(shell git rev-list HEAD --count))

flutter build ... \
              --build-number=$(flutter-build-number)
```




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
