### PR TITLE
Invoke `enterFullscreen()` and `exitFullscreen()` methods of `PlatformUtils` when `CallController.fullscreen` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Chat page:
         - File sizes displayed in B, KB, MB, GB or PB. ([#1115], [#603])
-    - Media panel:
-        - Fullscreen mode separated from application's fullscreen. ([#1123], [#853])
 
 ### Fixed
 
@@ -41,14 +39,12 @@ All user visible changes to this project will be documented in this file. This p
 [#568]: /../../issues/568
 [#603]: /../../issues/603
 [#692]: /../../issues/692
-[#853]: /../../issues/853
 [#1112]: /../../pull/1112
 [#1115]: /../../pull/1115
 [#1116]: /../../pull/1116
 [#1117]: /../../pull/1117
 [#1120]: /../../pull/1120
 [#1121]: /../../pull/1121
-[#1123]: /../../pull/1123
 
 
 

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -687,12 +687,10 @@ class CallController extends GetxController {
       refresh();
     });
 
-    if (WebUtils.isPopup) {
-      _onFullscreenChange = PlatformUtils.onFullscreenChange.listen((bool v) {
-        fullscreen.value = v;
-        refresh();
-      });
-    }
+    _onFullscreenChange = PlatformUtils.onFullscreenChange.listen((bool v) {
+      fullscreen.value = v;
+      refresh();
+    });
 
     _onWindowFocus = WebUtils.onWindowFocus.listen((e) {
       if (!e) {
@@ -876,7 +874,7 @@ class CallController extends GetxController {
       Rect.fromLTWH(left.value, top.value, width.value, height.value),
     );
 
-    if (WebUtils.isPopup && fullscreen.value) {
+    if (fullscreen.value) {
       PlatformUtils.exitFullscreen();
     }
 
@@ -1042,16 +1040,10 @@ class CallController extends GetxController {
   Future<void> toggleFullscreen() async {
     if (fullscreen.isTrue) {
       fullscreen.value = false;
-
-      if (WebUtils.isPopup) {
-        await PlatformUtils.exitFullscreen();
-      }
+      await PlatformUtils.exitFullscreen();
     } else {
       fullscreen.value = true;
-
-      if (WebUtils.isPopup) {
-        await PlatformUtils.enterFullscreen();
-      }
+      await PlatformUtils.enterFullscreen();
     }
 
     updateSecondaryAttach();


### PR DESCRIPTION
Related to #1123




## Synopsis

#1123 is no good.




## Solution

This PR reverts the change.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
