### PR TITLE
Display `ChatDirectLink.createdAt` in `DirectLinkField` widget

### DIFF
--- a/lib/api/backend/extension/chat.dart
+++ b/lib/api/backend/extension/chat.dart
@@ -56,6 +56,7 @@ extension ChatConversion on ChatMixin {
             ? ChatDirectLink(
                 slug: directLink!.slug,
                 usageCount: directLink!.usageCount,
+                createdAt: createdAt,
               )
             : null,
         createdAt: createdAt,

--- a/lib/api/backend/extension/my_user.dart
+++ b/lib/api/backend/extension/my_user.dart
@@ -42,6 +42,7 @@ extension MyUserConversion on MyUserMixin {
             ? ChatDirectLink(
                 slug: chatDirectLink!.slug,
                 usageCount: chatDirectLink!.usageCount,
+                createdAt: chatDirectLink!.createdAt,
               )
             : null,
         avatar: avatar?.toModel(),

--- a/lib/api/backend/graphql/fragments/Chat.graphql
+++ b/lib/api/backend/graphql/fragments/Chat.graphql
@@ -39,6 +39,7 @@ fragment Chat on Chat {
     directLink {
         slug
         usageCount
+        createdAt
     }
     createdAt
     updatedAt

--- a/lib/api/backend/graphql/fragments/ChatEventsVersioned.graphql
+++ b/lib/api/backend/graphql/fragments/ChatEventsVersioned.graphql
@@ -74,6 +74,7 @@ fragment ChatEventsVersioned on ChatEventsVersioned {
             directLink {
                 slug
                 usageCount
+                createdAt
             }
         }
         ... on EventChatItemDeleted {

--- a/lib/api/backend/graphql/fragments/MyUserEventsVersioned.graphql
+++ b/lib/api/backend/graphql/fragments/MyUserEventsVersioned.graphql
@@ -63,6 +63,7 @@ fragment MyUserEventsVersioned on MyUserEventsVersioned {
             directLink {
                 slug
                 usageCount
+                createdAt
             }
         }
         ... on EventUserEmailAdded {

--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -447,6 +447,7 @@ class ChatDirectLink {
   ChatDirectLink({
     required this.slug,
     this.usageCount = 0,
+    required this.createdAt,
   });
 
   /// Constructs a [ChatDirectLink] from the provided [json].
@@ -459,11 +460,15 @@ class ChatDirectLink {
   /// Number of times this [ChatDirectLink] has been used.
   int usageCount;
 
+  /// [PreciseDateTime] when this [ChatDirectLink] was created.
+  PreciseDateTime createdAt;
+
   @override
   bool operator ==(Object other) =>
       other is ChatDirectLink &&
       slug == other.slug &&
-      usageCount == other.usageCount;
+      usageCount == other.usageCount &&
+      createdAt == other.createdAt;
 
   @override
   int get hashCode => Object.hash(slug, usageCount);

--- a/lib/provider/drift/chat_item.dart
+++ b/lib/provider/drift/chat_item.dart
@@ -64,7 +64,7 @@ class ChatItemDriftProvider extends DriftProviderBaseWithScope {
 
   /// Creates or updates the a view for the provided [chatItemId] in [chatId].
   Future<void> upsertView(ChatId chatId, ChatItemId chatItemId) async {
-    Log.debug('upsertView($chatId, $chatItemId)');
+    Log.debug('upsertView($chatId, $chatItemId)', '$runtimeType');
 
     await safe((db) async {
       final view =
@@ -79,7 +79,7 @@ class ChatItemDriftProvider extends DriftProviderBaseWithScope {
   ///
   /// If [toView] is `true`, then also adds a view to the [ChatItemViews].
   Future<DtoChatItem> upsert(DtoChatItem item, {bool toView = false}) async {
-    Log.debug('upsert($item) toView($toView)');
+    Log.debug('upsert($item) toView($toView)', '$runtimeType');
 
     _cache[item.value.id] = item;
 
@@ -116,7 +116,10 @@ class ChatItemDriftProvider extends DriftProviderBaseWithScope {
     }
 
     final result = await safe((db) async {
-      Log.debug('upsertBulk(${items.length} items) toView($toView)');
+      Log.debug(
+        'upsertBulk(${items.length} items) toView($toView)',
+        '$runtimeType',
+      );
 
       await db.batch((batch) {
         for (var item in items) {

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -904,7 +904,12 @@ class ChatRepository extends DisposableInterface
     await _graphQlProvider.createChatDirectLink(slug, groupId: chatId);
 
     final RxChatImpl? chat = chats[chatId];
-    chat?.chat.update((c) => c?.directLink = ChatDirectLink(slug: slug));
+    chat?.chat.update(
+      (c) => c?.directLink = ChatDirectLink(
+        slug: slug,
+        createdAt: PreciseDateTime.now(),
+      ),
+    );
   }
 
   @override
@@ -1484,6 +1489,7 @@ class ChatRepository extends DisposableInterface
         ChatDirectLink(
           slug: node.directLink.slug,
           usageCount: node.directLink.usageCount,
+          createdAt: node.directLink.createdAt,
         ),
       );
     } else if (e.$$typename == 'EventChatCallMoved') {

--- a/lib/store/my_user.dart
+++ b/lib/store/my_user.dart
@@ -612,7 +612,12 @@ class MyUserRepository extends DisposableInterface
     // link right away.
     await _graphQlProvider.createUserDirectLink(slug);
 
-    myUser.update((u) => u?.chatDirectLink = ChatDirectLink(slug: slug));
+    myUser.update(
+      (u) => u?.chatDirectLink = ChatDirectLink(
+        slug: slug,
+        createdAt: PreciseDateTime.now(),
+      ),
+    );
   }
 
   @override
@@ -1365,6 +1370,7 @@ class MyUserRepository extends DisposableInterface
         ChatDirectLink(
           slug: node.directLink.slug,
           usageCount: node.directLink.usageCount,
+          createdAt: node.directLink.createdAt,
         ),
       );
     } else if (e.$$typename == 'EventUserDirectLinkDeleted') {

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -1971,6 +1971,10 @@ class ChatController extends GetxController {
           await _loadNextPage();
           await _loadPreviousPage();
           _ensureScrollable();
+        } else if (_atBottom) {
+          await _loadNextPage();
+        } else if (_atTop) {
+          await _loadPreviousPage();
         }
       });
     }

--- a/lib/ui/page/home/widget/direct_link.dart
+++ b/lib/ui/page/home/widget/direct_link.dart
@@ -282,7 +282,7 @@ class _DirectLinkFieldState extends State<DirectLinkField> {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   const SizedBox(height: 14),
-                  _info(context, Text(DateTime.now().yMd)),
+                  _info(context, Text('${widget.link?.createdAt.val.yMd}')),
                   Padding(
                     padding: const EdgeInsets.fromLTRB(48, 0, 0, 0),
                     child: ContextMenuRegion(


### PR DESCRIPTION
## Synopsis

`ChatDirectLink.createdAt` was added to GraphQL scheme.




## Solution

This PR adds the field to the model and displays it in the widget.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
