### PR TITLE
Fix `RecentChatTile` displayed as selected in `Chats` selecting mode

### DIFF
--- a/helm/messenger/Chart.yaml
+++ b/helm/messenger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: messenger
 description: Open-source front-end part of messenger by team113.
 version: 0.1.3
-appVersion: 0.2.2
+appVersion: 0.2.3
 type: application
 sources:
   - https://github.com/team113/messenger

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -1255,7 +1255,11 @@ class ChatRepository extends DisposableInterface
             _chat(await _graphQlProvider.createMonologChat());
 
         id = monolog.chat.value.id;
-        await _monologLocal.upsert(me, this.monolog = id);
+
+        await Future.wait([
+          _monologLocal.upsert(me, this.monolog = id),
+          _putEntry(monolog, ignoreVersion: true),
+        ]);
       } else if (id.isLocal) {
         final RxChatImpl? chat = await ensureRemoteDialog(id);
         if (chat != null) {

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -812,7 +812,7 @@ class ChatsTabView extends StatelessWidget {
                                     : Key('RecentChat_${e.id}'),
                                 me: c.me,
                                 blocked: e.blocked,
-                                selected: selected,
+                                selected: c.selecting.value ? selected : null,
                                 getUser: c.getUser,
                                 avatarBuilder: c.selecting.value
                                     ? (c) => WidgetButton(

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -95,7 +95,9 @@ class RecentChatTile extends StatelessWidget {
   final bool blocked;
 
   /// Indicator whether this [RecentChatTile] is selected.
-  final bool selected;
+  ///
+  /// If `null`, then uses the [ChatIsRoute.isRoute].
+  final bool? selected;
 
   /// Indicator whether [ChatIsRoute.isRoute] should be treated as [selected].
   final bool invertible;
@@ -175,7 +177,7 @@ class RecentChatTile extends StatelessWidget {
       final String? lastRoute =
           router.routes.lastWhereOrNull((e) => e.startsWith(Routes.chats));
       final bool isRoute = chat.isRoute(lastRoute ?? '', me);
-      final bool inverted = selected || (invertible && isRoute);
+      final bool inverted = selected ?? (invertible && isRoute);
 
       return Slidable(
         key: Key(rxChat.id.val),
@@ -234,7 +236,9 @@ class RecentChatTile extends StatelessWidget {
               child: Row(
                 children: [
                   const SizedBox(height: 3),
-                  Expanded(child: _subtitle(context, selected, inverted)),
+                  Expanded(
+                    child: _subtitle(context, selected ?? false, inverted),
+                  ),
                   const SizedBox(width: 3),
                   _status(context, inverted),
                   if (!chat.id.isLocal)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.2.2
+version: 0.2.3
 publish_to: none
 
 environment:

--- a/test/e2e/steps/see_chat_avatar.dart
+++ b/test/e2e/steps/see_chat_avatar.dart
@@ -45,7 +45,7 @@ final StepDefinitionGeneric seeChatAvatarAs = then1<String, CustomWorld>(
           context.world.appDriver
               .findBy('ChatAvatar_${chat?.id}', FindType.key),
           context.world.appDriver.findBy(
-            'Image_${chat?.avatar.value?.full.url}',
+            'Image_${chat?.avatar.value?.big.url}',
             FindType.key,
           ),
           firstMatchOnly: true,


### PR DESCRIPTION
## Synopsis

`Chat` is being displayed as selected in selection mode cuz `isRoute` returns `true`.




## Solution

This PR fixes that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
