### PR TITLE
Separate `Call` fullscreen from `PlatformUtils.onFullscreenChanged` (#853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Chat page:
         - File sizes displayed in B, KB, MB, GB or PB. ([#1115], [#603])
+    - Media panel:
+        - Fullscreen mode separated from application's fullscreen. ([#1123], [#853])
 
 ### Fixed
 
@@ -36,11 +38,13 @@ All user visible changes to this project will be documented in this file. This p
 [#568]: /../../issues/568
 [#603]: /../../issues/603
 [#692]: /../../issues/692
+[#853]: /../../issues/853
 [#1112]: /../../pull/1112
 [#1115]: /../../pull/1115
 [#1116]: /../../pull/1116
 [#1117]: /../../pull/1117
 [#1120]: /../../pull/1120
+[#1123]: /../../pull/1123
 
 
 

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -687,10 +687,12 @@ class CallController extends GetxController {
       refresh();
     });
 
-    _onFullscreenChange = PlatformUtils.onFullscreenChange.listen((bool v) {
-      fullscreen.value = v;
-      refresh();
-    });
+    if (WebUtils.isPopup) {
+      _onFullscreenChange = PlatformUtils.onFullscreenChange.listen((bool v) {
+        fullscreen.value = v;
+        refresh();
+      });
+    }
 
     _onWindowFocus = WebUtils.onWindowFocus.listen((e) {
       if (!e) {
@@ -874,7 +876,7 @@ class CallController extends GetxController {
       Rect.fromLTWH(left.value, top.value, width.value, height.value),
     );
 
-    if (fullscreen.value) {
+    if (WebUtils.isPopup && fullscreen.value) {
       PlatformUtils.exitFullscreen();
     }
 
@@ -1040,10 +1042,16 @@ class CallController extends GetxController {
   Future<void> toggleFullscreen() async {
     if (fullscreen.isTrue) {
       fullscreen.value = false;
-      await PlatformUtils.exitFullscreen();
+
+      if (WebUtils.isPopup) {
+        await PlatformUtils.exitFullscreen();
+      }
     } else {
       fullscreen.value = true;
-      await PlatformUtils.enterFullscreen();
+
+      if (WebUtils.isPopup) {
+        await PlatformUtils.enterFullscreen();
+      }
     }
 
     updateSecondaryAttach();

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -1056,6 +1056,8 @@ class CallController extends GetxController {
 
     updateSecondaryAttach();
     applySecondaryConstraints();
+
+    refresh();
   }
 
   /// Invokes [focusAll], moving every [Participant] to their `default`, or


### PR DESCRIPTION
Resolves #853




## Synopsis

Call's fullscreen is tied to application's fullscreen. This caused bad UX.




## Solution

This PR omits using the application's fullscreen in `Call` on desktop.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
