### PR TITLE
Use `WebUtils.pingCall()` to determine `PopupCall`s being active or stale (#1095)

### DIFF
--- a/lib/ui/page/popup_call/controller.dart
+++ b/lib/ui/page/popup_call/controller.dart
@@ -52,6 +52,9 @@ class PopupCallController extends GetxController {
   /// the browser's storage.
   late final Worker _stateWorker;
 
+  /// [Timer] invoking [WebUtils.pingCall] so it stays active to other tabs.
+  Timer? _pingTimer;
+
   /// Returns ID of the authenticated [MyUser].
   UserId get me => _calls.me;
 
@@ -104,6 +107,12 @@ class PopupCallController extends GetxController {
 
     _tryToConnect();
     WakelockPlus.enable().onError((_, __) => false);
+
+    _pingTimer = Timer.periodic(
+      const Duration(milliseconds: 500),
+      (_) => WebUtils.pingCall(chatId),
+    );
+
     super.onInit();
   }
 
@@ -111,6 +120,7 @@ class PopupCallController extends GetxController {
   void onClose() {
     WakelockPlus.disable().onError((_, __) => false);
     _storageSubscription?.cancel();
+    _pingTimer?.cancel();
     _stateWorker.dispose();
     if (call != null) {
       WebUtils.removeCall(call!.value.chatId.value);

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -178,6 +178,12 @@ class WebUtils {
     // No-op.
   }
 
+  /// Ensures a call in the provided [chatId] is considered active the browser's
+  /// storage.
+  static void pingCall(ChatId chatId) {
+    // No-op.
+  }
+
   /// Removes a call identified by the provided [chatId] from the browser's
   /// storage.
   static void removeCall(ChatId chatId) {

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -537,23 +537,37 @@ class WebUtils {
   /// Returns a call identified by the provided [chatId] from the browser's
   /// storage.
   static WebStoredCall? getCall(ChatId chatId) {
-    var data = web.window.localStorage['call_$chatId'];
+    final data = web.window.localStorage['call_$chatId'];
     if (data != null) {
-      return WebStoredCall.fromJson(json.decode(data));
+      final at = web.window.localStorage['at_call_$chatId'];
+      final updatedAt = at == null ? DateTime.now() : DateTime.parse(at);
+      if (DateTime.now().difference(updatedAt).inSeconds <= 2) {
+        return WebStoredCall.fromJson(json.decode(data));
+      }
     }
 
     return null;
   }
 
   /// Stores the provided [call] in the browser's storage.
-  static void setCall(WebStoredCall call) =>
-      web.window.localStorage['call_${call.chatId}'] =
-          json.encode(call.toJson());
+  static void setCall(WebStoredCall call) {
+    web.window.localStorage['call_${call.chatId}'] = json.encode(call.toJson());
+    web.window.localStorage['at_call_${call.chatId}'] =
+        DateTime.now().add(const Duration(seconds: 5)).toString();
+  }
+
+  /// Ensures a call in the provided [chatId] is considered active the browser's
+  /// storage.
+  static void pingCall(ChatId chatId) {
+    web.window.localStorage['at_call_$chatId'] = DateTime.now().toString();
+  }
 
   /// Removes a call identified by the provided [chatId] from the browser's
   /// storage.
-  static void removeCall(ChatId chatId) =>
-      web.window.localStorage.removeItem('call_$chatId');
+  static void removeCall(ChatId chatId) {
+    web.window.localStorage.removeItem('call_$chatId');
+    web.window.localStorage.removeItem('at_call_$chatId');
+  }
 
   /// Moves a call identified by its [chatId] to the [newChatId] replacing its
   /// stored state with an optional [newState].
@@ -580,8 +594,7 @@ class WebUtils {
 
   /// Indicates whether the browser's storage contains a call identified by the
   /// provided [chatId].
-  static bool containsCall(ChatId chatId) =>
-      web.window.localStorage.getItem('call_$chatId') != null;
+  static bool containsCall(ChatId chatId) => getCall(chatId) != null;
 
   /// Indicates whether the browser's storage contains any calls.
   static bool containsCalls() {

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -541,7 +541,7 @@ class WebUtils {
     if (data != null) {
       final at = web.window.localStorage['at_call_$chatId'];
       final updatedAt = at == null ? DateTime.now() : DateTime.parse(at);
-      if (DateTime.now().difference(updatedAt).inSeconds <= 2) {
+      if (DateTime.now().difference(updatedAt).inSeconds <= 1) {
         return WebStoredCall.fromJson(json.decode(data));
       }
     }

--- a/lib/util/web/web_utils.dart
+++ b/lib/util/web/web_utils.dart
@@ -17,10 +17,7 @@
 
 import '/domain/model/chat.dart';
 import '/domain/model/chat_call.dart';
-import '/domain/model/chat_item.dart';
 import '/domain/model/ongoing_call.dart';
-import '/domain/model/precise_date_time/precise_date_time.dart';
-import '/domain/model/user.dart';
 
 export 'non_web.dart' if (dart.library.js_interop) 'web.dart';
 
@@ -62,56 +59,7 @@ class WebStoredCall {
   factory WebStoredCall.fromJson(Map<dynamic, dynamic> data) {
     return WebStoredCall(
       chatId: ChatId(data['chatId']),
-      call: data['call'] == null
-          ? null
-          : ChatCall(
-              ChatItemId(data['call']['id']),
-              ChatId(data['call']['chatId']),
-              User(
-                UserId(data['call']['author']['id']),
-                UserNum(data['call']['author']['num']),
-                name: data['call']['author']['name'] == null
-                    ? null
-                    : UserName(data['call']['author']['name']),
-              ),
-              PreciseDateTime.parse(data['call']['at']),
-              members: (data['call']['members'] as List<dynamic>)
-                  .map((e) => ChatCallMember(
-                        user: User(
-                          UserId(e['user']['id']),
-                          UserNum(e['user']['num']),
-                        ),
-                        handRaised: e['handRaised'],
-                        joinedAt: PreciseDateTime.parse(e['joinedAt']),
-                      ))
-                  .toList(),
-              withVideo: data['call']['withVideo'],
-              dialed: data['call']['dialed'] == null
-                  ? null
-                  : data['call']['dialed']['type'] == 'ChatMembersDialedAll'
-                      ? ChatMembersDialedAll(
-                          (data['call']['dialed']['members'] as List<dynamic>)
-                              .map((e) => ChatMember(
-                                    User(
-                                      UserId(e['user']['id']),
-                                      UserNum(e['user']['num']),
-                                    ),
-                                    PreciseDateTime.parse(e['joinedAt']),
-                                  ))
-                              .toList(),
-                        )
-                      : ChatMembersDialedConcrete(
-                          (data['call']['dialed']['members'] as List<dynamic>)
-                              .map((e) => ChatMember(
-                                    User(
-                                      UserId(e['user']['id']),
-                                      UserNum(e['user']['num']),
-                                    ),
-                                    PreciseDateTime.parse(e['joinedAt']),
-                                  ))
-                              .toList(),
-                        ),
-            ),
+      call: data['call'] == null ? null : ChatCall.fromJson(data['call']),
       creds: data['creds'] == null ? null : ChatCallCredentials(data['creds']),
       deviceId:
           data['deviceId'] == null ? null : ChatCallDeviceId(data['deviceId']),
@@ -140,49 +88,7 @@ class WebStoredCall {
   Map<String, dynamic> toJson() {
     return {
       'chatId': chatId.val,
-      'call': call == null
-          ? null
-          : {
-              'id': call!.id.val,
-              'chatId': call!.chatId.val,
-              'at': call!.at.toString(),
-              'author': {
-                'id': call!.author.id.val,
-                'num': call!.author.num.val,
-                'name': call!.author.name?.val,
-              },
-              'members': call!.members
-                  .map((e) => {
-                        'user': {
-                          'id': e.user.id.val,
-                          'num': e.user.num.val,
-                        },
-                        'handRaised': e.handRaised,
-                        'joinedAt': e.joinedAt.toString(),
-                      })
-                  .toList(),
-              'withVideo': call!.withVideo,
-              'dialed': call!.dialed == null
-                  ? null
-                  : {
-                      'type': '${call!.dialed.runtimeType}',
-                      'members': (call!.dialed is ChatMembersDialedAll
-                              ? (call!.dialed as ChatMembersDialedAll)
-                                  .answeredMembers
-                              : (call!.dialed as ChatMembersDialedConcrete)
-                                  .members)
-                          .map(
-                            (e) => {
-                              'user': {
-                                'id': e.user.id.val,
-                                'num': e.user.num.val
-                              },
-                              'joinedAt': e.joinedAt.toString(),
-                            },
-                          )
-                          .toList(),
-                    },
-            },
+      'call': call?.toJson(),
       'creds': creds?.val,
       'deviceId': deviceId?.val,
       'state': state.index,


### PR DESCRIPTION
Resolves #1095




## Synopsis

Popup calls might be considered as still alive, causing `Call is being used in a popup` error when trying to reconnect.




## Solution

This PR adds a mechanism for determining the popup calls as really being active or stale by using timestamps.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
