### PR TITLE
Fix `ChatCallWidget` not rebuilding periodically active `ChatCall`'s duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Fixed
 
+- UI:
+    - Chat page:
+        - Active call's duration not being refreshed every second. ([#1105])
 - Web:
     - Inability to input chat's name during group creation. ([#1103])
 
 [#1103]: /../../pull/1103
+[#1105]: /../../pull/1105
 
 
 

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1829,8 +1829,8 @@ class ChatCallWidget extends StatefulWidget {
 /// State of a [ChatCallWidget] maintaining the [FutureOr] retrieving the
 /// [ChatCall] and [Timer] for its periodic updates.
 class ChatCallWidgetState extends State<ChatCallWidget> {
-  /// [FutureOr] used in [FutureBuilder].
-  FutureOr<Rx<ChatItem>?>? _futureOrCall;
+  /// Reactive [ChatItem] representing the [ChatCall].
+  Rx<ChatItem>? _item;
 
   /// [FixedTimer] rebuilding this widget every second, if this [ChatCall]
   /// represents an ongoing [ChatCall].
@@ -1841,7 +1841,7 @@ class ChatCallWidgetState extends State<ChatCallWidget> {
     super.initState();
 
     if (widget.getItem != null && widget.call != null) {
-      _futureOrCall = widget.getItem!.call(widget.call!.id);
+      _fetchItem();
     }
   }
 
@@ -1853,113 +1853,123 @@ class ChatCallWidgetState extends State<ChatCallWidget> {
 
   @override
   Widget build(BuildContext context) {
+    if (_item == null || _item?.value is! ChatCall) {
+      return _render(context, widget.call);
+    }
+
+    return Obx(() => _render(context, _item!.value as ChatCall));
+  }
+
+  /// Builds the [ChatCall] visual representation.
+  Widget _render(BuildContext context, ChatCall? call) {
     final style = Theme.of(context).style;
 
-    return FutureBuilder<Rx<ChatItem>?>(
-      initialData: _futureOrCall is Rx<ChatItem>?
-          ? _futureOrCall as Rx<ChatItem>?
-          : null,
-      future: _futureOrCall is Rx<ChatItem>?
-          ? null
-          : _futureOrCall as Future<Rx<ChatItem>?>,
-      builder: (context, snapshot) {
-        final ChatCall? call = snapshot.data?.value as ChatCall?;
+    final bool isOngoing =
+        call?.finishReason == null && call?.conversationStartedAt != null;
 
-        final bool isOngoing =
-            call?.finishReason == null && call?.conversationStartedAt != null;
+    bool isMissed = false;
+    String title = 'label_chat_call_ended'.l10n;
+    String? time;
 
-        bool isMissed = false;
-        String title = 'label_chat_call_ended'.l10n;
-        String? time;
+    if (isOngoing) {
+      title = 'label_chat_call_ongoing'.l10n;
+      time = call!.conversationStartedAt!.val
+          .difference(DateTime.now())
+          .localizedString();
+    } else if (call != null && call.finishReason != null) {
+      title = call.finishReason!.localizedString(call.author.id == widget.me) ??
+          title;
+      isMissed = call.finishReason == ChatCallFinishReason.dropped ||
+          call.finishReason == ChatCallFinishReason.unanswered;
 
-        if (isOngoing) {
-          title = 'label_chat_call_ongoing'.l10n;
-          time = call!.conversationStartedAt!.val
-              .difference(DateTime.now())
-              .localizedString();
-        } else if (call != null && call.finishReason != null) {
-          title =
-              call.finishReason!.localizedString(call.author.id == widget.me) ??
-                  title;
-          isMissed = call.finishReason == ChatCallFinishReason.dropped ||
-              call.finishReason == ChatCallFinishReason.unanswered;
+      if (call.finishedAt != null && call.conversationStartedAt != null) {
+        time = call.finishedAt!.val
+            .difference(call.conversationStartedAt!.val)
+            .localizedString();
+      }
+    } else {
+      title = call == null
+          ? title
+          : call.author.id == widget.me
+              ? 'label_outgoing_call'.l10n
+              : 'label_incoming_call'.l10n;
+    }
 
-          if (call.finishedAt != null && call.conversationStartedAt != null) {
-            time = call.finishedAt!.val
-                .difference(call.conversationStartedAt!.val)
-                .localizedString();
-          }
-        } else {
-          title = call == null
-              ? title
-              : call.author.id == widget.me
-                  ? 'label_outgoing_call'.l10n
-                  : 'label_incoming_call'.l10n;
+    if (isOngoing && !Config.disableInfiniteAnimations) {
+      _ongoingCallTimer ??= FixedTimer.periodic(1.seconds, () {
+        if (mounted) {
+          setState(() {});
         }
+      });
+    } else {
+      _ongoingCallTimer?.cancel();
+    }
 
-        if (isOngoing && !Config.disableInfiniteAnimations) {
-          _ongoingCallTimer ??= FixedTimer.periodic(1.seconds, () {
-            if (mounted) {
-              setState(() {});
-            }
-          });
-        } else {
-          _ongoingCallTimer?.cancel();
-        }
-
-        return Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(right: 8),
-              child: SvgIcon(
-                (call?.withVideo ?? false)
-                    ? isMissed
-                        ? SvgIcons.callVideoMissed
-                        : SvgIcons.callVideo
-                    : isMissed
-                        ? SvgIcons.callAudioMissed
-                        : SvgIcons.callAudio,
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(right: 8),
+          child: SvgIcon(
+            (call?.withVideo ?? false)
+                ? isMissed
+                    ? SvgIcons.callVideoMissed
+                    : SvgIcons.callVideo
+                : isMissed
+                    ? SvgIcons.callAudioMissed
+                    : SvgIcons.callAudio,
+          ),
+        ),
+        Flexible(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Flexible(
+                child: Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: style.fonts.medium.regular.onBackground,
+                ),
               ),
-            ),
-            Flexible(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Flexible(
-                    child: Text(
-                      title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: style.fonts.medium.regular.onBackground,
-                    ),
+              if (time != null) ...[
+                const SizedBox(width: 8),
+                Padding(
+                  padding: const EdgeInsets.only(top: 2.5),
+                  child: Stack(
+                    alignment: Alignment.topRight,
+                    children: [
+                      Text(
+                        time,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: style.fonts.normal.regular.secondary,
+                      ).fixedDigits(),
+                    ],
                   ),
-                  if (time != null) ...[
-                    const SizedBox(width: 8),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 2.5),
-                      child: Stack(
-                        alignment: Alignment.topRight,
-                        children: [
-                          Text(
-                            time,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: style.fonts.normal.regular.secondary,
-                          ).fixedDigits(),
-                        ],
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-            const SizedBox(width: 2),
-          ],
-        );
-      },
+                ),
+              ],
+            ],
+          ),
+        ),
+        const SizedBox(width: 2),
+      ],
     );
+  }
+
+  /// Fetches the [_item].
+  Future<void> _fetchItem() async {
+    final futureOrItem = widget.getItem!(widget.call!.id);
+    if (futureOrItem is Rx<ChatItem>?) {
+      _item = futureOrItem;
+    } else {
+      _item = await futureOrItem;
+    }
+
+    if (mounted) {
+      setState(() {});
+    }
   }
 }
 


### PR DESCRIPTION
## Synopsis

`ChatCallWidget` doesn't rebuild every second, as it should be.




## Solution

This PR removes the `FutureBuilder` and adds `Obx` monitoring `ChatCall` changes, so that the timer gets always assigned as it should be.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
