### PR TITLE
Add `UserPassword` confirmation to `MyUser` deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Support page:
         - Current version information. ([#1079], [#896])
+    - Profile page:
+        - Credentials confirmation of account deletion. ([#1086])
 
 ### Changed
 
@@ -46,6 +48,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1070]: /../../pull/1070
 [#1078]: /../../pull/1078
 [#1079]: /../../pull/1079
+[#1086]: /../../pull/1086
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -530,6 +530,7 @@ label_add_chat_member = Add member
 label_add_email = Add E-mail
 label_add_email_confirmation_sent = A confirmation code has been sent to the indicated email. The confirmation code is valid for 30 minutes. Please enter it below.
 label_add_email_confirmation_sent_again = A confirmation code has been sent again to the indicated email. The confirmation code is valid for 30 minutes. Please enter it below.
+label_add_email_confirmation_sent_to = A confirmation code has been sent to the {$email}. The confirmation code is valid for 30 minutes. Please enter it below.
 label_add_email_description = A confirmation code will be sent to the indicated E-mail.
 label_add_email_hint = Write your email address
 label_add_number = Add phone
@@ -673,6 +674,7 @@ label_conditions_ui_ux_designer =
     - 4-, 6- or 8-hour work day;
     - Relocation possible to one of the company offices.
 label_confirm = Confirm
+label_confirm_account_deletion = Confirm account deletion
 label_confirmation_code = Confirmation code
 label_connection_lost = Connection lost
 label_connection_restored = Connection restored
@@ -752,6 +754,7 @@ label_enabled = Enabled
 label_end_session = End session
 label_enter_confirmation_code = Confirmation code
 label_enter_confirmation_code_hint = Enter confirmation code
+label_enter_password_below = Please, enter your password in the field below.
 label_entrance = Login
 label_error = Error
 label_favorite_contacts = Favorite

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -541,6 +541,7 @@ label_add_chat_member = Добавление участника
 label_add_email = Добавить E-mail
 label_add_email_confirmation_sent = На указанный Вами E-mail был отправлен код подтверждения. Код подтверждения действителен в течение 30 минут. Пожалуйста, введите его ниже.
 label_add_email_confirmation_sent_again = На указанный Вами E-mail повторно отправлен код подтверждения. Код подтверждения действителен в течение 30 минут. Пожалуйста, введите его ниже.
+label_add_email_confirmation_sent_to = На {$email} был отправлен код подтверждения. Код подтверждения действителен в течение 30 минут. Пожалуйста, введите его ниже.
 label_add_email_description = На указанный Вами E-mail будет отправлен код подтверждения.
 label_add_email_hint = Напишите адрес Вашей почты
 label_add_number = Добавить телефон
@@ -697,6 +698,7 @@ label_conditions_ui_ux_designer =
     - 4-х, 6-ти или 8-ми часовой рабочий день;
     - учёт рабочего времени и оплата переработок.
 label_confirm = Подтвердить
+label_confirm_account_deletion = Подтверждение удаления аккаунта
 label_confirmation_code = Код подтверждения
 label_connection_lost = Связь с сервером потеряна
 label_connection_restored = Связь восстановлена
@@ -777,6 +779,7 @@ label_enabled = Включены
 label_end_session = Завершить сессию
 label_enter_confirmation_code = Проверочный код
 label_enter_confirmation_code_hint = Введите проверочный код
+label_enter_password_below = Пожалуйста, введите Ваш пароль в поле ниже.
 label_entrance = Вход
 label_error = Ошибка
 label_favorite_contacts = Избранные

--- a/lib/store/my_user.dart
+++ b/lib/store/my_user.dart
@@ -133,7 +133,7 @@ class MyUserRepository extends DisposableInterface
     this.onPasswordUpdated = onPasswordUpdated;
     this.onUserDeleted = onUserDeleted;
 
-    _active.then((v) => myUser.value = v?.value ?? myUser.value);
+    _active.then((v) => myUser.value = (v?.value ?? myUser.value));
 
     _initProfiles();
     _initLocalSubscription();

--- a/lib/store/my_user.dart
+++ b/lib/store/my_user.dart
@@ -133,7 +133,7 @@ class MyUserRepository extends DisposableInterface
     this.onPasswordUpdated = onPasswordUpdated;
     this.onUserDeleted = onUserDeleted;
 
-    _active.then((v) => myUser.value = (v?.value ?? myUser.value));
+    _active.then((v) => myUser.value = v?.value ?? myUser.value);
 
     _initProfiles();
     _initLocalSubscription();

--- a/lib/ui/page/erase/confirm_delete/controller.dart
+++ b/lib/ui/page/erase/confirm_delete/controller.dart
@@ -1,0 +1,16 @@
+import 'package:get/get.dart';
+
+import '/domain/model/my_user.dart';
+import '/domain/service/my_user.dart';
+
+enum ConfirmDeleteScreen { password, email }
+
+class ConfirmDeleteController extends GetxController {
+  ConfirmDeleteController(this._myUserService);
+
+  final Rx<ConfirmDeleteScreen> screen = Rx(ConfirmDeleteScreen.email);
+
+  final MyUserService _myUserService;
+
+  Rx<MyUser?> get myUser => _myUserService.myUser;
+}

--- a/lib/ui/page/erase/confirm_delete/controller.dart
+++ b/lib/ui/page/erase/confirm_delete/controller.dart
@@ -1,16 +1,66 @@
 import 'package:get/get.dart';
 
 import '/domain/model/my_user.dart';
+import '/domain/model/user.dart';
+import '/domain/service/auth.dart';
 import '/domain/service/my_user.dart';
-
-enum ConfirmDeleteScreen { password, email }
+import '/l10n/l10n.dart';
+import '/provider/gql/exceptions.dart' show DeleteMyUserException;
+import '/ui/widget/text_field.dart';
 
 class ConfirmDeleteController extends GetxController {
-  ConfirmDeleteController(this._myUserService);
+  ConfirmDeleteController(this._myUserService, this._authService);
 
-  final Rx<ConfirmDeleteScreen> screen = Rx(ConfirmDeleteScreen.email);
+  late final TextFieldState code = TextFieldState(
+    onChanged: (_) {
+      code.error.value = null;
+      password.error.value = null;
+    },
+  );
 
+  late final TextFieldState password = TextFieldState(
+    onChanged: (_) {
+      code.error.value = null;
+      password.error.value = null;
+    },
+  );
+
+  /// Indicator whether the [password] should be obscured.
+  final RxBool obscurePassword = RxBool(true);
+
+  final AuthService _authService;
   final MyUserService _myUserService;
 
   Rx<MyUser?> get myUser => _myUserService.myUser;
+
+  @override
+  void onInit() {
+    if (myUser.value?.emails.confirmed.isNotEmpty == true) {
+      sendConfirmationCode();
+    }
+
+    super.onInit();
+  }
+
+  Future<void> sendConfirmationCode() async {
+    await _authService.createConfirmationCode();
+  }
+
+  Future<void> deleteAccount() async {
+    code.error.value = null;
+    password.error.value = null;
+
+    try {
+      await _myUserService.deleteMyUser(
+        confirmation: code.text.isNotEmpty ? ConfirmationCode(code.text) : null,
+        password: password.text.isNotEmpty ? UserPassword(password.text) : null,
+      );
+    } on DeleteMyUserException catch (e) {
+      code.error.value = e.toMessage();
+      password.error.value = e.toMessage();
+    } catch (e) {
+      code.error.value = 'err_data_transfer'.l10n;
+      password.error.value = 'err_data_transfer'.l10n;
+    }
+  }
 }

--- a/lib/ui/page/erase/confirm_delete/controller.dart
+++ b/lib/ui/page/erase/confirm_delete/controller.dart
@@ -1,3 +1,20 @@
+// Copyright © 2022-2024 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
 import 'dart:async';
 
 import 'package:get/get.dart';

--- a/lib/ui/page/erase/confirm_delete/view.dart
+++ b/lib/ui/page/erase/confirm_delete/view.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+import '/l10n/l10n.dart';
+import '/themes.dart';
 import '/ui/widget/modal_popup.dart';
+import '/ui/widget/primary_button.dart';
+import '/ui/widget/svg/svg.dart';
+import '/ui/widget/text_field.dart';
 import 'controller.dart';
 
 class ConfirmDeleteView extends StatelessWidget {
@@ -14,20 +19,75 @@ class ConfirmDeleteView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final style = Theme.of(context).style;
+
     return GetBuilder(
-      init: ConfirmDeleteController(Get.find()),
+      key: const Key('ConfirmAccountDeletion'),
+      init: ConfirmDeleteController(Get.find(), Get.find()),
       builder: (ConfirmDeleteController c) {
         return Obx(() {
           final List<Widget> children = [];
 
-          if (c.myUser.value?.emails.confirmed.isNotEmpty == true) {}
+          if (c.myUser.value?.emails.confirmed.isNotEmpty == true) {
+            children.addAll([
+              Text(
+                'label_add_email_confirmation_sent_to'.l10nfmt(
+                  {'email': '${c.myUser.value?.emails.confirmed.firstOrNull}'},
+                ),
+                style: style.fonts.small.regular.secondary,
+              ),
+              ReactiveTextField(state: c.code),
+              PrimaryButton(
+                key: const Key('Proceed'),
+                onPressed: c.deleteAccount,
+                title: 'btn_proceed'.l10n,
+              ),
+            ]);
+          } else if (c.myUser.value?.hasPassword == true) {
+            children.addAll([
+              const SizedBox(height: 12),
+              Text(
+                'label_enter_password_below'.l10n,
+                style: style.fonts.normal.regular.secondary,
+              ),
+              const SizedBox(height: 12),
+              Obx(() {
+                return ReactiveTextField(
+                  key: const Key('PasswordField'),
+                  state: c.password,
+                  obscure: c.obscurePassword.value,
+                  onSuffixPressed: c.obscurePassword.toggle,
+                  treatErrorAsStatus: false,
+                  trailing: SvgIcon(
+                    c.obscurePassword.value
+                        ? SvgIcons.visibleOff
+                        : SvgIcons.visibleOn,
+                  ),
+                  hint: 'label_password'.l10n,
+                );
+              }),
+              const SizedBox(height: 25),
+              Obx(() {
+                final bool enabled =
+                    !c.password.isEmpty.value && c.password.error.value == null;
+
+                return PrimaryButton(
+                  key: const Key('Proceed'),
+                  onPressed: enabled ? c.deleteAccount : null,
+                  title: 'btn_proceed'.l10n,
+                );
+              }),
+              const SizedBox(height: 16),
+            ]);
+          }
 
           return Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              ModalPopupHeader(text: ''),
+              ModalPopupHeader(text: 'label_confirm_account_deletion'.l10n),
               Flexible(
                 child: ListView(
+                  padding: ModalPopup.padding(context),
                   shrinkWrap: true,
                   children: children,
                 ),

--- a/lib/ui/page/erase/confirm_delete/view.dart
+++ b/lib/ui/page/erase/confirm_delete/view.dart
@@ -7,8 +7,10 @@ import '/ui/widget/modal_popup.dart';
 import '/ui/widget/primary_button.dart';
 import '/ui/widget/svg/svg.dart';
 import '/ui/widget/text_field.dart';
+import '/ui/widget/widget_button.dart';
 import 'controller.dart';
 
+/// View of the [MyUser] deletion confirmation.
 class ConfirmDeleteView extends StatelessWidget {
   const ConfirmDeleteView({super.key});
 
@@ -30,18 +32,50 @@ class ConfirmDeleteView extends StatelessWidget {
 
           if (c.myUser.value?.emails.confirmed.isNotEmpty == true) {
             children.addAll([
+              const SizedBox(height: 12),
               Text(
                 'label_add_email_confirmation_sent_to'.l10nfmt(
                   {'email': '${c.myUser.value?.emails.confirmed.firstOrNull}'},
                 ),
-                style: style.fonts.small.regular.secondary,
+                style: style.fonts.normal.regular.onBackground,
               ),
-              ReactiveTextField(state: c.code),
+              const SizedBox(height: 16),
+              Obx(() {
+                return Text(
+                  c.resendEmailTimeout.value == 0
+                      ? 'label_did_not_receive_code'.l10n
+                      : 'label_code_sent_again'.l10n,
+                  style: style.fonts.normal.regular.onBackground,
+                );
+              }),
+              Obx(() {
+                final bool enabled = c.resendEmailTimeout.value == 0;
+
+                return WidgetButton(
+                  onPressed: enabled ? c.sendConfirmationCode : null,
+                  child: Text(
+                    enabled
+                        ? 'btn_resend_code'.l10n
+                        : 'label_wait_seconds'
+                            .l10nfmt({'for': c.resendEmailTimeout.value}),
+                    style: enabled
+                        ? style.fonts.normal.regular.primary
+                        : style.fonts.normal.regular.onBackground,
+                  ),
+                );
+              }),
+              const SizedBox(height: 16),
+              ReactiveTextField(
+                state: c.code,
+                hint: 'label_confirmation_code'.l10n,
+              ),
+              const SizedBox(height: 25),
               PrimaryButton(
                 key: const Key('Proceed'),
                 onPressed: c.deleteAccount,
                 title: 'btn_proceed'.l10n,
               ),
+              const SizedBox(height: 16),
             ]);
           } else if (c.myUser.value?.hasPassword == true) {
             children.addAll([

--- a/lib/ui/page/erase/confirm_delete/view.dart
+++ b/lib/ui/page/erase/confirm_delete/view.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '/ui/widget/modal_popup.dart';
+import 'controller.dart';
+
+class ConfirmDeleteView extends StatelessWidget {
+  const ConfirmDeleteView({super.key});
+
+  /// Displays a [ConfirmDeleteView] wrapped in a [ModalPopup].
+  static Future<T?> show<T>(BuildContext context) {
+    return ModalPopup.show(context: context, child: const ConfirmDeleteView());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GetBuilder(
+      init: ConfirmDeleteController(Get.find()),
+      builder: (ConfirmDeleteController c) {
+        return Obx(() {
+          final List<Widget> children = [];
+
+          if (c.myUser.value?.emails.confirmed.isNotEmpty == true) {}
+
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ModalPopupHeader(text: ''),
+              Flexible(
+                child: ListView(
+                  shrinkWrap: true,
+                  children: children,
+                ),
+              ),
+            ],
+          );
+        });
+      },
+    );
+  }
+}

--- a/lib/ui/page/erase/confirm_delete/view.dart
+++ b/lib/ui/page/erase/confirm_delete/view.dart
@@ -1,3 +1,20 @@
+// Copyright © 2022-2024 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 

--- a/lib/ui/page/erase/view.dart
+++ b/lib/ui/page/erase/view.dart
@@ -33,6 +33,7 @@ import '/ui/widget/svg/svg.dart';
 import '/ui/widget/text_field.dart';
 import '/util/get.dart';
 import '/util/message_popup.dart';
+import 'confirm_delete/view.dart';
 import 'controller.dart';
 
 /// [Routes.erase] page.
@@ -165,7 +166,14 @@ class EraseView extends StatelessWidget {
     );
 
     if (result == true) {
-      await c.deleteAccount();
+      if (context.mounted) {
+        if (c.myUser?.value?.emails.confirmed.isNotEmpty == true ||
+            c.myUser?.value?.hasPassword == true) {
+          await ConfirmDeleteView.show(context);
+        } else {
+          await c.deleteAccount();
+        }
+      }
     }
   }
 }

--- a/test/e2e/features/auth/create_account/.feature
+++ b/test/e2e/features/auth/create_account/.feature
@@ -36,3 +36,20 @@ Feature: Account creation
     And I tap `Proceed` button
     And I tap `CloseButton` button
     Then I wait until `ChangePassword` is present
+
+    When I scroll `MenuListView` until `DangerZone` is present
+    And I tap `DangerZone` button
+    And I scroll `MyProfileScrollable` until `DeleteAccount` is present
+    And I tap `DeleteAccount` button
+    Then I wait until `EraseView` is present
+
+    When I scroll `EraseScrollable` until `ConfirmDelete` is present
+    And I tap `ConfirmDelete` button
+    And I tap `Proceed` button
+    Then I wait until `ConfirmAccountDeletion` is present
+
+    When I fill `PasswordField` field with "123"
+    And I tap `Proceed` button
+
+    Then I wait until `AuthView` is present
+    And I pause for 1 second

--- a/test/e2e/features/my_user/delete/.feature
+++ b/test/e2e/features/my_user/delete/.feature
@@ -1,0 +1,38 @@
+# Copyright © 2022-2024 IT ENGINEERING MANAGEMENT INC,
+#                       <https://github.com/team113>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0 as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+# more details.
+#
+# You should have received a copy of the GNU Affero General Public License v3.0
+# along with this program. If not, see
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+Feature: Account deletion
+
+  Scenario: User creates and deletes account without confirmation
+    When I tap `StartButton` button
+    And I wait until `IntroductionView` is present
+    And I scroll `IntroductionScrollable` until `ProceedButton` is present
+    And I tap `ProceedButton` button
+
+    When I tap `MenuButton` button
+    And I scroll `MenuListView` until `DangerZone` is present
+    And I tap `DangerZone` button
+    And I scroll `MyProfileScrollable` until `DeleteAccount` is present
+    And I tap `DeleteAccount` button
+    Then I wait until `EraseView` is present
+
+    When I scroll `EraseScrollable` until `ConfirmDelete` is present
+    And I tap `ConfirmDelete` button
+    And I tap `Proceed` button
+
+    Then I wait until `AuthView` is present
+    And I pause for 1 second

--- a/test/e2e/parameters/keys.dart
+++ b/test/e2e/parameters/keys.dart
@@ -57,6 +57,7 @@ enum WidgetKey {
   ChatView,
   ClearHistoryButton,
   CloseButton,
+  ConfirmAccountDeletion,
   ConfirmationCode,
   ConfirmationPhone,
   ConfirmDelete,


### PR DESCRIPTION
## Synopsis

`MyUser` deletion requires a confirmation.




## Solution

This PR adds `UserPassword` and `ConfirmationCode` inputs to `MyUser` deletion modal.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
