### PR TITLE
Add `.gitattributes` file to keep LF line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Convert to LF line endings on checkout.
+/linux/flutter/generated_plugin_registrant.cc text eol=lf
+/linux/flutter/generated_plugin_registrant.h text eol=lf
+/linux/flutter/generated_plugins.cmake text eol=lf
+/macos/Flutter/GeneratedPluginRegistrant.swift text eol=lf
+
+# Convert to CRLF line endings on checkout.
+/windows/flutter/generated_plugin_registrant.cc text eol=crlf
+/windows/flutter/generated_plugin_registrant.h text eol=crlf
+/windows/flutter/generated_plugins.cmake text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,8 +3,6 @@ linux/flutter/generated_plugin_registrant.cc text eol=lf
 linux/flutter/generated_plugin_registrant.h text eol=lf
 linux/flutter/generated_plugins.cmake text eol=lf
 macos/Flutter/GeneratedPluginRegistrant.swift text eol=lf
-
-# Convert to CRLF line endings on checkout.
-windows/flutter/generated_plugin_registrant.cc text eol=crlf
-windows/flutter/generated_plugin_registrant.h text eol=crlf
-windows/flutter/generated_plugins.cmake text eol=crlf
+windows/flutter/generated_plugin_registrant.cc text eol=lf
+windows/flutter/generated_plugin_registrant.h text eol=lf
+windows/flutter/generated_plugins.cmake text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 # Convert to LF line endings on checkout.
-linux/flutter/generated_plugin_registrant.cc text eol=lf
-linux/flutter/generated_plugin_registrant.h text eol=lf
-linux/flutter/generated_plugins.cmake text eol=lf
-macos/Flutter/GeneratedPluginRegistrant.swift text eol=lf
-windows/flutter/generated_plugin_registrant.cc text eol=lf
-windows/flutter/generated_plugin_registrant.h text eol=lf
-windows/flutter/generated_plugins.cmake text eol=lf
+/linux/flutter/generated_plugin_registrant.cc text eol=lf
+/linux/flutter/generated_plugin_registrant.h text eol=lf
+/linux/flutter/generated_plugins.cmake text eol=lf
+/macos/Flutter/GeneratedPluginRegistrant.swift text eol=lf
+/windows/flutter/generated_plugin_registrant.cc text eol=lf
+/windows/flutter/generated_plugin_registrant.h text eol=lf
+/windows/flutter/generated_plugins.cmake text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Convert to LF line endings on checkout.
+# Prevent Flutter toolchain from changing line endings on Windows.
 /linux/flutter/generated_plugin_registrant.cc text eol=lf
 /linux/flutter/generated_plugin_registrant.h text eol=lf
 /linux/flutter/generated_plugins.cmake text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,10 @@
 # Convert to LF line endings on checkout.
-/linux/flutter/generated_plugin_registrant.cc text eol=lf
-/linux/flutter/generated_plugin_registrant.h text eol=lf
-/linux/flutter/generated_plugins.cmake text eol=lf
-/macos/Flutter/GeneratedPluginRegistrant.swift text eol=lf
+linux/flutter/generated_plugin_registrant.cc text eol=lf
+linux/flutter/generated_plugin_registrant.h text eol=lf
+linux/flutter/generated_plugins.cmake text eol=lf
+macos/Flutter/GeneratedPluginRegistrant.swift text eol=lf
 
 # Convert to CRLF line endings on checkout.
-/windows/flutter/generated_plugin_registrant.cc text eol=crlf
-/windows/flutter/generated_plugin_registrant.h text eol=crlf
-/windows/flutter/generated_plugins.cmake text eol=crlf
+windows/flutter/generated_plugin_registrant.cc text eol=crlf
+windows/flutter/generated_plugin_registrant.h text eol=crlf
+windows/flutter/generated_plugins.cmake text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,9 @@ jobs:
           cache: true
 
       - run: git describe --tags --dirty --abbrev=0
+      - name: Set Git to replace CRLF with LF symbols automatically
+        run: git config --global core.autocrlf input
+        if: ${{ matrix.platform == 'windows' }}
       - run: make flutter.pub
       - run: git describe --tags --dirty --abbrev=0
       - run: git diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,12 +307,6 @@ jobs:
         uses: juliangruber/read-file-action@v1
         with:
           path: ./lib/pubspec.g.dart
-      # - name: Parse semver versions from Git tag
-      #   id: semver
-      #   uses: actions-ecosystem/action-regex-match@v2
-      #   with:
-      #     text: ${{ steps.pubspec.outputs.content }}
-      #     regex: 'ref = .*-dirty.*'
       - name: Ensure no `-dirty` part is present in resulted version.
         run: ${{ contains(steps.pubspec.outputs.content, '-dirty') && 'exit 1'
               || 'exit 0' }}
@@ -550,6 +544,15 @@ jobs:
                             SOCAPP_LINK_PREFIX=${{ startsWith(github.ref, 'refs/tags/v') && secrets.LINK_STABLE || secrets.LINK_MAIN }}
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}
                             SOCAPP_USER_AGENT_VERSION=${{ steps.semver.outputs.group1 }}'
+
+      - name: Read `pubspec.g.dart`
+        id: pubspec
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./lib/pubspec.g.dart
+      - name: Ensure no `-dirty` part is present in resulted version.
+        run: ${{ contains(steps.pubspec.outputs.content, '-dirty') && 'exit 1'
+              || 'exit 0' }}
 
       - name: Parse application name from Git repository name
         id: app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       # `git describe` command returns the valid result without possible
       # `-dirty` part, that may happen during FCM configuration.
       - run: make flutter.gen overwrite=true
-        if: ${{ contains('apk appbundle ipa web', matrix.platform) }}
+        if: ${{ contains('apk appbundle ipa web windows', matrix.platform) }}
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,9 @@ jobs:
               || (matrix.platform == 'windows'           && 'windows-latest')
               ||                                            'ubuntu-latest' }}
     steps:
-      - name: Set Git to replace CRLF with LF symbols automatically
-        run: git config --global core.autocrlf true
-        if: ${{ matrix.platform == 'windows' }}
+      # - name: Set Git to replace CRLF with LF symbols automatically
+      #   run: git config --global core.autocrlf true
+      #   if: ${{ matrix.platform == 'windows' }}
 
       - uses: actions/checkout@v4
         with:
@@ -188,10 +188,12 @@ jobs:
           channel: stable
           cache: true
 
+      - run: git status
       - run: git describe --tags --dirty --abbrev=0
       - run: make flutter.pub
       - run: git describe --tags --dirty --abbrev=0
       - run: git diff
+      - run: git status
 
       # Running `build_runner` here ensures `PubspecBuilder` and its
       # `git describe` command returns the valid result without possible

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,8 @@ jobs:
 
       - run: make flutter.pub
 
+      - run: git diff
+
       # Running `build_runner` here ensures `PubspecBuilder` and its
       # `git describe` command returns the valid result without possible
       # `-dirty` part, that may happen during FCM configuration.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
 
       - run: git describe --tags --dirty --abbrev=0
       - name: Set Git to replace CRLF with LF symbols automatically
-        run: git config --global core.autocrlf input
+        run: git config --global core.autocrlf true
         if: ${{ matrix.platform == 'windows' }}
       - run: make flutter.pub
       - run: git describe --tags --dirty --abbrev=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,17 +235,20 @@ jobs:
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}'
         if: ${{ matrix.platform == 'web' }}
 
+      - name: Read `pubspec.g.dart`
+        id: pubspec
+        uses: jaywcjlove/github-action-read-file@main
+        with:
+          path: lib/pubspec.g.dart
+      # - name: Parse semver versions from Git tag
+      #   id: semver
+      #   uses: actions-ecosystem/action-regex-match@v2
+      #   with:
+      #     text: ${{ steps.pubspec.outputs.content }}
+      #     regex: 'ref = .*-dirty.*'
       - name: Ensure no `-dirty` part is present in resulted version.
-        run: findstr "ref =" pubspec.g.dart | select-string "-dirty" | %{throw "Error"}
-        if: ${{ matrix.platform == 'windows' }}
-      - name: Ensure no `-dirty` part is present in resulted version.
-        run: |
-          test "" \
-            == "$(grep -m1 'ref = ' lib/pubspec.g.dart \
-                  | cut -d"'" -f2 \
-                  | grep 'dirty' \
-                  | { grep -v grep || true; })"
-        if: ${{ matrix.platform != 'windows' }}
+        run: ${{ contains(steps.pubspec.outputs.content, '-dirty') && 'exit 1'
+              || 'exit 0' }}
 
       - name: Prepare Android signing resources
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,21 +235,6 @@ jobs:
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}'
         if: ${{ matrix.platform == 'web' }}
 
-      - name: Read `pubspec.g.dart`
-        id: pubspec
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ./lib/pubspec.g.dart
-      # - name: Parse semver versions from Git tag
-      #   id: semver
-      #   uses: actions-ecosystem/action-regex-match@v2
-      #   with:
-      #     text: ${{ steps.pubspec.outputs.content }}
-      #     regex: 'ref = .*-dirty.*'
-      - name: Ensure no `-dirty` part is present in resulted version.
-        run: ${{ contains(steps.pubspec.outputs.content, '-dirty') && 'exit 1'
-              || 'exit 0' }}
-
       - name: Prepare Android signing resources
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE }}" | base64 -d \
@@ -316,6 +301,21 @@ jobs:
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}
                             SOCAPP_USER_AGENT_VERSION=${{ steps.semver.outputs.group1 }}'
         if: ${{ matrix.platform != 'web' }}
+
+      - name: Read `pubspec.g.dart`
+        id: pubspec
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./lib/pubspec.g.dart
+      # - name: Parse semver versions from Git tag
+      #   id: semver
+      #   uses: actions-ecosystem/action-regex-match@v2
+      #   with:
+      #     text: ${{ steps.pubspec.outputs.content }}
+      #     regex: 'ref = .*-dirty.*'
+      - name: Ensure no `-dirty` part is present in resulted version.
+        run: ${{ contains(steps.pubspec.outputs.content, '-dirty') && 'exit 1'
+              || 'exit 0' }}
 
       - name: Codesign macOS application
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,10 +173,6 @@ jobs:
               || (matrix.platform == 'windows'           && 'windows-latest')
               ||                                            'ubuntu-latest' }}
     steps:
-      # - name: Set Git to replace CRLF with LF symbols automatically
-      #   run: git config --global core.autocrlf true
-      #   if: ${{ matrix.platform == 'windows' }}
-
       - uses: actions/checkout@v4
         with:
           # Unshallow the repository in order for `PubspecBuilder` and its
@@ -188,20 +184,13 @@ jobs:
           channel: stable
           cache: true
 
-      - run: git status
-      - run: git describe --tags --dirty --abbrev=0
       - run: make flutter.pub
-      - run: git describe --tags --dirty --abbrev=0
-      - run: git diff
-      - run: git status
 
       # Running `build_runner` here ensures `PubspecBuilder` and its
       # `git describe` command returns the valid result without possible
       # `-dirty` part, that may happen during FCM configuration.
       - run: make flutter.gen overwrite=true
-        if: ${{ contains('apk appbundle ipa web windows', matrix.platform) }}
-
-      - run: git describe --tags --dirty --abbrev=0
+        if: ${{ contains('apk appbundle ipa web', matrix.platform) }}
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,14 +302,15 @@ jobs:
                             SOCAPP_USER_AGENT_VERSION=${{ steps.semver.outputs.group1 }}'
         if: ${{ matrix.platform != 'web' }}
 
-      - name: Read `pubspec.g.dart`
+      - name: Read generated `pubspec.g.dart`
         id: pubspec
         uses: juliangruber/read-file-action@v1
         with:
-          path: ./lib/pubspec.g.dart
-      - name: Ensure no `-dirty` part is present in resulted version.
-        run: ${{ contains(steps.pubspec.outputs.content, '-dirty') && 'exit 1'
-              || 'exit 0' }}
+          path: lib/pubspec.g.dart
+      - name: Ensure no `-dirty` in `pubspec.g.dart` version
+        run: ${{ contains(steps.pubspec.outputs.content, '-dirty')
+                 && 'exit 1'
+                 || 'exit 0' }}
 
       - name: Codesign macOS application
         run: |
@@ -545,14 +546,15 @@ jobs:
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}
                             SOCAPP_USER_AGENT_VERSION=${{ steps.semver.outputs.group1 }}'
 
-      - name: Read `pubspec.g.dart`
+      - name: Read generated `pubspec.g.dart`
         id: pubspec
         uses: juliangruber/read-file-action@v1
         with:
-          path: ./lib/pubspec.g.dart
-      - name: Ensure no `-dirty` part is present in resulted version.
-        run: ${{ contains(steps.pubspec.outputs.content, '-dirty') && 'exit 1'
-              || 'exit 0' }}
+          path: lib/pubspec.g.dart
+      - name: Ensure no `-dirty` in `pubspec.g.dart` version
+        run: ${{ contains(steps.pubspec.outputs.content, '-dirty')
+                 && 'exit 1'
+                 || 'exit 0' }}
 
       - name: Parse application name from Git repository name
         id: app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,9 +237,9 @@ jobs:
 
       - name: Read `pubspec.g.dart`
         id: pubspec
-        uses: jaywcjlove/github-action-read-file@main
+        uses: juliangruber/read-file-action@v1
         with:
-          path: lib/pubspec.g.dart
+          path: ./lib/pubspec.g.dart
       # - name: Parse semver versions from Git tag
       #   id: semver
       #   uses: actions-ecosystem/action-regex-match@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,10 @@ jobs:
               || (matrix.platform == 'windows'           && 'windows-latest')
               ||                                            'ubuntu-latest' }}
     steps:
+      - name: Set Git to replace CRLF with LF symbols automatically
+        run: git config --global core.autocrlf true
+        if: ${{ matrix.platform == 'windows' }}
+
       - uses: actions/checkout@v4
         with:
           # Unshallow the repository in order for `PubspecBuilder` and its
@@ -185,9 +189,6 @@ jobs:
           cache: true
 
       - run: git describe --tags --dirty --abbrev=0
-      - name: Set Git to replace CRLF with LF symbols automatically
-        run: git config --global core.autocrlf false
-        if: ${{ matrix.platform == 'windows' }}
       - run: make flutter.pub
       - run: git describe --tags --dirty --abbrev=0
       - run: git diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,8 +184,9 @@ jobs:
           channel: stable
           cache: true
 
+      - run: git describe --tags --dirty --abbrev=0
       - run: make flutter.pub
-
+      - run: git describe --tags --dirty --abbrev=0
       - run: git diff
 
       # Running `build_runner` here ensures `PubspecBuilder` and its
@@ -193,6 +194,8 @@ jobs:
       # `-dirty` part, that may happen during FCM configuration.
       - run: make flutter.gen overwrite=true
         if: ${{ contains('apk appbundle ipa web windows', matrix.platform) }}
+
+      - run: git describe --tags --dirty --abbrev=0
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
 
       - run: git describe --tags --dirty --abbrev=0
       - name: Set Git to replace CRLF with LF symbols automatically
-        run: git config --global core.autocrlf true
+        run: git config --global core.autocrlf false
         if: ${{ matrix.platform == 'windows' }}
       - run: make flutter.pub
       - run: git describe --tags --dirty --abbrev=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,18 @@ jobs:
                             SOCAPP_SENTRY_DSN=${{ startsWith(github.ref, 'refs/tags/v') && secrets.SENTRY_DSN_STABLE || secrets.SENTRY_DSN_MAIN }}'
         if: ${{ matrix.platform == 'web' }}
 
+      - name: Ensure no `-dirty` part is present in resulted version.
+        run: findstr "ref =" pubspec.g.dart | select-string "-dirty" | %{throw "Error"}
+        if: ${{ matrix.platform == 'windows' }}
+      - name: Ensure no `-dirty` part is present in resulted version.
+        run: |
+          test "" \
+            == "$(grep -m1 'ref = ' lib/pubspec.g.dart \
+                  | cut -d"'" -f2 \
+                  | grep 'dirty' \
+                  | { grep -v grep || true; })"
+        if: ${{ matrix.platform != 'windows' }}
+
       - name: Prepare Android signing resources
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE }}" | base64 -d \

--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -77,6 +77,9 @@ class PubspecBuilder implements Builder {
       }
 
       buffer.write('  static const String ref = \'$ref+$count\';\n');
+
+      // ignore: avoid_print
+      print('[PubspecBuilder] `Pubspec.ref` field is set to be `$ref+$count`.');
     } else {
       throw Exception(
         '[PubspecBuilder] Unable to properly generate `pubspec.g.dart` summary: `git` executable exited with code ${git.exitCode}, \nstdout: ${git.stdout}\nstderr: ${git.stderr}',

--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -76,11 +76,10 @@ class PubspecBuilder implements Builder {
         count = count.substring(0, count.length - 1);
       }
 
-      buffer.write('  static const String ref = \'$ref-dirty+$count\';\n');
+      buffer.write('  static const String ref = \'$ref+$count\';\n');
 
       // ignore: avoid_print
-      print(
-          '[PubspecBuilder] `Pubspec.ref` field is set to be `$ref-dirty+$count`.');
+      print('[PubspecBuilder] `Pubspec.ref` field is set to be `$ref+$count`.');
     } else {
       throw Exception(
         '[PubspecBuilder] Unable to properly generate `pubspec.g.dart` summary: `git` executable exited with code ${git.exitCode}, \nstdout: ${git.stdout}\nstderr: ${git.stderr}',

--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -76,10 +76,11 @@ class PubspecBuilder implements Builder {
         count = count.substring(0, count.length - 1);
       }
 
-      buffer.write('  static const String ref = \'$ref+$count\';\n');
+      buffer.write('  static const String ref = \'$ref-dirty+$count\';\n');
 
       // ignore: avoid_print
-      print('[PubspecBuilder] `Pubspec.ref` field is set to be `$ref+$count`.');
+      print(
+          '[PubspecBuilder] `Pubspec.ref` field is set to be `$ref-dirty+$count`.');
     } else {
       throw Exception(
         '[PubspecBuilder] Unable to properly generate `pubspec.g.dart` summary: `git` executable exited with code ${git.exitCode}, \nstdout: ${git.stdout}\nstderr: ${git.stderr}',

--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -52,8 +52,6 @@ class PubspecBuilder implements Builder {
       '  static const String version = \'${pubspec['version']}\';\n',
     );
 
-    print((await Process.run('git', ['diff'])).stdout);
-
     final ProcessResult git = await Process.run(
       'git',
       ['describe', '--tags', '--abbrev=0', '--dirty', '--match', 'v*'],
@@ -77,8 +75,6 @@ class PubspecBuilder implements Builder {
       if (count.endsWith('\n')) {
         count = count.substring(0, count.length - 1);
       }
-
-      print('========== git resulted in `$ref` output ==========');
 
       buffer.write('  static const String ref = \'$ref+$count\';\n');
     } else {

--- a/lib/util/pubspec_builder.dart
+++ b/lib/util/pubspec_builder.dart
@@ -52,6 +52,8 @@ class PubspecBuilder implements Builder {
       '  static const String version = \'${pubspec['version']}\';\n',
     );
 
+    print((await Process.run('git', ['diff'])).stdout);
+
     final ProcessResult git = await Process.run(
       'git',
       ['describe', '--tags', '--abbrev=0', '--dirty', '--match', 'v*'],
@@ -75,6 +77,8 @@ class PubspecBuilder implements Builder {
       if (count.endsWith('\n')) {
         count = count.substring(0, count.length - 1);
       }
+
+      print('========== git resulted in `$ref` output ==========');
 
       buffer.write('  static const String ref = \'$ref+$count\';\n');
     } else {


### PR DESCRIPTION
## Synopsis

On Windows `-dirty` is added to the version generated in `build` CI job:

```
flutter: 2024-07-29 07:16:34.000303 INFO: [UpgradeWorker] Whether `0.1.4-dirty+539` is lower than `0.1.4+539`: true
flutter: 2024-07-29 07:16:34.000303 INFO: [UpgradeWorker] Whether `0.1.4-dirty+539` is considered critical relative to `0.1.4+539`: true
```




## Solution

This PR runs `flutter.gen` command for Windows as well before FCM configuration.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
