### PR TITLE
Display `SystemMouseCursors.click` over `FloatingSnackBar` when `onPressed` is set (#1124)

### DIFF
--- a/lib/ui/widget/floating_snack_bar.dart
+++ b/lib/ui/widget/floating_snack_bar.dart
@@ -128,21 +128,26 @@ class _FloatingSnackBarState extends State<FloatingSnackBar>
                 opacity: _opacity,
                 duration: const Duration(milliseconds: 120),
                 onEnd: _onEnd,
-                child: Container(
-                  padding: const EdgeInsets.fromLTRB(24, 8, 24, 8),
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(20),
-                    color: style.cardColor.darken(0.03),
-                    border: style.cardHoveredBorder,
-                    boxShadow: [
-                      BoxShadow(
-                        color: style.colors.onBackgroundOpacity20,
-                        blurRadius: 8,
-                        blurStyle: BlurStyle.outer.workaround,
-                      ),
-                    ],
+                child: MouseRegion(
+                  cursor: widget.onPressed == null
+                      ? MouseCursor.defer
+                      : SystemMouseCursors.click,
+                  child: Container(
+                    padding: const EdgeInsets.fromLTRB(24, 8, 24, 8),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(20),
+                      color: style.cardColor.darken(0.03),
+                      border: style.cardHoveredBorder,
+                      boxShadow: [
+                        BoxShadow(
+                          color: style.colors.onBackgroundOpacity20,
+                          blurRadius: 8,
+                          blurStyle: BlurStyle.outer.workaround,
+                        ),
+                      ],
+                    ),
+                    child: widget.child,
                   ),
-                  child: widget.child,
                 ),
               ),
             ),


### PR DESCRIPTION
Resolves #1124




## Synopsis

`FloatingSnackBar` doesn't indicate the fact that it can be clicked. 




## Solution

This PR adds `MouseRegion` over the widget.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
