### PR TITLE
Fix restore button clipping chats on mobile platforms (#758)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Chat page:
         - Active call's duration not being refreshed every second. ([#1105])
+    - Chats tab:
+        - Restore button clipping chats on mobile platforms. ([#1108], [#758])
 - Web:
     - Inability to input chat's name during group creation. ([#1103])
 
 [#1103]: /../../pull/1103
 [#1105]: /../../pull/1105
+[#1108]: /../../pull/1108
 
 
 

--- a/lib/ui/page/home/page/chat/info/controller.dart
+++ b/lib/ui/page/home/page/chat/info/controller.dart
@@ -21,6 +21,7 @@ import 'dart:typed_data';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -243,7 +244,7 @@ class ChatInfoController extends GetxController {
   /// Opens a file choose popup and updates the [Chat.avatar] with the selected
   /// image, if any.
   Future<void> pickAvatar() async {
-    FilePickerResult? result = await FilePicker.platform.pickFiles(
+    final FilePickerResult? result = await PlatformUtils.pickFiles(
       type: FileType.image,
       withReadStream: !PlatformUtils.isWeb,
       withData: PlatformUtils.isWeb,

--- a/lib/ui/page/home/page/chat/info/controller.dart
+++ b/lib/ui/page/home/page/chat/info/controller.dart
@@ -21,7 +21,6 @@ import 'dart:typed_data';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/lib/ui/page/home/page/chat/message_field/controller.dart
+++ b/lib/ui/page/home/page/chat/message_field/controller.dart
@@ -414,7 +414,7 @@ class MessageFieldController extends GetxController {
   /// Opens a file choose popup of the specified [type] and adds the selected
   /// files to the [attachments].
   Future<void> _pickAttachment(FileType type) async {
-    FilePickerResult? result = await FilePicker.platform.pickFiles(
+    FilePickerResult? result = await PlatformUtils.pickFiles(
       type: type,
       allowMultiple: true,
       withReadStream: true,

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -404,7 +404,7 @@ class MyProfileController extends GetxController {
 
   /// Opens an image choose popup and sets the selected file as a [background].
   Future<void> pickBackground() async {
-    FilePickerResult? result = await FilePicker.platform.pickFiles(
+    FilePickerResult? result = await PlatformUtils.pickFiles(
       type: FileType.image,
       allowMultiple: false,
       withData: true,
@@ -450,7 +450,7 @@ class MyProfileController extends GetxController {
   /// Uploads an image and sets it as [MyUser.avatar] and [MyUser.callCover].
   Future<void> uploadAvatar() async {
     try {
-      FilePickerResult? result = await FilePicker.platform.pickFiles(
+      FilePickerResult? result = await PlatformUtils.pickFiles(
         type: FileType.image,
         allowMultiple: false,
         withData: true,

--- a/lib/ui/page/home/page/my_profile/welcome_field/controller.dart
+++ b/lib/ui/page/home/page/my_profile/welcome_field/controller.dart
@@ -239,7 +239,7 @@ class WelcomeFieldController extends GetxController {
   /// Opens a file choose popup of the specified [type] and adds the selected
   /// files to the [attachments].
   Future<void> _pickAttachment(FileType type) async {
-    FilePickerResult? result = await FilePicker.platform.pickFiles(
+    FilePickerResult? result = await PlatformUtils.pickFiles(
       type: type,
       allowMultiple: true,
       withReadStream: true,

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -438,7 +438,7 @@ class UserController extends GetxController {
   /// Opens a file choose popup and updates the `ChatContact.avatar` with the
   /// selected image, if any.
   Future<void> pickAvatar() async {
-    FilePickerResult? result = await FilePicker.platform.pickFiles(
+    FilePickerResult? result = await PlatformUtils.pickFiles(
       type: FileType.image,
       withReadStream: !PlatformUtils.isWeb,
       withData: PlatformUtils.isWeb,

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -308,6 +308,8 @@ class ChatsTabView extends StatelessWidget {
                                 c.search.value?.search.clear();
                                 c.search.value?.query.value = '';
                                 c.search.value?.search.focus.requestFocus();
+                              } else {
+                                c.closeSearch();
                               }
                             } else if (c.selecting.value) {
                               c.toggleSelecting();
@@ -1064,80 +1066,6 @@ class ChatsTabView extends StatelessWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Obx(() {
-                      final Widget child;
-                      final action = c.dismissed.lastOrNull;
-
-                      if (action == null) {
-                        child = const SizedBox(key: Key('NoDismissed'));
-                      } else {
-                        child = Padding(
-                          key: Key('Dismissed_${action.chat.id}'),
-                          padding: EdgeInsets.fromLTRB(
-                            10 + 10,
-                            0,
-                            10 + 10,
-                            72 + router.context!.mediaQueryViewPadding.bottom,
-                          ),
-                          child: WidgetButton(
-                            key: const Key('Restore'),
-                            onPressed: action.cancel,
-                            child: Container(
-                              key: Key('${action.chat.id}'),
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(12),
-                                color: style.colors.primary.withOpacity(0.9),
-                                boxShadow: [
-                                  CustomBoxShadow(
-                                    blurRadius: 8,
-                                    color: style.colors.onBackgroundOpacity13,
-                                    blurStyle: BlurStyle.outer.workaround,
-                                  ),
-                                ],
-                              ),
-                              height: CustomNavigationBar.height,
-                              width: double.infinity,
-                              padding: const EdgeInsets.all(16),
-                              child: Stack(
-                                alignment: Alignment.centerLeft,
-                                children: [
-                                  Stack(
-                                    alignment: Alignment.center,
-                                    children: [
-                                      SizedBox(
-                                        width: 20,
-                                        height: 20,
-                                        child: CircularProgressIndicator(
-                                          value: action.remaining.value / 5000,
-                                          color: style.colors.onPrimary,
-                                          strokeWidth: 2,
-                                        ),
-                                      ),
-                                      Text(
-                                        '${action.remaining.value ~/ 1000 + 1}',
-                                        style:
-                                            style.fonts.small.regular.onPrimary,
-                                      )
-                                    ],
-                                  ),
-                                  Center(
-                                    child: Text(
-                                      'btn_undo_delete'.l10n,
-                                      style: style.fonts.big.regular.onPrimary,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                        );
-                      }
-
-                      return SafeAnimatedSwitcher(
-                        duration: 200.milliseconds,
-                        child: child,
-                      );
-                    }),
-                    Obx(() {
                       if (c.groupCreating.value) {
                         return BottomPaddedRow(
                           children: [
@@ -1202,6 +1130,79 @@ class ChatsTabView extends StatelessWidget {
                 ),
               );
             }),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 72 + router.context!.mediaQueryViewPadding.bottom,
+              child: Obx(() {
+                final Widget child;
+                final action = c.dismissed.lastOrNull;
+
+                if (action == null) {
+                  child = const SizedBox(key: Key('NoDismissed'));
+                } else {
+                  child = Padding(
+                    key: Key('Dismissed_${action.chat.id}'),
+                    padding: const EdgeInsets.fromLTRB(10 + 10, 0, 10 + 10, 0),
+                    child: WidgetButton(
+                      key: const Key('Restore'),
+                      onPressed: action.cancel,
+                      child: Container(
+                        key: Key('${action.chat.id}'),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(12),
+                          color: style.colors.primary.withOpacity(0.9),
+                          boxShadow: [
+                            CustomBoxShadow(
+                              blurRadius: 8,
+                              color: style.colors.onBackgroundOpacity13,
+                              blurStyle: BlurStyle.outer.workaround,
+                            ),
+                          ],
+                        ),
+                        height: CustomNavigationBar.height,
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(16),
+                        child: Stack(
+                          alignment: Alignment.centerLeft,
+                          children: [
+                            Stack(
+                              alignment: Alignment.center,
+                              children: [
+                                SizedBox(
+                                  width: 20,
+                                  height: 20,
+                                  child: CircularProgressIndicator(
+                                    value: action.remaining.value / 5000,
+                                    color: style.colors.onPrimary,
+                                    strokeWidth: 2,
+                                  ),
+                                ),
+                                Text(
+                                  '${action.remaining.value ~/ 1000 + 1}',
+                                  style: style.fonts.small.regular.onPrimary,
+                                )
+                              ],
+                            ),
+                            Center(
+                              child: Text(
+                                'btn_undo_delete'.l10n,
+                                style: style.fonts.big.regular.onPrimary,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                }
+
+                return SafeAnimatedSwitcher(
+                  duration: 200.milliseconds,
+                  child: child,
+                );
+              }),
+            ),
             Obx(() {
               final Widget child;
 

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -1133,7 +1133,7 @@ class ChatsTabView extends StatelessWidget {
             Positioned(
               left: 0,
               right: 0,
-              bottom: 72 + router.context!.mediaQueryViewPadding.bottom,
+              bottom: 72,
               child: Obx(() {
                 final Widget child;
                 final action = c.dismissed.lastOrNull;
@@ -1143,7 +1143,12 @@ class ChatsTabView extends StatelessWidget {
                 } else {
                   child = Padding(
                     key: Key('Dismissed_${action.chat.id}'),
-                    padding: const EdgeInsets.fromLTRB(10 + 10, 0, 10 + 10, 0),
+                    padding: EdgeInsets.fromLTRB(
+                      10 + 10,
+                      0,
+                      10 + 10,
+                      MediaQuery.of(context).viewPadding.bottom,
+                    ),
                     child: WidgetButton(
                       key: const Key('Restore'),
                       onPressed: action.cancel,

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -613,6 +613,35 @@ class PlatformUtilsImpl {
       });
     }
   }
+
+  /// Returns the [FilePickerResult] of the file picking of the provided [type].
+  Future<FilePickerResult?> pickFiles({
+    FileType type = FileType.any,
+    bool allowCompression = true,
+    int compressionQuality = 30,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+  }) async {
+    try {
+      return await FilePicker.platform.pickFiles(
+        type: type,
+        allowCompression: allowCompression,
+        compressionQuality: compressionQuality,
+        allowMultiple: allowMultiple,
+        withData: withData,
+        withReadStream: withReadStream,
+        lockParentWindow: lockParentWindow,
+      );
+    } on PlatformException catch (e) {
+      if (e.code == 'already_active') {
+        return null;
+      } else {
+        rethrow;
+      }
+    }
+  }
 }
 
 /// Determining whether a [BuildContext] is mobile or not.

--- a/test/e2e/steps/scroll_until.dart
+++ b/test/e2e/steps/scroll_until.dart
@@ -101,28 +101,36 @@ Future<void> _scrollScrollableTo(
   StepContext<CustomWorld> context,
   double Function(ScrollPosition) getPosition,
 ) async {
-  await context.world.appDriver.waitForAppToSettle();
+  await context.world.appDriver.waitUntil(() async {
+    await context.world.appDriver.waitForAppToSettle();
 
-  final Finder scrollable = find.descendant(
-    of: find.byKey(Key(key.name)),
-    matching: find.byWidgetPredicate((widget) {
-      // TODO: Find a proper way to differentiate [Scrollable]s from
-      //       [TextField]s:
-      //       https://github.com/flutter/flutter/issues/76981
-      if (widget is Scrollable) {
-        return widget.restorationId == null;
-      }
+    final Finder scrollable = find.descendant(
+      of: find.byKey(Key(key.name)),
+      matching: find.byWidgetPredicate((widget) {
+        // TODO: Find a proper way to differentiate [Scrollable]s from
+        //       [TextField]s:
+        //       https://github.com/flutter/flutter/issues/76981
+        if (widget is Scrollable) {
+          return widget.restorationId == null;
+        }
+        return false;
+      }),
+    );
+
+    if (!scrollable.tryEvaluate()) {
       return false;
-    }),
-  );
+    }
 
-  final ScrollableState state =
-      context.world.appDriver.nativeDriver.state(scrollable) as ScrollableState;
-  final ScrollPosition position = state.position;
+    final ScrollableState state = context.world.appDriver.nativeDriver
+        .state(scrollable) as ScrollableState;
+    final ScrollPosition position = state.position;
 
-  position.jumpTo(getPosition(position));
+    position.jumpTo(getPosition(position));
 
-  await context.world.appDriver.waitForAppToSettle();
+    await context.world.appDriver.waitForAppToSettle();
+
+    return true;
+  });
 }
 
 /// Extension fixing the [AppDriverAdapter.scrollUntilVisible] by adding its


### PR DESCRIPTION
Resolves #758




## Synopsis

Chats are being clipped when `restore` button is displayed on mobile platforms.




## Solution

This PR fixes the layout issue.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
