### PR TITLE
Replace `UserId.dialog` with `ChatService.monolog` within `ChatItemWidget` (#1083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Chat page:
         - Typing being infinitely displayed after focus is lost. ([#995], [#988])
+        - Notes being duplicated when pressing on authorized user's name in chat. ([#1097], [#1083])
 - Web:
     - Application becoming unresponsive when navigating back with gallery being opened. ([#1078], [#900])
 - Windows:
@@ -56,11 +57,13 @@ All user visible changes to this project will be documented in this file. This p
 [#1070]: /../../pull/1070
 [#1078]: /../../pull/1078
 [#1079]: /../../pull/1079
+[#1083]: /../../issues/1083
 [#1086]: /../../pull/1086
 [#1087]: /../../pull/1087
 [#1089]: /../../pull/1089
 [#1090]: /../../pull/1090
 [#1094]: /../../pull/1094
+[#1097]: /../../pull/1097
 
 
 

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -295,6 +295,10 @@ class ChatRepository extends DisposableInterface
   FutureOr<RxChatImpl?> get(ChatId id) {
     Log.debug('get($id)', '$runtimeType');
 
+    if (id.isLocalWith(me)) {
+      id = monolog;
+    }
+
     RxChatImpl? chat = chats[id];
     if (chat != null) {
       return chat;

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -405,6 +405,10 @@ class ChatController extends GetxController {
   /// Returns the [WelcomeMessage] of this [chat], if any.
   WelcomeMessage? get welcomeMessage => user?.user.value.welcomeMessage;
 
+  /// Returns [ChatId] of the [Chat]-monolog of the currently authenticated
+  /// [MyUser], if any.
+  ChatId get monolog => _chatService.monolog;
+
   /// Indicates whether the [listController] is scrolled to its bottom.
   bool get _atBottom =>
       listController.hasClients && listController.position.pixels < 500;

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -901,6 +901,14 @@ class ChatView extends StatelessWidget {
                     c.selecting.toggle();
                     c.selected.add(element);
                   },
+                  onUserPressed: (user) {
+                    ChatId chatId = user.dialog;
+                    if (chatId.isLocalWith(c.me)) {
+                      chatId = c.monolog;
+                    }
+
+                    router.chat(chatId, push: true);
+                  },
                 ),
               ),
             );

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -93,6 +93,7 @@ class ChatItemWidget extends StatefulWidget {
     this.onDownloadAs,
     this.onSave,
     this.onSelect,
+    this.onUserPressed = _defaultOnUserPressed,
   });
 
   /// Reactive value of a [ChatItem] to display.
@@ -167,6 +168,9 @@ class ChatItemWidget extends StatefulWidget {
 
   /// Callback, called when a select action is triggered.
   final void Function()? onSelect;
+
+  /// Callback, called whenever some [User]'s name is being pressed.
+  final void Function(User) onUserPressed;
 
   @override
   State<ChatItemWidget> createState() => _ChatItemWidgetState();
@@ -327,6 +331,10 @@ class ChatItemWidget extends StatefulWidget {
       },
     );
   }
+
+  /// Opens the [User.dialog] chat.
+  static _defaultOnUserPressed(User user) =>
+      router.chat(user.dialog, push: true);
 }
 
 /// State of a [ChatItemWidget] maintaining the [GlobalKey]s for gallery and
@@ -495,8 +503,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                     TextSpan(
                       text: 'label_group_created_by1'.l10nfmt(args),
                       recognizer: TapGestureRecognizer()
-                        ..onTap = () =>
-                            router.chat(user.user.value.dialog, push: true),
+                        ..onTap = () => widget.onUserPressed(user.user.value),
                     ),
                     TextSpan(
                       text: 'label_group_created_by2'.l10nfmt(args),
@@ -552,7 +559,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                   TextSpan(
                     text: 'label_user_added_user1'.l10nfmt(args),
                     recognizer: TapGestureRecognizer()
-                      ..onTap = () => router.chat(author.dialog, push: true),
+                      ..onTap = () => widget.onUserPressed(author),
                   ),
                   TextSpan(
                     text: 'label_user_added_user2'.l10nfmt(args),
@@ -561,7 +568,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                   TextSpan(
                     text: 'label_user_added_user3'.l10nfmt(args),
                     recognizer: TapGestureRecognizer()
-                      ..onTap = () => router.chat(user.dialog, push: true),
+                      ..onTap = () => widget.onUserPressed(user),
                   ),
                 ],
                 style: style.systemMessagePrimary,
@@ -581,7 +588,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                 TextSpan(
                   text: 'label_was_added1'.l10nfmt(args),
                   recognizer: TapGestureRecognizer()
-                    ..onTap = () => router.chat(user.dialog, push: true),
+                    ..onTap = () => widget.onUserPressed(user),
                 ),
                 TextSpan(
                   text: 'label_was_added2'.l10nfmt(args),
@@ -613,7 +620,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                   TextSpan(
                     text: 'label_user_removed_user1'.l10nfmt(args),
                     recognizer: TapGestureRecognizer()
-                      ..onTap = () => router.chat(author.dialog, push: true),
+                      ..onTap = () => widget.onUserPressed(author),
                   ),
                   TextSpan(
                     text: 'label_user_removed_user2'.l10nfmt(args),
@@ -622,7 +629,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                   TextSpan(
                     text: 'label_user_removed_user3'.l10nfmt(args),
                     recognizer: TapGestureRecognizer()
-                      ..onTap = () => router.chat(user.dialog, push: true),
+                      ..onTap = () => widget.onUserPressed(user),
                   ),
                 ],
                 style: style.systemMessagePrimary,
@@ -642,7 +649,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                 TextSpan(
                   text: 'label_was_removed1'.l10nfmt(args),
                   recognizer: TapGestureRecognizer()
-                    ..onTap = () => router.chat(user.dialog, push: true),
+                    ..onTap = () => widget.onUserPressed(user),
                 ),
                 TextSpan(
                   text: 'label_was_removed2'.l10nfmt(args),
@@ -678,7 +685,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
               TextSpan(
                 text: phrase1.l10nfmt(args),
                 recognizer: TapGestureRecognizer()
-                  ..onTap = () => router.chat(user.dialog, push: true),
+                  ..onTap = () => widget.onUserPressed(user),
               ),
               TextSpan(
                 text: phrase2.l10nfmt(args),
@@ -714,7 +721,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
               TextSpan(
                 text: phrase1.l10nfmt(args),
                 recognizer: TapGestureRecognizer()
-                  ..onTap = () => router.chat(user.dialog, push: true),
+                  ..onTap = () => widget.onUserPressed(user),
               ),
               TextSpan(
                 text: phrase2.l10nfmt(args),
@@ -790,8 +797,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                       TextSpan(
                         text: widget.user?.title ?? 'dot'.l10n * 3,
                         recognizer: TapGestureRecognizer()
-                          ..onTap =
-                              () => router.chat(_author.dialog, push: true),
+                          ..onTap = () => widget.onUserPressed(_author),
                       ),
                       selectable: PlatformUtils.isDesktop || menu,
                       onChanged: (a) => _selection = a,
@@ -1035,8 +1041,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                         TextSpan(
                           text: widget.user?.title ?? 'dot'.l10n * 3,
                           recognizer: TapGestureRecognizer()
-                            ..onTap =
-                                () => router.chat(_author.dialog, push: true),
+                            ..onTap = () => widget.onUserPressed(_author),
                         ),
                         selectable: PlatformUtils.isDesktop || menu,
                         onChanged: (a) => _selection = a,
@@ -1465,8 +1470,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
                 child: widget.avatar
                     ? InkWell(
                         customBorder: const CircleBorder(),
-                        onTap: () =>
-                            router.chat(item.author.dialog, push: true),
+                        onTap: () => widget.onUserPressed(item.author),
                         child: AvatarWidget.fromRxUser(
                           widget.user,
                           radius: avatarRadius,


### PR DESCRIPTION
Resolves #1083




## Synopsis

Monolog can be duplicated by pressing on authorized user's name within the chat.




## Solution

This PR ensures that the local `User.dialog` is replaced with monolog's `ChatId` whenever such a press occurs.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
