### PR TITLE
Fix finished `ChatCall`s being rapidly displayed on `Chats` tab during synchronization

### DIFF
--- a/lib/api/backend/graphql/fragments/ChatEventsVersioned.graphql
+++ b/lib/api/backend/graphql/fragments/ChatEventsVersioned.graphql
@@ -253,6 +253,9 @@ fragment ChatEventsVersioned on ChatEventsVersioned {
             }
             at
         }
+        ... on EventChatCallAnswerTimeoutPassed {
+            callId
+        }
     }
     ver
 }

--- a/lib/store/call.dart
+++ b/lib/store/call.dart
@@ -137,6 +137,17 @@ class CallRepository extends DisposableInterface
       return null;
     }
 
+    // If dialing has already ended, then notification shouldn't be displayed.
+    if (call.dialed == null) {
+      return null;
+    } else if (call.dialed is ChatMembersDialedConcrete) {
+      if ((call.dialed as ChatMembersDialedConcrete)
+          .members
+          .none((e) => e.user.id == me)) {
+        return null;
+      }
+    }
+
     if (ongoing == null) {
       ongoing = Rx<OngoingCall>(
         OngoingCall(

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -1525,6 +1525,10 @@ class ChatRepository extends DisposableInterface
         node.at,
         node.call.toModel(),
       );
+    } else if (e.$$typename == 'EventChatCallAnswerTimeoutPassed') {
+      var node =
+          e as ChatEventsVersionedMixin$Events$EventChatCallAnswerTimeoutPassed;
+      return EventChatCallAnswerTimeoutPassed(e.chatId, node.callId);
     } else {
       throw UnimplementedError('Unknown ChatEvent: ${e.$$typename}');
     }
@@ -1800,7 +1804,6 @@ class ChatRepository extends DisposableInterface
     _paginationSubscription = _localPagination!.changes.listen((event) async {
       switch (event.op) {
         case OperationKind.added:
-        case OperationKind.updated:
           final ChatItem? last = event.value!.value.lastItem;
 
           // [Chat.ongoingCall] is set to `null` there, as it's locally fetched,
@@ -1817,6 +1820,9 @@ class ChatRepository extends DisposableInterface
             ),
             pagination: true,
           );
+
+        case OperationKind.updated:
+          await _putEntry(ChatData(event.value!, null, null), pagination: true);
           break;
 
         case OperationKind.removed:

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -1804,23 +1804,6 @@ class ChatRepository extends DisposableInterface
     _paginationSubscription = _localPagination!.changes.listen((event) async {
       switch (event.op) {
         case OperationKind.added:
-          final ChatItem? last = event.value!.value.lastItem;
-
-          // [Chat.ongoingCall] is set to `null` there, as it's locally fetched,
-          // and might not be happening remotely at all.
-          await _putEntry(
-            ChatData(
-              event.value!
-                ..value.ongoingCall = null
-                ..value.lastItem = last is ChatCall
-                    ? (last..conversationStartedAt = null)
-                    : last,
-              null,
-              null,
-            ),
-            pagination: true,
-          );
-
         case OperationKind.updated:
           await _putEntry(ChatData(event.value!, null, null), pagination: true);
           break;

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -1697,7 +1697,7 @@ class RxChatImpl extends RxChat {
             _eventsDebounce = debounce(_debouncedEvents, (events) {
               if (_eventsDebounce?.disposed == false) {
                 Log.debug(
-                  '_initRemoteSubscription(): debounced with ${events.expand((e) => e.events)}',
+                  '_initRemoteSubscription(): debounced with ${events.expand((e) => e.events).map((e) => e.kind)}',
                   '$runtimeType($id)',
                 );
 

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -1705,8 +1705,15 @@ class RxChatImpl extends RxChat {
                 _eventsDebounce = null;
                 _justSubscribed = false;
 
-                for (var e in events) {
-                  _chatEvent(ChatEventsEvent(e));
+                if (events.isNotEmpty) {
+                  _chatEvent(
+                    ChatEventsEvent(
+                      ChatEventsVersioned(
+                        events.expand((e) => e.events).toList(),
+                        events.first.ver,
+                      ),
+                    ),
+                  );
                 }
               }
             });

--- a/lib/store/event/chat.dart
+++ b/lib/store/event/chat.dart
@@ -28,6 +28,7 @@ import '/store/model/chat.dart';
 
 /// Possible kinds of a [ChatEvent].
 enum ChatEventKind {
+  callAnswerTimeoutPassed,
   callConversationStarted,
   callDeclined,
   callFinished,
@@ -539,6 +540,20 @@ class EventChatCallConversationStarted extends ChatEvent {
 
   @override
   ChatEventKind get kind => ChatEventKind.callConversationStarted;
+}
+
+/// Event of an answer timeout being reached in a [ChatCall].
+class EventChatCallAnswerTimeoutPassed extends ChatEvent {
+  const EventChatCallAnswerTimeoutPassed(
+    super.chatId,
+    this.callId,
+  );
+
+  /// ID of the [ChatCall] the conversation started in.
+  final ChatItemId callId;
+
+  @override
+  ChatEventKind get kind => ChatEventKind.callAnswerTimeoutPassed;
 }
 
 /// Edited [ChatMessageText].

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -628,6 +628,9 @@ class ChatsTabView extends StatelessWidget {
                                       getUser: c.getUser,
                                       onJoin: () => c.joinCall(chat.id),
                                       onDrop: () => c.dropCall(chat.id),
+                                      hasCall: c.status.value.isLoadingMore
+                                          ? false
+                                          : null,
                                     );
                                   }),
                                 );
@@ -845,6 +848,8 @@ class ChatsTabView extends StatelessWidget {
                                         )
                                       ]
                                     : null,
+                                hasCall:
+                                    c.status.value.isLoadingMore ? false : null,
                               );
                             }
 

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -81,6 +81,7 @@ class RecentChatTile extends StatelessWidget {
     this.onDismissed,
     Widget Function(Widget)? avatarBuilder,
     this.enableContextMenu = true,
+    this.hasCall,
   }) : avatarBuilder = avatarBuilder ?? _defaultAvatarBuilder;
 
   /// [RxChat] this [RecentChatTile] is about.
@@ -159,6 +160,11 @@ class RecentChatTile extends StatelessWidget {
   /// Indicator whether context menu should be enabled over this
   /// [RecentChatTile].
   final bool enableContextMenu;
+
+  /// Indicator whether the [RxChat] has an [OngoingCall] happening in it.
+  ///
+  /// If none specified, then [RxChat.inCall] is used.
+  final bool? hasCall;
 
   @override
   Widget build(BuildContext context) {
@@ -450,7 +456,8 @@ class RecentChatTile extends StatelessWidget {
         ];
       } else if (item != null) {
         if (item is ChatCall) {
-          final bool isOngoing = item.finishReason == null &&
+          final bool isOngoing = hasCall != false &&
+              item.finishReason == null &&
               (item.conversationStartedAt != null || !chat.isDialog);
 
           final bool isMissed =
@@ -907,7 +914,7 @@ class RecentChatTile extends StatelessWidget {
     return Obx(() {
       final Chat chat = rxChat.chat.value;
 
-      if (chat.ongoingCall == null) {
+      if (chat.ongoingCall == null || hasCall == false) {
         return const SizedBox();
       }
 

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -450,8 +450,8 @@ class RecentChatTile extends StatelessWidget {
         ];
       } else if (item != null) {
         if (item is ChatCall) {
-          final bool isOngoing =
-              item.finishReason == null && item.conversationStartedAt != null;
+          final bool isOngoing = item.finishReason == null &&
+              (item.conversationStartedAt != null || !chat.isDialog);
 
           final bool isMissed =
               item.finishReason == ChatCallFinishReason.dropped ||

--- a/test/unit/call_test.dart
+++ b/test/unit/call_test.dart
@@ -120,6 +120,10 @@ void main() async {
               'joinedAt': DateTime.now().toString(),
             }
           ],
+          'dialed': {
+            '__typename': 'ChatMembersDialedAll',
+            'answeredMembers': [],
+          },
           'ver': '1',
           'presence': 'AWAY',
           'online': {'__typename': 'UserOnline'},
@@ -216,7 +220,11 @@ void main() async {
                     }
                   ],
                   'ver': '1',
-                  'withVideo': false
+                  'withVideo': false,
+                  'dialed': {
+                    '__typename': 'ChatMembersDialedAll',
+                    'answeredMembers': [],
+                  },
                 },
                 'reason': 'UNANSWERED',
                 'at': DateTime.now().toString(),
@@ -253,6 +261,10 @@ void main() async {
             'ver': '2',
             'presence': 'AWAY',
             'online': {'__typename': 'UserOnline'},
+            'dialed': {
+              '__typename': 'ChatMembersDialedAll',
+              'answeredMembers': [],
+            },
           },
         },
       },
@@ -470,6 +482,10 @@ void main() async {
             'ver': '1',
             'presence': 'AWAY',
             'online': {'__typename': 'UserOnline'},
+            'dialed': {
+              '__typename': 'ChatMembersDialedAll',
+              'answeredMembers': [],
+            },
           },
         },
       },
@@ -508,6 +524,10 @@ void main() async {
             'ver': '2',
             'PRESENCE': 'AWAY',
             'online': {'__typename': 'UserOnline'},
+            'dialed': {
+              '__typename': 'ChatMembersDialedAll',
+              'answeredMembers': [],
+            },
           },
         },
       },
@@ -658,6 +678,10 @@ class _FakeGraphQlProvider extends MockedGraphQlProvider {
             'ver': '$latestVersion',
             'presence': 'AWAY',
             'online': {'__typename': 'UserOnline'},
+            'dialed': {
+              '__typename': 'ChatMembersDialedAll',
+              'answeredMembers': [],
+            },
           },
         },
       },
@@ -692,6 +716,10 @@ class _FakeGraphQlProvider extends MockedGraphQlProvider {
                 'ver': '$latestVersion',
                 'presence': 'AWAY',
                 'online': {'__typename': 'UserOnline'},
+                'dialed': {
+                  '__typename': 'ChatMembersDialedAll',
+                  'answeredMembers': [],
+                },
               },
             },
           ],


### PR DESCRIPTION
## Synopsis

Whenever application is being logged in, it loads the actual state of `Chat`s user has. However, if there's many call events, the chats will rapidly display those calls as being started and then being ended.




## Solution

This PR fixes some events not setting `conversationStartedAt`, `dialing` variable being ignored and fixes displaying of the already finished calls.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
