### PR TITLE
Change `ChatItemWidget` color to `Colors.primaryLight`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Changed
 
+- UI:
+    - Chat page:
+        - Updated messages color. ([#1069])
 - iOS:
     - Better described microphone and camera usage prompts. ([#1066])
 
 [#1066]: /../../pull/1066
+[#1069]: /../../pull/1069
 
 
 

--- a/lib/themes.dart
+++ b/lib/themes.dart
@@ -87,6 +87,8 @@ class Themes {
       primaryHighlightShiny: const Color(0xFF58A6EF),
       primaryHighlightShiniest: const Color(0xFFD2E3F9),
       primaryHighlightLightest: const Color(0xFFB9D9FA),
+      primaryLight: const Color(0xFFD2E9FE),
+      primaryLightest: const Color(0xFFD5EDFE),
       primaryDark: const Color(0xFF1F3C5D),
       primaryAuxiliary: const Color(0xFF165084),
       onPrimary: const Color(0xFFFFFFFF),
@@ -208,7 +210,7 @@ class Themes {
             color: colors.secondaryHighlightDark,
             width: 0.5,
           ),
-          readMessageColor: colors.acceptLighter,
+          readMessageColor: colors.primaryLight,
           secondaryBorder: Border.all(color: colors.acceptLight, width: 0.5),
           sidebarColor: colors.onPrimaryOpacity50,
           systemMessageBorder: Border.all(
@@ -218,7 +220,7 @@ class Themes {
           systemMessageColor: colors.secondaryHighlight,
           systemMessageStyle: fonts.small.regular.secondary,
           systemMessagePrimary: fonts.small.regular.primary,
-          unreadMessageColor: colors.acceptLightest,
+          unreadMessageColor: colors.primaryLightest,
         ),
       ],
       scaffoldBackgroundColor: colors.transparent,
@@ -639,6 +641,8 @@ class Palette {
     required this.primaryHighlightShiny,
     required this.primaryHighlightShiniest,
     required this.primaryHighlightLightest,
+    required this.primaryLight,
+    required this.primaryLightest,
     required this.primaryDark,
     Color? primaryDarkOpacity70,
     Color? primaryDarkOpacity90,
@@ -760,6 +764,16 @@ class Palette {
   ///
   /// Used as a border of [ChatMessage]s and [ChatForward]s.
   final Color primaryHighlightLightest;
+
+  /// Light [primary] highlight [Color].
+  ///
+  /// Used as a read [ChatMessage] color.
+  final Color primaryLight;
+
+  /// Lightest [primary].
+  ///
+  /// Used as an unread [ChatMessage] color.
+  final Color primaryLightest;
 
   /// Dark [Color] of the [primary] elements.
   ///
@@ -1012,6 +1026,9 @@ class Palette {
           color.primaryHighlightShiniest, other.primaryHighlightShiniest, t)!,
       primaryHighlightLightest: Color.lerp(
           color.primaryHighlightLightest, other.primaryHighlightLightest, t)!,
+      primaryLight: Color.lerp(color.primaryLight, other.primaryLight, t)!,
+      primaryLightest:
+          Color.lerp(color.primaryLightest, other.primaryLightest, t)!,
       primaryDark: Color.lerp(color.primaryDark, other.primaryDark, t)!,
       primaryDarkOpacity70: Color.lerp(
           color.primaryDarkOpacity70, other.primaryDarkOpacity70, t)!,

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -973,14 +973,8 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                             : style.unreadMessageColor
                         : style.messageColor,
                     borderRadius: BorderRadius.circular(15),
-                    border: _fromMe
-                        ? _isRead
-                            ? style.secondaryBorder
-                            : Border.all(
-                                color: style.readMessageColor,
-                                width: 0.5,
-                              )
-                        : style.primaryBorder,
+                    border:
+                        _fromMe ? style.secondaryBorder : style.primaryBorder,
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -1099,14 +1093,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 500),
           decoration: BoxDecoration(
-            border: _fromMe
-                ? _isRead
-                    ? style.secondaryBorder
-                    : Border.all(
-                        color: style.colors.backgroundAuxiliaryLighter,
-                        width: 0.5,
-                      )
-                : style.primaryBorder,
+            border: _fromMe ? style.secondaryBorder : style.primaryBorder,
             color: _fromMe
                 ? _isRead
                     ? style.readMessageColor

--- a/lib/ui/page/style/page/colors/view.dart
+++ b/lib/ui/page/style/page/colors/view.dart
@@ -69,6 +69,8 @@ class ColorsView extends StatelessWidget {
       (style.colors.primary, 'primary'),
       (style.colors.primaryHighlightShiniest, 'primaryHighlightShiniest'),
       (style.colors.primaryHighlightLightest, 'primaryHighlightLightest'),
+      (style.colors.primaryLight, 'primaryLight'),
+      (style.colors.primaryLightest, 'primaryLightest'),
       (style.colors.backgroundAuxiliaryLighter, 'backgroundAuxiliaryLighter'),
       (style.colors.backgroundAuxiliaryLightest, 'backgroundAuxiliaryLightest'),
       (style.colors.accept, 'accept'),


### PR DESCRIPTION
## Synopsis

`ChatMessage` color has been updated from green to blue.




## Solution

This PR changes the color.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
