### PR TITLE
Implement sign in and sign up by one-time password (#555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All user visible changes to this project will be documented in this file. This p
         - Credentials confirmation of account deletion. ([#1086])
     - Auth page:
         - Signing up by login and password. ([#1087])
+        - Signing in by one-time password sent to e-mail. ([#1089], [#555])
 
 ### Changed
 
@@ -41,6 +42,7 @@ All user visible changes to this project will be documented in this file. This p
 - Windows:
     - Application not launching due to `MSVCP140.dll` library being missing. ([#1070])
 
+[#555]: /../../issues/555
 [#896]: /../../issues/896
 [#900]: /../../issues/900
 [#988]: /../../issues/988
@@ -52,6 +54,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1079]: /../../pull/1079
 [#1086]: /../../pull/1086
 [#1087]: /../../pull/1087
+[#1089]: /../../pull/1089
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -888,6 +888,7 @@ label_notifications = Notifications
 label_num = Gapopa ID
 label_off = Off
 label_offline = offline
+label_one_time_password = One-time password
 label_online = online
 label_open_calls_in_app = In the application
 label_open_calls_in_window = In a separate window

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -915,6 +915,7 @@ label_notifications = Уведомления
 label_num = Gapopa ID
 label_off = Выкл
 label_offline = офлайн
+label_one_time_password = Одноразовый пароль
 label_online = онлайн
 label_open_calls_in_app = В окне приложения
 label_open_calls_in_window = В отдельном окне

--- a/lib/domain/repository/auth.dart
+++ b/lib/domain/repository/auth.dart
@@ -58,12 +58,13 @@ abstract class AbstractAuthRepository {
 
   /// Creates a new [Session] for the [MyUser] identified by the provided
   /// [num]/[login]/[email]/[phone] (exactly one of four should be specified).
-  Future<Credentials> signIn(
-    UserPassword password, {
+  Future<Credentials> signIn({
     UserLogin? login,
     UserNum? num,
     UserEmail? email,
     UserPhone? phone,
+    UserPassword? password,
+    ConfirmationCode? code,
   });
 
   /// Invalidates a [Session] with the provided [id] of the [MyUser] identified
@@ -83,21 +84,6 @@ abstract class AbstractAuthRepository {
   ///
   /// If [keepProfile] is `true`, then keeps the [MyUser] in the [profiles].
   Future<void> removeAccount(UserId id, {bool keepProfile = false});
-
-  /// Sends a [ConfirmationCode] to the provided [email] for signing up with it.
-  ///
-  /// [ConfirmationCode] is sent to the [email], which should be confirmed with
-  /// [confirmSignUpEmail] in order to successfully sign up.
-  ///
-  /// [ConfirmationCode] sent can be resent with [resendSignUpEmail].
-  Future<void> signUpWithEmail(UserEmail email);
-
-  /// Confirms the [signUpWithEmail] with the provided [ConfirmationCode].
-  Future<Credentials> confirmSignUpEmail(ConfirmationCode code);
-
-  /// Resends a new [ConfirmationCode] to the [UserEmail] specified in
-  /// [signUpWithEmail].
-  Future<void> resendSignUpEmail();
 
   /// Validates the [AccessToken] of the provided [Credentials].
   Future<void> validateToken(Credentials credentials);

--- a/lib/domain/service/my_user.dart
+++ b/lib/domain/service/my_user.dart
@@ -118,7 +118,7 @@ class MyUserService extends DisposableService {
 
         // TODO: Replace `unsafe` with something more granular and correct.
         await _authService.signIn(
-          newPassword,
+          password: newPassword,
           num: myUser.value?.num,
           unsafe: true,
           force: true,

--- a/lib/provider/gql/components/auth.dart
+++ b/lib/provider/gql/components/auth.dart
@@ -168,23 +168,18 @@ mixin AuthGraphQlMixin {
   ///
   /// Additionally, always uses the provided [ConfirmationCode], disallowing to
   /// use it again.
-  Future<SignIn$Mutation$CreateSession$CreateSessionOk> signIn(
-    UserPassword password,
-    UserLogin? login,
-    UserNum? num,
-    UserEmail? email,
-    UserPhone? phone,
-  ) async {
-    Log.debug('signIn(***, $login, $num, $email, $phone)', '$runtimeType');
+  Future<SignIn$Mutation$CreateSession$CreateSessionOk> signIn({
+    required MyUserCredentials credentials,
+    required MyUserIdentifier identifier,
+  }) async {
+    Log.debug(
+      'signIn(identifier: identifier, credentials: credentials)',
+      '$runtimeType',
+    );
 
     final variables = SignInArguments(
-      credentials: MyUserCredentials(password: password),
-      ident: MyUserIdentifier(
-        login: login,
-        num: num,
-        email: email,
-        phone: phone,
-      ),
+      credentials: credentials,
+      ident: identifier,
     );
     final QueryResult result = await client.mutate(
       MutationOptions(

--- a/lib/ui/page/erase/controller.dart
+++ b/lib/ui/page/erase/controller.dart
@@ -116,7 +116,7 @@ class EraseController extends GetxController {
       password.status.value = RxStatus.loading();
 
       await _authService.signIn(
-        UserPassword(password.text),
+        password: UserPassword(password.text),
         login: userLogin,
         num: num,
         email: email,

--- a/lib/ui/page/home/tab/menu/accounts/controller.dart
+++ b/lib/ui/page/home/tab/menu/accounts/controller.dart
@@ -189,7 +189,7 @@ class AccountsController extends GetxController {
           emailCode.clear();
           stage.value = AccountsViewStage.signUpWithEmailCode;
           try {
-            await _authService.signUpWithEmail(email);
+            await _authService.createConfirmationCode(email: email);
             s.unsubmit();
           } on AddUserEmailException catch (e) {
             s.error.value = e.toMessage();
@@ -213,8 +213,9 @@ class AccountsController extends GetxController {
       onSubmitted: (s) async {
         s.status.value = RxStatus.loading();
         try {
-          await _authService.confirmSignUpEmail(
-            ConfirmationCode(emailCode.text),
+          await _authService.signIn(
+            email: UserEmail(email.text),
+            code: ConfirmationCode(emailCode.text),
             force: true,
           );
 
@@ -299,7 +300,7 @@ class AccountsController extends GetxController {
       password.status.value = RxStatus.loading();
 
       await _authService.signIn(
-        userPassword,
+        password: userPassword,
         login: userLogin,
         num: userNum,
         email: userEmail,
@@ -473,7 +474,7 @@ class AccountsController extends GetxController {
     _setResendEmailTimer();
 
     try {
-      await _authService.resendSignUpEmail();
+      await _authService.createConfirmationCode(email: UserEmail(email.text));
     } on AddUserEmailException catch (e) {
       emailCode.error.value = e.toMessage();
     } catch (e) {

--- a/lib/ui/page/login/controller.dart
+++ b/lib/ui/page/login/controller.dart
@@ -21,7 +21,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '/api/backend/schema.dart'
-    show AddUserEmailErrorCode, UpdateUserPasswordErrorCode;
+    show CreateSessionErrorCode, UpdateUserPasswordErrorCode;
 import '/domain/model/my_user.dart';
 import '/domain/model/user.dart';
 import '/domain/service/auth.dart';
@@ -311,9 +311,9 @@ class LoginController extends GetxController {
           );
 
           (onSuccess ?? router.home)(signedUp: true);
-        } on AddUserEmailException catch (e) {
+        } on CreateSessionException catch (e) {
           switch (e.code) {
-            case AddUserEmailErrorCode.wrongCode:
+            case CreateSessionErrorCode.wrongCode:
               s.error.value = e.toMessage();
 
               ++codeAttempts;

--- a/lib/ui/page/login/view.dart
+++ b/lib/ui/page/login/view.dart
@@ -197,71 +197,6 @@ class LoginView extends StatelessWidget {
               ];
               break;
 
-            case LoginViewStage.signUpWithEmailCode:
-              header = ModalPopupHeader(
-                onBack: () => c.stage.value = LoginViewStage.signUpWithEmail,
-                text: 'label_sign_up'.l10n,
-              );
-
-              children = [
-                Text.rich(
-                  'label_sign_up_code_email_sent'
-                      .l10nfmt({'text': c.email.text}).parseLinks(
-                    [],
-                    style.fonts.normal.regular.primary,
-                  ),
-                  style: style.fonts.normal.regular.onBackground,
-                ),
-                const SizedBox(height: 16),
-                Obx(() {
-                  return Text(
-                    c.resendEmailTimeout.value == 0
-                        ? 'label_did_not_receive_code'.l10n
-                        : 'label_code_sent_again'.l10n,
-                    style: style.fonts.normal.regular.onBackground,
-                  );
-                }),
-                Obx(() {
-                  final bool enabled = c.resendEmailTimeout.value == 0;
-
-                  return WidgetButton(
-                    onPressed: enabled ? c.resendEmail : null,
-                    child: Text(
-                      enabled
-                          ? 'btn_resend_code'.l10n
-                          : 'label_wait_seconds'
-                              .l10nfmt({'for': c.resendEmailTimeout.value}),
-                      style: enabled
-                          ? style.fonts.normal.regular.primary
-                          : style.fonts.normal.regular.onBackground,
-                    ),
-                  );
-                }),
-                const SizedBox(height: 25),
-                ReactiveTextField(
-                  key: const Key('EmailCodeField'),
-                  state: c.emailCode,
-                  label: 'label_confirmation_code'.l10n,
-                  type: TextInputType.number,
-                ),
-                const SizedBox(height: 25),
-                Obx(() {
-                  final bool enabled = !c.emailCode.isEmpty.value &&
-                      c.codeTimeout.value == 0 &&
-                      c.authStatus.value.isEmpty;
-
-                  return PrimaryButton(
-                    key: const Key('Proceed'),
-                    title: c.codeTimeout.value == 0
-                        ? 'btn_send'.l10n
-                        : 'label_wait_seconds'
-                            .l10nfmt({'for': c.codeTimeout.value}),
-                    onPressed: enabled ? c.emailCode.submit : null,
-                  );
-                }),
-              ];
-              break;
-
             case LoginViewStage.signUpWithPassword:
               header = ModalPopupHeader(
                 text: 'label_sign_up_with_password'.l10n,
@@ -386,6 +321,71 @@ class LoginView extends StatelessWidget {
               ];
               break;
 
+            case LoginViewStage.signUpWithEmailCode:
+              header = ModalPopupHeader(
+                onBack: () => c.stage.value = LoginViewStage.signUpWithEmail,
+                text: 'label_sign_up'.l10n,
+              );
+
+              children = [
+                Text.rich(
+                  'label_sign_up_code_email_sent'
+                      .l10nfmt({'text': c.email.text}).parseLinks(
+                    [],
+                    style.fonts.normal.regular.primary,
+                  ),
+                  style: style.fonts.normal.regular.onBackground,
+                ),
+                const SizedBox(height: 16),
+                Obx(() {
+                  return Text(
+                    c.resendEmailTimeout.value == 0
+                        ? 'label_did_not_receive_code'.l10n
+                        : 'label_code_sent_again'.l10n,
+                    style: style.fonts.normal.regular.onBackground,
+                  );
+                }),
+                Obx(() {
+                  final bool enabled = c.resendEmailTimeout.value == 0;
+
+                  return WidgetButton(
+                    onPressed: enabled ? c.resendEmail : null,
+                    child: Text(
+                      enabled
+                          ? 'btn_resend_code'.l10n
+                          : 'label_wait_seconds'
+                              .l10nfmt({'for': c.resendEmailTimeout.value}),
+                      style: enabled
+                          ? style.fonts.normal.regular.primary
+                          : style.fonts.normal.regular.onBackground,
+                    ),
+                  );
+                }),
+                const SizedBox(height: 25),
+                ReactiveTextField(
+                  key: const Key('EmailCodeField'),
+                  state: c.emailCode,
+                  label: 'label_confirmation_code'.l10n,
+                  type: TextInputType.number,
+                ),
+                const SizedBox(height: 25),
+                Obx(() {
+                  final bool enabled = !c.emailCode.isEmpty.value &&
+                      c.codeTimeout.value == 0 &&
+                      c.authStatus.value.isEmpty;
+
+                  return PrimaryButton(
+                    key: const Key('Proceed'),
+                    title: c.codeTimeout.value == 0
+                        ? 'btn_send'.l10n
+                        : 'label_wait_seconds'
+                            .l10nfmt({'for': c.codeTimeout.value}),
+                    onPressed: enabled ? c.emailCode.submit : null,
+                  );
+                }),
+              ];
+              break;
+
             case LoginViewStage.signInWithPassword:
               header = ModalPopupHeader(
                 text: 'label_sign_in_with_password'.l10n,
@@ -450,6 +450,103 @@ class LoginView extends StatelessWidget {
               ];
               break;
 
+            case LoginViewStage.signInWithEmail:
+              header = ModalPopupHeader(
+                text: 'label_sign_in'.l10n,
+                onBack: () {
+                  c.stage.value = LoginViewStage.signIn;
+                  c.email.unsubmit();
+                },
+              );
+
+              children = [
+                ReactiveTextField(
+                  state: c.email,
+                  label: 'label_email'.l10n,
+                  hint: 'example@domain.com',
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  style: style.fonts.normal.regular.onBackground,
+                  treatErrorAsStatus: false,
+                ),
+                const SizedBox(height: 25),
+                Center(
+                  child: Obx(() {
+                    final bool enabled = !c.email.isEmpty.value;
+
+                    return PrimaryButton(
+                      onPressed: enabled ? c.email.submit : null,
+                      title: 'btn_proceed'.l10n,
+                    );
+                  }),
+                ),
+              ];
+              break;
+
+            case LoginViewStage.signInWithEmailCode:
+              header = ModalPopupHeader(
+                onBack: () => c.stage.value = LoginViewStage.signInWithEmail,
+                text: 'label_sign_in'.l10n,
+              );
+
+              children = [
+                Text.rich(
+                  'label_sign_up_code_email_sent'
+                      .l10nfmt({'text': c.email.text}).parseLinks(
+                    [],
+                    style.fonts.normal.regular.primary,
+                  ),
+                  style: style.fonts.normal.regular.onBackground,
+                ),
+                const SizedBox(height: 16),
+                Obx(() {
+                  return Text(
+                    c.resendEmailTimeout.value == 0
+                        ? 'label_did_not_receive_code'.l10n
+                        : 'label_code_sent_again'.l10n,
+                    style: style.fonts.normal.regular.onBackground,
+                  );
+                }),
+                Obx(() {
+                  final bool enabled = c.resendEmailTimeout.value == 0;
+
+                  return WidgetButton(
+                    onPressed: enabled ? c.resendEmail : null,
+                    child: Text(
+                      enabled
+                          ? 'btn_resend_code'.l10n
+                          : 'label_wait_seconds'
+                              .l10nfmt({'for': c.resendEmailTimeout.value}),
+                      style: enabled
+                          ? style.fonts.normal.regular.primary
+                          : style.fonts.normal.regular.onBackground,
+                    ),
+                  );
+                }),
+                const SizedBox(height: 25),
+                ReactiveTextField(
+                  key: const Key('EmailCodeField'),
+                  state: c.emailCode,
+                  label: 'label_confirmation_code'.l10n,
+                  type: TextInputType.number,
+                ),
+                const SizedBox(height: 25),
+                Obx(() {
+                  final bool enabled = !c.emailCode.isEmpty.value &&
+                      c.codeTimeout.value == 0 &&
+                      c.authStatus.value.isEmpty;
+
+                  return PrimaryButton(
+                    key: const Key('Proceed'),
+                    title: c.codeTimeout.value == 0
+                        ? 'btn_send'.l10n
+                        : 'label_wait_seconds'
+                            .l10nfmt({'for': c.codeTimeout.value}),
+                    onPressed: enabled ? c.emailCode.submit : null,
+                  );
+                }),
+              ];
+              break;
+
             case LoginViewStage.signIn:
               header = ModalPopupHeader(
                 text: 'label_sign_in'.l10n,
@@ -464,6 +561,16 @@ class LoginView extends StatelessWidget {
                   title: 'btn_password'.l10n,
                   onPressed: () =>
                       c.stage.value = LoginViewStage.signInWithPassword,
+                  icon: const SvgIcon(SvgIcons.password),
+                  padding: const EdgeInsets.only(left: 1),
+                ),
+                const SizedBox(height: 16),
+                SignButton(
+                  key: const Key('EmailButton'),
+                  title: 'btn_email'.l10n,
+                  subtitle: 'label_one_time_password'.l10n,
+                  onPressed: () =>
+                      c.stage.value = LoginViewStage.signInWithEmail,
                   icon: const SvgIcon(SvgIcons.password),
                   padding: const EdgeInsets.only(left: 1),
                 ),

--- a/lib/ui/page/login/view.dart
+++ b/lib/ui/page/login/view.dart
@@ -571,8 +571,7 @@ class LoginView extends StatelessWidget {
                   subtitle: 'label_one_time_password'.l10n,
                   onPressed: () =>
                       c.stage.value = LoginViewStage.signInWithEmail,
-                  icon: const SvgIcon(SvgIcons.password),
-                  padding: const EdgeInsets.only(left: 1),
+                  icon: const SvgIcon(SvgIcons.email),
                 ),
                 const SizedBox(height: 16),
               ];

--- a/lib/ui/page/login/widget/prefix_button.dart
+++ b/lib/ui/page/login/widget/prefix_button.dart
@@ -24,6 +24,7 @@ class PrefixButton extends StatelessWidget {
   const PrefixButton({
     super.key,
     this.title = '',
+    this.subtitle,
     this.onPressed,
     this.style,
     this.prefix,
@@ -31,6 +32,9 @@ class PrefixButton extends StatelessWidget {
 
   /// Title of this [PrefixButton].
   final String title;
+
+  /// Title of this [PrefixButton].
+  final String? subtitle;
 
   /// [TextStyle] of the [title].
   final TextStyle? style;
@@ -70,21 +74,28 @@ class PrefixButton extends StatelessWidget {
                   minHeight: 46,
                   maxHeight: double.infinity,
                 ),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 5.6, vertical: 4.2),
-                child: Row(
-                  children: [
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: DefaultTextStyle.merge(
-                        overflow: TextOverflow.ellipsis,
-                        textAlign: TextAlign.center,
-                        style: style,
-                        child: Center(child: Text(title)),
+                padding: const EdgeInsets.fromLTRB(13.6, 4.2, 13.6, 4.2),
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          title,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.center,
+                          style: style,
+                        ),
                       ),
-                    ),
-                    const SizedBox(width: 8),
-                  ],
+                      if (subtitle != null)
+                        Text(
+                          subtitle!,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.center,
+                          style: styles.fonts.small.regular.secondary,
+                        )
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/ui/page/login/widget/sign_button.dart
+++ b/lib/ui/page/login/widget/sign_button.dart
@@ -25,6 +25,7 @@ class SignButton extends StatelessWidget {
   const SignButton({
     super.key,
     required this.title,
+    this.subtitle,
     this.icon,
     this.padding = EdgeInsets.zero,
     this.onPressed,
@@ -32,6 +33,9 @@ class SignButton extends StatelessWidget {
 
   /// Title of this [SignButton].
   final String title;
+
+  /// Subtitle of this [SignButton].
+  final String? subtitle;
 
   /// Widget to display as a [PrefixButton.prefix].
   final Widget? icon;
@@ -49,6 +53,7 @@ class SignButton extends StatelessWidget {
     return Center(
       child: PrefixButton(
         title: title,
+        subtitle: subtitle,
         style: onPressed == null
             ? style.fonts.medium.regular.secondary
             : style.fonts.medium.regular.onBackground,

--- a/test/e2e/configuration.dart
+++ b/test/e2e/configuration.dart
@@ -381,8 +381,13 @@ Future<CustomUser> createUser({
       await provider.updateUserPassword(newPassword: password);
       world.sessions[user.name]?.password = password;
 
-      final result =
-          await provider.signIn(password, null, customUser.userNum, null, null);
+      final result = await provider.signIn(
+        credentials: MyUserCredentials(password: password),
+        identifier: MyUserIdentifier(
+          num: customUser.userNum
+        ),
+
+      );
       world.sessions[user.name]?.credentials = result.toModel();
     }
   }

--- a/test/e2e/configuration.dart
+++ b/test/e2e/configuration.dart
@@ -383,10 +383,7 @@ Future<CustomUser> createUser({
 
       final result = await provider.signIn(
         credentials: MyUserCredentials(password: password),
-        identifier: MyUserIdentifier(
-          num: customUser.userNum
-        ),
-
+        identifier: MyUserIdentifier(num: customUser.userNum),
       );
       world.sessions[user.name]?.credentials = result.toModel();
     }

--- a/test/e2e/steps/users.dart
+++ b/test/e2e/steps/users.dart
@@ -20,6 +20,7 @@ import 'dart:math';
 import 'package:get/get.dart';
 import 'package:gherkin/gherkin.dart';
 import 'package:messenger/api/backend/extension/credentials.dart';
+import 'package:messenger/api/backend/schema.dart';
 import 'package:messenger/domain/model/session.dart';
 import 'package:messenger/domain/model/user.dart';
 import 'package:messenger/domain/service/auth.dart';
@@ -79,7 +80,7 @@ final StepDefinitionGeneric signInAs = then1<TestUser, CustomWorld>(
           .signInWith(await context.world.sessions[user.name]!.credentials);
     } catch (_) {
       await Get.find<AuthService>().signIn(
-        UserPassword('123'),
+        password: UserPassword('123'),
         num: context.world.sessions[user.name]!.userNum,
         unsafe: true,
         force: true,
@@ -176,8 +177,10 @@ final StepDefinitionGeneric hasSession = then1<TestUser, CustomWorld>(
 
     final CustomUser user = context.world.sessions[testUser.name]!.first;
 
-    final result =
-        await provider.signIn(user.password!, null, user.userNum, null, null);
+    final result = await provider.signIn(
+      identifier: MyUserIdentifier(num: user.userNum),
+      credentials: MyUserCredentials(password: user.password),
+    );
 
     final CustomUser newUser = CustomUser(result.toModel(), result.user.num);
     context.world.sessions[testUser.name]?.add(newUser);

--- a/test/e2e/world/custom_world.dart
+++ b/test/e2e/world/custom_world.dart
@@ -20,6 +20,7 @@ import 'dart:async';
 import 'package:flutter_gherkin/flutter_gherkin.dart';
 import 'package:flutter/services.dart' show ClipboardData;
 import 'package:messenger/api/backend/extension/credentials.dart';
+import 'package:messenger/api/backend/schema.graphql.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/contact.dart';
 import 'package:messenger/domain/model/session.dart';
@@ -115,11 +116,9 @@ class CustomUser {
       return Future(() async {
         final provider = GraphQlProvider();
         final response = await provider.signIn(
-          password ?? UserPassword('123'),
-          null,
-          userNum,
-          null,
-          null,
+          identifier: MyUserIdentifier(num: userNum),
+          credentials:
+              MyUserCredentials(password: password ?? UserPassword('123')),
         );
         _credentials = response.toModel();
 

--- a/test/unit/auth_test.dart
+++ b/test/unit/auth_test.dart
@@ -62,11 +62,8 @@ void main() async {
 
     when(
       graphQlProvider.signIn(
-        UserPassword('123'),
-        UserLogin('user'),
-        null,
-        null,
-        null,
+        credentials: MyUserCredentials(password: UserPassword('123')),
+        identifier: MyUserIdentifier(login: UserLogin('user')),
       ),
     ).thenAnswer(
       (_) => Future.value(
@@ -136,8 +133,12 @@ void main() async {
     await authService.logout();
 
     expect(authService.status.value.isEmpty, true);
-    verify(graphQlProvider.signIn(
-        UserPassword('123'), UserLogin('user'), null, null, null));
+    verify(
+      graphQlProvider.signIn(
+        credentials: MyUserCredentials(password: UserPassword('123')),
+        identifier: MyUserIdentifier(login: UserLogin('user')),
+      ),
+    );
   });
 
   test('AuthService successfully logins with saved session', () async {
@@ -188,17 +189,21 @@ void main() async {
     final graphQlProvider = MockGraphQlProvider();
     when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
 
-    when(graphQlProvider.signIn(UserPassword('123'), null, null, null, null))
-        .thenThrow(
+    when(
+      graphQlProvider.signIn(
+        credentials: MyUserCredentials(password: UserPassword('123')),
+        identifier: MyUserIdentifier(),
+      ),
+    ).thenThrow(
       const CreateSessionException((CreateSessionErrorCode.wrongPassword)),
     );
 
-    AuthRepository authRepository = Get.put(AuthRepository(
+    final AuthRepository authRepository = Get.put(AuthRepository(
       graphQlProvider,
       myUserProvider,
       credsProvider,
     ));
-    AuthService authService = Get.put(AuthService(
+    final AuthService authService = Get.put(AuthService(
       authRepository,
       credsProvider,
       accountProvider,
@@ -212,7 +217,12 @@ void main() async {
       expect(e, isA<CreateSessionException>());
     }
 
-    verify(graphQlProvider.signIn(UserPassword('123'), null, null, null, null));
+    verify(
+      graphQlProvider.signIn(
+        credentials: MyUserCredentials(password: UserPassword('123')),
+        identifier: MyUserIdentifier(),
+      ),
+    );
   });
 
   test('AuthService successfully resets password', () async {

--- a/test/unit/auth_test.dart
+++ b/test/unit/auth_test.dart
@@ -122,7 +122,10 @@ void main() async {
 
     expect(await authService.init(), Routes.auth);
 
-    await authService.signIn(UserPassword('123'), login: UserLogin('user'));
+    await authService.signIn(
+      password: UserPassword('123'),
+      login: UserLogin('user'),
+    );
 
     expect(authService.status.value.isSuccess, true);
     expect(
@@ -203,7 +206,7 @@ void main() async {
 
     expect(await authService.init(), Routes.auth);
     try {
-      await authService.signIn(UserPassword('123'));
+      await authService.signIn(password: UserPassword('123'));
       fail('Exception is not thrown');
     } catch (e) {
       expect(e, isA<CreateSessionException>());

--- a/test/widget/auth_test.dart
+++ b/test/widget/auth_test.dart
@@ -227,14 +227,14 @@ class _FakeGraphQlProvider extends MockedGraphQlProvider {
   };
 
   @override
-  Future<SignIn$Mutation$CreateSession$CreateSessionOk> signIn(
-    UserPassword password,
-    UserLogin? username,
-    UserNum? num,
-    UserEmail? email,
-    UserPhone? phone,
-  ) async {
-    if (username == null && num == null && email == null && phone == null) {
+  Future<SignIn$Mutation$CreateSession$CreateSessionOk> signIn({
+    required MyUserIdentifier identifier,
+    required MyUserCredentials credentials,
+  }) async {
+    if (identifier.email == null &&
+        identifier.num == null &&
+        identifier.login == null &&
+        identifier.phone == null) {
       throw Exception('Username or num or email or phone must not be null');
     }
 


### PR DESCRIPTION
Resolves #555




## Synopsis

OTP was implemented as a way to sign in or sign up.




## Solution

This PR bootstraps the interface and the methods for OTP sign in or sign up.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
