### PR TITLE
Fix `_lastReadItemCursor` not being updated

### DIFF
--- a/lib/provider/drift/chat_item.dart
+++ b/lib/provider/drift/chat_item.dart
@@ -161,6 +161,26 @@ class ChatItemDriftProvider extends DriftProviderBaseWithScope {
     }, tag: 'chat_item.read($id)');
   }
 
+  /// Returns the [DtoChatItem] stored in the database by the provided [at], if
+  /// any.
+  Future<DtoChatItem?> readAt(PreciseDateTime at) async {
+    return await safe<DtoChatItem?>((db) async {
+      final stmt = db.select(db.chatItems)
+        ..where(
+          (u) => u.at.isSmallerOrEqual(Variable(at.microsecondsSinceEpoch)),
+        )
+        ..orderBy([(u) => OrderingTerm.desc(u.at)])
+        ..limit(1);
+      final ChatItemRow? row = await stmt.getSingleOrNull();
+
+      if (row == null) {
+        return null;
+      }
+
+      return _ChatItemDb.fromDb(row);
+    }, tag: 'chat_item.readAt($at)');
+  }
+
   /// Deletes the [DtoChatItem] identified by the provided [id] from the
   /// database.
   Future<void> delete(ChatItemId id) async {

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -665,6 +665,9 @@ class RxChatImpl extends RxChat {
         () async {
           try {
             await _chatRepository.readUntil(id, untilId);
+
+            final DtoChatItem? item = await _driftItems.read(untilId);
+            _lastReadItemCursor = item?.cursor ?? _lastReadItemCursor;
           } catch (_) {
             chat.update((e) => e?..lastReadItem = lastReadItem);
             unreadCount.value = chat.value.unreadCount;
@@ -1740,7 +1743,7 @@ class RxChatImpl extends RxChat {
           members.values.firstWhereOrNull((e) => e.user.id == readId);
 
       // Only proceed, if the [ChatMember] this event represents
-      // joined earlier that latest acquired message.
+      // joined earlier than latest acquired message.
       if (member?.joinedAt.isAfter(at) != true) {
         if (read == null) {
           reads.add(LastChatRead(readId, at));
@@ -2177,6 +2180,11 @@ class RxChatImpl extends RxChat {
                 );
               } else {
                 lastRead.at = event.at;
+              }
+
+              if (event.byUser.id == me) {
+                final DtoChatItem? item = await _driftItems.readAt(event.at);
+                _lastReadItemCursor = item?.cursor ?? _lastReadItemCursor;
               }
               break;
 

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -887,6 +887,7 @@ class RxChatImpl extends RxChat {
     Log.debug('updateChat($newChat)', '$runtimeType($id)');
 
     if (chat.value.id != newChat.value.id) {
+      dto = newChat;
       chat.value = newChat.value;
       ver = newChat.ver;
 


### PR DESCRIPTION
## Synopsis

`RxChat` doesn't update its last read item cursor, causing initial `around()` to fetch previous pages of items.




## Solution

This PR adds updating of the cursor when receiving the read event and invoking `read()` mutation.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
