### PR TITLE
Replace `docker-compose` with `docker compose` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ docker-tags = $(strip $(if $(call eq,$(tags),),\
 #	make docker.down
 
 docker.down:
-	-docker-compose down --rmi=local -v
+	-docker compose down --rmi=local -v
 
 
 # Build project Docker image.
@@ -598,7 +598,7 @@ docker.untar:
 
 docker.up: docker.down
 ifeq ($(pull),yes)
-	docker-compose pull --parallel --ignore-pull-failures
+	docker compose pull --parallel --ignore-pull-failures
 endif
 ifeq ($(no-cache),yes)
 	rm -rf .cache/baza/ .cache/cockroachdb/
@@ -617,11 +617,11 @@ ifeq ($(rebuild),yes)
 	@make flutter.build platform=web dart-env='$(dart-env)' \
 	                    dockerized=$(dockerized)
 endif
-	docker-compose up \
+	docker compose up \
 		$(if $(call eq,$(background),yes),-d,--abort-on-container-exit)
 ifeq ($(background),yes)
 ifeq ($(log),yes)
-	docker-compose logs -f
+	docker compose logs -f
 endif
 endif
 


### PR DESCRIPTION
## Synopsis

E2E tests fail due to `docker-compose` not being recognized.

```
docker-compose down --rmi=local -v
make[1]: docker-compose: No such file or directory
make[1]: [Makefile:487: docker.down] Error 127 (ignored)
make[1]: docker-compose: No such file or directory
make[1]: *** [Makefile:601: docker.up] Error 127
docker-compose pull --parallel --ignore-pull-failures
make[1]: Leaving directory '/home/runner/work/messenger/messenger'
make: *** [Makefile:284: test.e2e] Error 2
```

This is reproducible on the latest Docker Desktop as well locally.





## Solution

The latest Ubuntu runner has dropped the `docker-compose` command completely: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2

Latest successful E2E tests run:
```
  Image: ubuntu-22.04
  Version: 20240721.1.0
  Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20240721.1/images/ubuntu/Ubuntu2204-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240721.1
```

The run on the main:
```
  Image: ubuntu-22.04
  Version: 20240730.2.0
  Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20240730.2/images/ubuntu/Ubuntu2204-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2
```

This PR replaces `docker-compose` with `docker compose`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
