### PR TITLE
Force `AccountDriftProvider.read()` to always read from `drift` instead of relying on cache (#987)

### DIFF
--- a/lib/domain/repository/my_user.dart
+++ b/lib/domain/repository/my_user.dart
@@ -47,9 +47,6 @@ abstract class AbstractMyUserRepository {
     required Function() onPasswordUpdated,
   });
 
-  /// Disposes the repository.
-  void dispose();
-
   /// Updates [MyUser.name] field for the authenticated [MyUser].
   ///
   /// Resets [MyUser.name] field to `null` for the authenticated [MyUser] if

--- a/lib/domain/service/my_user.dart
+++ b/lib/domain/service/my_user.dart
@@ -66,14 +66,6 @@ class MyUserService extends DisposableService {
     super.onInit();
   }
 
-  @override
-  void onClose() {
-    Log.debug('onClose()', '$runtimeType');
-
-    _userRepo.dispose();
-    super.onClose();
-  }
-
   /// Updates [MyUser.name] field for the authenticated [MyUser].
   ///
   /// If [name] is `null`, then resets [MyUser.name] field.

--- a/lib/provider/drift/account.dart
+++ b/lib/provider/drift/account.dart
@@ -86,14 +86,12 @@ class AccountDriftProvider extends DriftProviderBase {
 
   /// Returns the currently active [UserId] account stored in the database.
   Future<UserId?> read() async {
-    if (_userId != null) {
-      return _userId;
-    }
-
     return await safe<UserId?>((db) async {
       final stmt = db.select(db.accounts)..where((e) => e.id.equals(0));
       final AccountRow? row = await stmt.getSingleOrNull();
-      return row == null ? null : UserId(row.userId);
+      _userId = row == null ? null : UserId(row.userId);
+
+      return _userId;
     }, tag: 'account.read()');
   }
 

--- a/lib/ui/page/auth/controller.dart
+++ b/lib/ui/page/auth/controller.dart
@@ -58,6 +58,10 @@ class AuthController extends GetxController {
     autoFinishAfter: const Duration(minutes: 2),
   )..startChild('ready');
 
+  /// [profiles] subscription to set [screen] to [AuthScreen.signIn] when
+  /// [profiles] become empty.
+  StreamSubscription? _accountsSubscription;
+
   /// Returns user authentication status.
   Rx<RxStatus> get authStatus => _auth.status;
 
@@ -70,12 +74,20 @@ class AuthController extends GetxController {
   @override
   void onReady() {
     SchedulerBinding.instance.addPostFrameCallback((_) => _ready.finish());
+
+    _accountsSubscription = profiles.listen((accounts) {
+      if (accounts.isEmpty) {
+        screen.value = AuthScreen.signIn;
+      }
+    });
+
     super.onReady();
   }
 
   @override
   void onClose() {
     _animationTimer?.cancel();
+    _accountsSubscription?.cancel();
     super.onClose();
   }
 

--- a/test/unit/chat_hide_test.dart
+++ b/test/unit/chat_hide_test.dart
@@ -332,5 +332,13 @@ void main() async {
     );
   });
 
-  tearDown(() async => await Future.wait([common.close(), scoped.close()]));
+  tearDown(() async {
+    await Future.wait(
+      [
+        Get.delete(),
+        common.close(),
+        scoped.close(),
+      ],
+    );
+  });
 }

--- a/test/widget/chat_hide_test.dart
+++ b/test/widget/chat_hide_test.dart
@@ -24,8 +24,10 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/user.dart';
+import 'package:messenger/domain/repository/call.dart';
 import 'package:messenger/domain/repository/chat.dart';
 import 'package:messenger/domain/repository/contact.dart';
+import 'package:messenger/domain/repository/my_user.dart';
 import 'package:messenger/domain/repository/settings.dart';
 import 'package:messenger/domain/service/auth.dart';
 import 'package:messenger/domain/service/call.dart';
@@ -312,16 +314,18 @@ void main() async {
       ),
     );
 
-    MyUserRepository myUserRepository = MyUserRepository(
-      graphQlProvider,
-      myUserProvider,
-      blocklistRepository,
-      userRepository,
-      accountProvider,
+    final myUserRepository = Get.put<AbstractMyUserRepository>(
+      MyUserRepository(
+        graphQlProvider,
+        myUserProvider,
+        blocklistRepository,
+        userRepository,
+        accountProvider,
+      ),
     );
     Get.put(MyUserService(authService, myUserRepository));
 
-    AbstractSettingsRepository settingsRepository = Get.put(
+    final settingsRepository = Get.put<AbstractSettingsRepository>(
       SettingsRepository(
         const UserId('me'),
         settingsProvider,
@@ -330,13 +334,15 @@ void main() async {
       ),
     );
 
-    final callRepository = CallRepository(
-      graphQlProvider,
-      userRepository,
-      callCredentialsProvider,
-      chatCredentialsProvider,
-      settingsRepository,
-      me: const UserId('me'),
+    final callRepository = Get.put<AbstractCallRepository>(
+      CallRepository(
+        graphQlProvider,
+        userRepository,
+        callCredentialsProvider,
+        chatCredentialsProvider,
+        settingsRepository,
+        me: const UserId('me'),
+      ),
     );
     AbstractChatRepository chatRepository = Get.put<AbstractChatRepository>(
       ChatRepository(


### PR DESCRIPTION
Resolves #987




## Synopsis

> `??` is displayed in places where `MyUser`s data should be displayed.




## Solution

1. Always read the actual `UserId` stored in the database.
2. Put both the `Credentials` and `UserId` in a transaction to database, to it's always has a `UserId` when queried.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
