### PR TITLE
Fix inability to input `ChatName` on `Chats` tab in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.3.0] · 2024-??-??
+[0.3.0]: /../../tree/v0.3.0
+
+[Diff](/../../compare/v0.2.0...v0.3.0) | [Milestone](/../../milestone/29)
+
+### Fixed
+
+- Web:
+    - Inability to input chat's name during group creation. ([#1103])
+
+[#1103]: /../../pull/1103
+
+
+
+
 ## [0.2.0] · 2024-09-04
 [0.2.0]: /../../tree/v0.2.0
 

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -1046,6 +1046,7 @@ class ChatsTabView extends StatelessWidget {
                   }
 
                   return ContextMenuInterceptor(
+                    margin: const EdgeInsets.fromLTRB(0, 64, 0, 0),
                     child: SlidableAutoCloseBehavior(
                       child: SafeAnimatedSwitcher(
                         duration: const Duration(milliseconds: 250),

--- a/lib/ui/widget/menu_interceptor/src/non_web.dart
+++ b/lib/ui/widget/menu_interceptor/src/non_web.dart
@@ -22,9 +22,10 @@ class ContextMenuInterceptor extends StatelessWidget {
   // ignore: prefer_const_constructors_in_immutables
   ContextMenuInterceptor({
     super.key,
+    EdgeInsets margin = EdgeInsets.zero,
     required this.child,
-    enabled = true,
-    debug = false,
+    bool enabled = true,
+    bool debug = false,
   });
 
   /// Widget being wrapped.

--- a/lib/ui/widget/menu_interceptor/src/web.dart
+++ b/lib/ui/widget/menu_interceptor/src/web.dart
@@ -25,6 +25,7 @@ import 'package:web/web.dart' as web;
 class ContextMenuInterceptor extends StatelessWidget {
   ContextMenuInterceptor({
     super.key,
+    this.margin = EdgeInsets.zero,
     required this.child,
     this.enabled = true,
     this.debug = false,
@@ -33,6 +34,9 @@ class ContextMenuInterceptor extends StatelessWidget {
       _register();
     }
   }
+
+  /// [EdgeInsets] being the margin of the interception.
+  final EdgeInsets margin;
 
   /// Widget being wrapped.
   final Widget child;
@@ -58,7 +62,12 @@ class ContextMenuInterceptor extends StatelessWidget {
     return Stack(
       alignment: Alignment.center,
       children: [
-        Positioned.fill(child: HtmlElementView(viewType: viewType)),
+        Positioned.fill(
+          child: Padding(
+            padding: margin,
+            child: HtmlElementView(viewType: viewType),
+          ),
+        ),
         child,
       ],
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -364,7 +364,7 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/desktop_drop"
-      ref: HEAD
+      ref: "08c1ce40eb6abfad6049fb6aad8bd30312ec5319"
       resolved-ref: "08c1ce40eb6abfad6049fb6aad8bd30312ec5319"
       url: "https://github.com/MixinNetwork/flutter-plugins"
     source: git
@@ -1274,7 +1274,7 @@ packages:
     description:
       path: media_kit
       ref: HEAD
-      resolved-ref: "9ccb01729051b4f071d020e6e1fce6e35a50ead0"
+      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.1.11"
@@ -1283,7 +1283,7 @@ packages:
     description:
       path: "libs/android/media_kit_libs_android_video"
       ref: HEAD
-      resolved-ref: "9ccb01729051b4f071d020e6e1fce6e35a50ead0"
+      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.3.6"
@@ -1292,7 +1292,7 @@ packages:
     description:
       path: "libs/ios/media_kit_libs_ios_video"
       ref: HEAD
-      resolved-ref: "9ccb01729051b4f071d020e6e1fce6e35a50ead0"
+      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.1.4"
@@ -1301,7 +1301,7 @@ packages:
     description:
       path: "libs/linux/media_kit_libs_linux"
       ref: HEAD
-      resolved-ref: "9ccb01729051b4f071d020e6e1fce6e35a50ead0"
+      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.1.3"
@@ -1318,7 +1318,7 @@ packages:
     description:
       path: "libs/windows/media_kit_libs_windows_video"
       ref: HEAD
-      resolved-ref: "9ccb01729051b4f071d020e6e1fce6e35a50ead0"
+      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.0.10"
@@ -1327,7 +1327,7 @@ packages:
     description:
       path: media_kit_native_event_loop
       ref: HEAD
-      resolved-ref: "9ccb01729051b4f071d020e6e1fce6e35a50ead0"
+      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.0.9"
@@ -1336,7 +1336,7 @@ packages:
     description:
       path: media_kit_video
       ref: HEAD
-      resolved-ref: "9ccb01729051b4f071d020e6e1fce6e35a50ead0"
+      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.2.5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2267,7 +2267,7 @@ packages:
     source: hosted
     version: "14.2.5"
   volume_controller:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: volume_controller
       sha256: c71d4c62631305df63b72da79089e078af2659649301807fa746088f365cb48e

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1274,7 +1274,7 @@ packages:
     description:
       path: media_kit
       ref: HEAD
-      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
+      resolved-ref: e357b2ba80852c7e0a8df1da1281cb813b1fd42b
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.1.11"
@@ -1283,7 +1283,7 @@ packages:
     description:
       path: "libs/android/media_kit_libs_android_video"
       ref: HEAD
-      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
+      resolved-ref: e357b2ba80852c7e0a8df1da1281cb813b1fd42b
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.3.6"
@@ -1292,7 +1292,7 @@ packages:
     description:
       path: "libs/ios/media_kit_libs_ios_video"
       ref: HEAD
-      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
+      resolved-ref: e357b2ba80852c7e0a8df1da1281cb813b1fd42b
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.1.4"
@@ -1301,7 +1301,7 @@ packages:
     description:
       path: "libs/linux/media_kit_libs_linux"
       ref: HEAD
-      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
+      resolved-ref: e357b2ba80852c7e0a8df1da1281cb813b1fd42b
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.1.3"
@@ -1318,7 +1318,7 @@ packages:
     description:
       path: "libs/windows/media_kit_libs_windows_video"
       ref: HEAD
-      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
+      resolved-ref: e357b2ba80852c7e0a8df1da1281cb813b1fd42b
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.0.10"
@@ -1327,7 +1327,7 @@ packages:
     description:
       path: media_kit_native_event_loop
       ref: HEAD
-      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
+      resolved-ref: e357b2ba80852c7e0a8df1da1281cb813b1fd42b
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.0.9"
@@ -1336,7 +1336,7 @@ packages:
     description:
       path: media_kit_video
       ref: HEAD
-      resolved-ref: de4c351172796b96a7cade832941d793c975bf28
+      resolved-ref: e357b2ba80852c7e0a8df1da1281cb813b1fd42b
       url: "https://github.com/SleepySquash/media-kit"
     source: git
     version: "1.2.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
     git:
       url: https://github.com/MixinNetwork/flutter-plugins
       path: packages/desktop_drop
+      ref: 08c1ce40eb6abfad6049fb6aad8bd30312ec5319
   device_info_plus: ^10.1.0
   dio: ^5.1.2
   dough: ^2.0.0
@@ -64,8 +65,8 @@ dependencies:
   just_audio: ^0.9.38
   log_me: ^0.1.2
   material_floating_search_bar: ^0.3.7
-  medea_flutter_webrtc: ^0.11.0
-  medea_jason: ^0.6.0
+  medea_flutter_webrtc: 0.11.0
+  medea_jason: 0.6.0
   media_kit: ^1.1.5
   media_kit_libs_android_video: ^1.3.2
   media_kit_libs_ios_video: ^1.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -104,6 +104,7 @@ dependencies:
   url_launcher: ^6.1.12
   uuid: ^4.3.3
   vibration: ^1.8.1
+  volume_controller: any
   wakelock_plus: ^1.1.4
   web_socket_channel: ^2.4.0
   web: ">=0.5.1 <2.0.0"


### PR DESCRIPTION
## Synopsis

Firefox won't allow `ChatName` to be inputted for some reason on `Chats` tab.




## Solution

This PR fixes that by adding margin to `ContextMenuInterceptor`




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
