### PR TITLE
Throw `Exception`s, when `PubspecBuilder` is unable to use `git`

### DIFF
--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -57,11 +57,10 @@ class PubspecBuilder implements Builder {
         'git',
         ['describe', '--tags', '--abbrev=0', '--dirty', '--match', 'v*'],
       );
+      final ProcessResult rev =
+          await Process.run('git', ['rev-list', 'HEAD', '--count']);
 
-      if (git.exitCode == 0) {
-        final ProcessResult rev =
-            await Process.run('git', ['rev-list', 'HEAD', '--count']);
-
+      if (git.exitCode == 0 && rev.exitCode == 0) {
         String ref = git.stdout.toString();
         String count = rev.stdout.toString();
 
@@ -80,20 +79,14 @@ class PubspecBuilder implements Builder {
 
         buffer.write('  static const String ref = \'$ref+$count\';\n');
       } else {
-        // ignore: avoid_print
-        print(
+        throw Exception(
           '[PubspecBuilder] Unable to properly generate `pubspec.g.dart` summary: `git` executable exited with code ${git.exitCode}, \nstdout: ${git.stdout}\nstderr: ${git.stderr}',
         );
-
-        buffer.write('  static const String ref = version;\n');
       }
     } catch (e) {
-      // ignore: avoid_print
-      print(
+      throw Exception(
         '[PubspecBuilder] Unable to properly generate `pubspec.g.dart` summary: `git` executable failed: ${e.toString()}',
       );
-
-      buffer.write('  static const String ref = version;\n');
     }
 
     buffer.write('}\n');


### PR DESCRIPTION
## Synopsis

`PubspecBuilder` prints a warning, when it's unable to use `git`. However, this caused Linux build to silently fail to populate the `ref` value used for `UpgradeWorker` to determine whether application's upgrade is available or not.




## Solution

This PR refactors `PubspecBuilder` to throw `Exception`s instead of printing a warnings, when `git` isn't available.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
