### PR TITLE
Fix `tags` step forming invalid tags in `docker-push` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -855,7 +855,7 @@ jobs:
               if ('${{ steps.semver.outputs.group4 }}' !== '0') {
                 versions += ',${{ steps.semver.outputs.group4 }}';
               }
-              versions += 'latest';
+              versions += ',latest';
             }
             return versions;
         if: ${{ steps.skip.outputs.no == 'true'


### PR DESCRIPTION
## Synopsis

CI resulted in the following tags being formed:
```
make docker.tags of=build-8653 registries=ghcr.io tags=0.2.0,0.2latest
-> 0.2.0
-> 0.2latest
```

Instead it should be:

```
make docker.tags of=build-8653 registries=ghcr.io tags=0.2.0,0.2,latest
-> 0.2.0
-> 0.2
-> latest
```




## Solution

This PR adds the missing `,`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
