### PR TITLE
Display blurred preview under single `ImageAttachment`s in `Chat` (#985)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.2.0] · 2024-??-??
+[0.2.0]: /../../tree/v0.2.0
+
+[Diff](/../../compare/v0.1.0...v0.2.0) | [Milestone](/../../milestone/26)
+
+### Changed
+
+- UI:
+    - Chat page:
+        - Blurred previews under single images. ([#1057], [#985])
+
+[#985]: /../../issues/985
+[#1057]: /../../pull/1057
+
+
+
+
 ## [0.1.0] · 2024-06-27
 [0.1.0]: /../../tree/v0.1.0
 

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -151,12 +151,11 @@ class _MediaAttachmentState extends State<MediaAttachment> {
       } else if (attachment is ImageAttachment) {
         final ImageFile file = attachment.original as ImageFile;
         final double ratio = (file.width ?? 300) / (file.height ?? 300);
-        final bool narrow = ratio > 3 ||
-            ratio < 0.33 ||
-            (widget.width != double.infinity &&
-                widget.height != double.infinity);
+        final bool narrow = ratio > 3 || ratio < 0.33;
+        final bool single =
+            widget.width != double.infinity && widget.height != double.infinity;
 
-        if (narrow) {
+        if (narrow || single) {
           final ThumbHash? thumbhash =
               (attachment.original as ImageFile).thumbhash ??
                   attachment.big.thumbhash ??

--- a/lib/ui/page/home/page/chat/widget/media_attachment.dart
+++ b/lib/ui/page/home/page/chat/widget/media_attachment.dart
@@ -151,7 +151,10 @@ class _MediaAttachmentState extends State<MediaAttachment> {
       } else if (attachment is ImageAttachment) {
         final ImageFile file = attachment.original as ImageFile;
         final double ratio = (file.width ?? 300) / (file.height ?? 300);
-        final bool narrow = ratio > 3 || ratio < 0.33;
+        final bool narrow = ratio > 3 ||
+            ratio < 0.33 ||
+            (widget.width != double.infinity &&
+                widget.height != double.infinity);
 
         if (narrow) {
           final ThumbHash? thumbhash =

--- a/test/widget/chat_update_attachments_test.dart
+++ b/test/widget/chat_update_attachments_test.dart
@@ -507,7 +507,7 @@ void main() async {
     await tester.pumpAndSettle(const Duration(seconds: 2));
 
     expect(
-      find.byKey(const Key('Image_oldRef.png'), skipOffstage: false),
+      find.byKey(const Key('Image_oldRef.png'), skipOffstage: false).first,
       findsOneWidget,
     );
 
@@ -525,7 +525,7 @@ void main() async {
     await tester.pumpAndSettle(const Duration(seconds: 2));
 
     expect(
-      find.byKey(const Key('Image_updatedRef.png'), skipOffstage: false),
+      find.byKey(const Key('Image_updatedRef.png'), skipOffstage: false).first,
       findsOneWidget,
     );
 


### PR DESCRIPTION
Resolves #985




## Synopsis

> If both image and text are specified, and the text occupies more width, than the image, then the image is rendered in an ugly way with the empty spaces on the sides.




## Solution

> We already display a blurred preview under too narrow/too wide images. Should probably do the same for this case.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
