### PR TITLE
Pin `media_kit` to its latest GitHub version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,14 @@ All user visible changes to this project will be documented in this file. This p
 - iOS:
     - Better described microphone and camera usage prompts. ([#1066])
 
+### Fixed
+
+- Windows:
+    - Application not launching due to `MSVCP140.dll` library being missing. ([#1070])
+
 [#1066]: /../../pull/1066
 [#1069]: /../../pull/1069
+[#1070]: /../../pull/1070
 
 
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,8 +53,6 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>fetch</string>
-		<string>processing</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/lib/ui/page/home/page/chat/widget/video/widget/video_progress_bar.dart
+++ b/lib/ui/page/home/page/chat/widget/video/widget/video_progress_bar.dart
@@ -223,13 +223,16 @@ class _ProgressBarPainter extends CustomPainter {
       colors.background,
     );
 
-    final double playedPartPercent =
-        position.inMilliseconds / duration.inMilliseconds;
+    final double playedPartPercent = duration == Duration.zero
+        ? 0
+        : position.inMilliseconds / duration.inMilliseconds;
     final double playedPart =
         playedPartPercent > 1 ? size.width : playedPartPercent * size.width;
 
-    final double end =
-        (buffered.inMilliseconds / duration.inMilliseconds) * size.width;
+    final double end = duration == Duration.zero
+        ? 0
+        : (buffered.inMilliseconds / duration.inMilliseconds) * size.width;
+
     canvas.drawRRect(
       RRect.fromRectAndRadius(
         Rect.fromPoints(

--- a/lib/ui/widget/upgrade_popup/view.dart
+++ b/lib/ui/widget/upgrade_popup/view.dart
@@ -127,7 +127,6 @@ class UpgradePopupView extends StatelessWidget {
                 text: critical
                     ? 'label_critical_update_is_available'.l10n
                     : 'label_update_is_available'.l10n,
-                close: !critical,
               );
               children = [
                 Flexible(

--- a/lib/ui/worker/upgrade.dart
+++ b/lib/ui/worker/upgrade.dart
@@ -117,14 +117,14 @@ class UpgradeWorker extends DisposableService {
             final bool lower = ours != null && their != null
                 ? ours < their
                 : Pubspec.ref.compareTo(release.name) == -1;
-            Log.debug(
+            Log.info(
               'Whether `${Pubspec.ref}` is lower than `${release.name}`: $lower',
               '$runtimeType',
             );
 
             // Critical releases must always be displayed and can't be skipped.
             final bool critical = ours?.isCritical(their) ?? false;
-            Log.debug(
+            Log.info(
               'Whether `$ours` is considered critical relative to `$their`: $critical',
               '$runtimeType',
             );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1201,34 +1201,38 @@ packages:
   media_kit:
     dependency: "direct main"
     description:
-      name: media_kit
-      sha256: "3289062540e3b8b9746e5c50d95bd78a9289826b7227e253dff806d002b9e67a"
-      url: "https://pub.dev"
-    source: hosted
+      path: media_kit
+      ref: HEAD
+      resolved-ref: "50c510d018cc5286eb6730f3ea165290f19dc5f6"
+      url: "https://github.com/media-kit/media-kit"
+    source: git
     version: "1.1.10+1"
   media_kit_libs_android_video:
     dependency: "direct main"
     description:
-      name: media_kit_libs_android_video
-      sha256: "9dd8012572e4aff47516e55f2597998f0a378e3d588d0fad0ca1f11a53ae090c"
-      url: "https://pub.dev"
-    source: hosted
+      path: "libs/android/media_kit_libs_android_video"
+      ref: HEAD
+      resolved-ref: "50c510d018cc5286eb6730f3ea165290f19dc5f6"
+      url: "https://github.com/media-kit/media-kit"
+    source: git
     version: "1.3.6"
   media_kit_libs_ios_video:
     dependency: "direct main"
     description:
-      name: media_kit_libs_ios_video
-      sha256: b5382994eb37a4564c368386c154ad70ba0cc78dacdd3fb0cd9f30db6d837991
-      url: "https://pub.dev"
-    source: hosted
+      path: "libs/ios/media_kit_libs_ios_video"
+      ref: HEAD
+      resolved-ref: "50c510d018cc5286eb6730f3ea165290f19dc5f6"
+      url: "https://github.com/media-kit/media-kit"
+    source: git
     version: "1.1.4"
   media_kit_libs_linux:
     dependency: "direct main"
     description:
-      name: media_kit_libs_linux
-      sha256: e186891c31daa6bedab4d74dcdb4e8adfccc7d786bfed6ad81fe24a3b3010310
-      url: "https://pub.dev"
-    source: hosted
+      path: "libs/linux/media_kit_libs_linux"
+      ref: HEAD
+      resolved-ref: "50c510d018cc5286eb6730f3ea165290f19dc5f6"
+      url: "https://github.com/media-kit/media-kit"
+    source: git
     version: "1.1.3"
   media_kit_libs_macos_video:
     dependency: "direct main"
@@ -1243,25 +1247,27 @@ packages:
     description:
       path: "libs/windows/media_kit_libs_windows_video"
       ref: HEAD
-      resolved-ref: "65b5e81e8fb37e9039df7a6ef65874b1658e8750"
-      url: "https://github.com/SleepySquash/media-kit.git"
+      resolved-ref: "50c510d018cc5286eb6730f3ea165290f19dc5f6"
+      url: "https://github.com/media-kit/media-kit"
     source: git
     version: "1.0.9"
   media_kit_native_event_loop:
     dependency: "direct main"
     description:
-      name: media_kit_native_event_loop
-      sha256: a605cf185499d14d58935b8784955a92a4bf0ff4e19a23de3d17a9106303930e
-      url: "https://pub.dev"
-    source: hosted
+      path: media_kit_native_event_loop
+      ref: HEAD
+      resolved-ref: "50c510d018cc5286eb6730f3ea165290f19dc5f6"
+      url: "https://github.com/media-kit/media-kit"
+    source: git
     version: "1.0.8"
   media_kit_video:
     dependency: "direct main"
     description:
-      name: media_kit_video
-      sha256: c048d11a19e379aebbe810647636e3fc6d18374637e2ae12def4ff8a4b99a882
-      url: "https://pub.dev"
-    source: hosted
+      path: media_kit_video
+      ref: HEAD
+      resolved-ref: "50c510d018cc5286eb6730f3ea165290f19dc5f6"
+      url: "https://github.com/media-kit/media-kit"
+    source: git
     version: "1.2.4"
   meta:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -157,12 +157,41 @@ dependency_overrides:
       path: packages/image_picker/image_picker_ios
   # TODO: Remove when `medea_jason` updates.
   medea_flutter_webrtc: 0.10.0-dev+rev.56483212e465ddaaee4593a4e4b7cc828e3faeb3
-  # TODO: Remove, when `media_kit` removes `msvcp140` dlls from Windows libs:
-  #       https://github.com/media-kit/media-kit/issues/846
+  # TODO: Remove, when `media_kit` publishes its latest version to pub.dev.
+  media_kit:
+    git:
+      url: https://github.com/media-kit/media-kit
+      path: media_kit
+  # TODO: Remove, when `media_kit` publishes its latest version to pub.dev.
+  media_kit_libs_android_video:
+    git:
+      url: https://github.com/media-kit/media-kit
+      path: libs/android/media_kit_libs_android_video
+  # TODO: Remove, when `media_kit` publishes its latest version to pub.dev.
+  media_kit_libs_ios_video:
+    git:
+      url: https://github.com/media-kit/media-kit
+      path: libs/ios/media_kit_libs_ios_video
+  # TODO: Remove, when `media_kit` publishes its latest version to pub.dev.
+  media_kit_libs_linux:
+    git:
+      url: https://github.com/media-kit/media-kit
+      path: libs/linux/media_kit_libs_linux
+  # TODO: Remove, when `media_kit` publishes its latest version to pub.dev.
+  media_kit_native_event_loop:
+    git:
+      url: https://github.com/media-kit/media-kit
+      path: media_kit_native_event_loop
+  # TODO: Remove, when `media_kit` publishes its latest version to pub.dev.
   media_kit_libs_windows_video:
     git:
-      url: https://github.com/SleepySquash/media-kit.git
+      url: https://github.com/media-kit/media-kit
       path: libs/windows/media_kit_libs_windows_video
+  # TODO: Remove, when `media_kit` publishes its latest version to pub.dev.
+  media_kit_video:
+    git:
+      url: https://github.com/media-kit/media-kit
+      path: media_kit_video
   # TODO: Remove when `medea_jason` updates.
   uuid: ^4.3.3
 


### PR DESCRIPTION
## Synopsis

`media_kit` on pub.dev hasn't been updated in a long time. Some fixes its main branch has are currently blockers for some bugs. E.g. Windows users need to have Microsoft Visual C++ libraries to be installed, which they might not have.




## Solution

This PR pins the `media_kit` to its GitHub version.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
