### PR TITLE
Use `CropAvatar` modal for `Chat.avatar` cropping on `ChatInfo` page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ All user visible changes to this project will be documented in this file. This p
 
 - UI:
     - Profile page:
-        - Avatar cropping. ([#1130], [#530])
+        - Avatar cropping. ([#1139], [#1130], [#530])
 
 [#530]: /../../issues/530
 [#1130]: /../../pull/1130
+[#1139]: /../../pull/1139
 
 
 

--- a/lib/domain/repository/chat.dart
+++ b/lib/domain/repository/chat.dart
@@ -20,6 +20,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:get/get.dart';
 
+import '/api/backend/schema.dart' show CropAreaInput;
 import '/domain/model/attachment.dart';
 import '/domain/model/avatar.dart';
 import '/domain/model/chat.dart';
@@ -186,6 +187,7 @@ abstract class AbstractChatRepository {
   Future<void> updateChatAvatar(
     ChatId id, {
     NativeFile? file,
+    CropAreaInput? crop,
     void Function(int count, int total)? onSendProgress,
   });
 

--- a/lib/domain/service/chat.dart
+++ b/lib/domain/service/chat.dart
@@ -20,7 +20,7 @@ import 'dart:async';
 import 'package:get/get.dart';
 
 import '/api/backend/schema.dart'
-    show DeleteChatMessageErrorCode, DeleteChatForwardErrorCode;
+    show CropAreaInput, DeleteChatForwardErrorCode, DeleteChatMessageErrorCode;
 import '/domain/model/attachment.dart';
 import '/domain/model/chat.dart';
 import '/domain/model/chat_item.dart';
@@ -389,13 +389,18 @@ class ChatService extends DisposableService {
   Future<void> updateChatAvatar(
     ChatId id, {
     NativeFile? file,
+    CropAreaInput? crop,
     void Function(int count, int total)? onSendProgress,
   }) async {
-    Log.debug('updateChatAvatar($id, $file, onSendProgress)', '$runtimeType');
+    Log.debug(
+      'updateChatAvatar($id, $file, crop: $crop, onSendProgress)',
+      '$runtimeType',
+    );
 
     await _chatRepository.updateChatAvatar(
       id,
       file: file,
+      crop: crop,
       onSendProgress: onSendProgress,
     );
   }

--- a/lib/provider/gql/components/chat.dart
+++ b/lib/provider/gql/components/chat.dart
@@ -1264,14 +1264,19 @@ mixin ChatGraphQlMixin {
   Future<ChatEventsVersionedMixin?> updateChatAvatar(
     ChatId id, {
     dio.MultipartFile? file,
+    CropAreaInput? crop,
     void Function(int count, int total)? onSendProgress,
   }) async {
     Log.debug(
-      'updateChatAvatar($id, $file, onSendProgress)',
+      'updateChatAvatar($id, $file, $crop, onSendProgress)',
       '$runtimeType',
     );
 
-    final variables = UpdateChatAvatarArguments(chatId: id, file: null);
+    final variables = UpdateChatAvatarArguments(
+      chatId: id,
+      file: null,
+      crop: crop,
+    );
     final query = MutationOptions(
       operationName: 'UpdateChatAvatar',
       document: UpdateChatAvatarMutation(variables: variables).document,

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -972,10 +972,11 @@ class ChatRepository extends DisposableInterface
   Future<void> updateChatAvatar(
     ChatId id, {
     NativeFile? file,
+    CropAreaInput? crop,
     void Function(int count, int total)? onSendProgress,
   }) async {
     Log.debug(
-      'updateChatAvatar($id, $file, onSendProgress)',
+      'updateChatAvatar($id, $file, crop: $crop, onSendProgress)',
       '$runtimeType',
     );
 
@@ -1025,6 +1026,7 @@ class ChatRepository extends DisposableInterface
       await _graphQlProvider.updateChatAvatar(
         id,
         file: file == null ? null : upload,
+        crop: crop,
         onSendProgress: onSendProgress,
       );
     } catch (e) {

--- a/lib/ui/page/home/page/chat/info/controller.dart
+++ b/lib/ui/page/home/page/chat/info/controller.dart
@@ -26,8 +26,10 @@ import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '/api/backend/schema.dart' show CropAreaInput;
 import '/config.dart';
 import '/domain/model/chat.dart';
+import '/domain/model/file.dart';
 import '/domain/model/mute_duration.dart';
 import '/domain/model/my_user.dart';
 import '/domain/model/native_file.dart';
@@ -46,7 +48,9 @@ import '/domain/service/my_user.dart';
 import '/l10n/l10n.dart';
 import '/provider/gql/exceptions.dart';
 import '/routes.dart';
+import '/ui/page/home/page/my_profile/crop_avatar/view.dart';
 import '/ui/widget/text_field.dart';
+import '/ui/worker/cache.dart';
 import '/util/message_popup.dart';
 import '/util/obs/obs.dart';
 import '/util/platform_utils.dart';
@@ -79,7 +83,7 @@ class ChatInfoController extends GetxController {
   final Rx<RxStatus> status = Rx<RxStatus>(RxStatus.loading());
 
   /// Status of the [Chat.avatar] upload or removal.
-  final Rx<RxStatus> avatar = Rx<RxStatus>(RxStatus.empty());
+  final Rx<RxStatus> avatarUpload = Rx<RxStatus>(RxStatus.empty());
 
   /// [ScrollController] to pass to a [Scrollbar].
   final ScrollController scrollController = ScrollController();
@@ -245,13 +249,13 @@ class ChatInfoController extends GetxController {
   Future<void> pickAvatar() async {
     final FilePickerResult? result = await PlatformUtils.pickFiles(
       type: FileType.image,
-      withReadStream: !PlatformUtils.isWeb,
-      withData: PlatformUtils.isWeb,
+      allowMultiple: false,
+      withData: true,
       lockParentWindow: true,
     );
 
     if (result != null) {
-      updateChatAvatar(result.files.first);
+      await updateChatAvatar(result.files.first);
     }
   }
 
@@ -261,19 +265,29 @@ class ChatInfoController extends GetxController {
   /// Updates the [Chat.avatar] with the provided [image], or resets it to
   /// `null`.
   Future<void> updateChatAvatar(PlatformFile? image) async {
-    avatar.value = RxStatus.loading();
+    avatarUpload.value = RxStatus.loading();
 
     try {
+      CropAreaInput? crop;
+
+      if (image != null) {
+        crop = await CropAvatarView.show(router.context!, image.bytes!);
+        if (crop == null) {
+          return;
+        }
+      }
+
       await _chatService.updateChatAvatar(
         chatId,
         file: image == null ? null : NativeFile.fromPlatformFile(image),
+        crop: crop,
       );
 
-      avatar.value = RxStatus.empty();
+      avatarUpload.value = RxStatus.empty();
     } on UpdateChatAvatarException catch (e) {
-      avatar.value = RxStatus.error(e.toMessage());
+      avatarUpload.value = RxStatus.error(e.toMessage());
     } catch (e) {
-      avatar.value = RxStatus.empty();
+      avatarUpload.value = RxStatus.empty();
       MessagePopup.error(e);
       rethrow;
     }
@@ -478,6 +492,43 @@ class ChatInfoController extends GetxController {
     _highlightTimer = Timer(_highlightTimeout, () {
       highlighted.value = null;
     });
+  }
+
+  /// Opens the [CropAvatarView] to update the [MyUser.avatar] with the
+  /// [CropAreaInput] returned from it.
+  Future<void> editAvatar() async {
+    final ImageFile? file = chat?.chat.value.avatar?.original;
+    if (file == null) {
+      return;
+    }
+
+    avatarUpload.value = RxStatus.loading();
+
+    try {
+      final CacheEntry cache = await CacheWorker.instance.get(
+        url: file.url,
+        checksum: file.checksum,
+      );
+
+      if (cache.bytes != null) {
+        final CropAreaInput? crop =
+            await CropAvatarView.show(router.context!, cache.bytes!);
+
+        if (crop != null) {
+          await _chatService.updateChatAvatar(
+            chatId,
+            file: NativeFile(
+              name: file.name,
+              size: cache.bytes!.lengthInBytes,
+              bytes: cache.bytes,
+            ),
+            crop: crop,
+          );
+        }
+      }
+    } finally {
+      avatarUpload.value = RxStatus.empty();
+    }
   }
 
   /// Fetches the [chat].

--- a/lib/ui/page/home/page/chat/info/controller.dart
+++ b/lib/ui/page/home/page/chat/info/controller.dart
@@ -255,7 +255,15 @@ class ChatInfoController extends GetxController {
     );
 
     if (result != null) {
-      await updateChatAvatar(result.files.first);
+      final PlatformFile file = result.files.first;
+
+      final CropAreaInput? crop =
+          await CropAvatarView.show(router.context!, file.bytes!);
+      if (crop == null) {
+        return;
+      }
+
+      await updateChatAvatar(file);
     }
   }
 
@@ -264,19 +272,13 @@ class ChatInfoController extends GetxController {
 
   /// Updates the [Chat.avatar] with the provided [image], or resets it to
   /// `null`.
-  Future<void> updateChatAvatar(PlatformFile? image) async {
+  Future<void> updateChatAvatar(
+    PlatformFile? image, {
+    CropAreaInput? crop,
+  }) async {
     avatarUpload.value = RxStatus.loading();
 
     try {
-      CropAreaInput? crop;
-
-      if (image != null) {
-        crop = await CropAvatarView.show(router.context!, image.bytes!);
-        if (crop == null) {
-          return;
-        }
-      }
-
       await _chatService.updateChatAvatar(
         chatId,
         file: image == null ? null : NativeFile.fromPlatformFile(image),

--- a/lib/ui/page/home/page/chat/info/view.dart
+++ b/lib/ui/page/home/page/chat/info/view.dart
@@ -23,6 +23,7 @@ import 'package:get/get.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import '/config.dart';
+import '/domain/model/avatar.dart';
 import '/domain/model/chat.dart';
 import '/domain/model/my_user.dart';
 import '/domain/repository/user.dart';
@@ -130,20 +131,25 @@ class ChatInfoView extends StatelessWidget {
 
   /// Returns the [Block] displaying a [Chat.avatar].
   Widget _avatar(ChatInfoController c, BuildContext context) {
-    return Block(
-      children: [
-        SelectionContainer.disabled(
-          child: BigAvatarWidget.chat(
-            c.chat,
-            key: Key('ChatAvatar_${c.chat!.id}'),
-            loading: c.avatar.value.isLoading,
-            error: c.avatar.value.errorMessage,
-            onUpload: c.pickAvatar,
-            onDelete: c.chat?.avatar.value != null ? c.deleteAvatar : null,
+    return Obx(() {
+      final Avatar? avatar = c.chat?.avatar.value;
+
+      return Block(
+        children: [
+          SelectionContainer.disabled(
+            child: BigAvatarWidget.chat(
+              c.chat,
+              key: Key('ChatAvatar_${c.chat!.id}'),
+              loading: c.avatarUpload.value.isLoading,
+              error: c.avatarUpload.value.errorMessage,
+              onUpload: c.pickAvatar,
+              onEdit: avatar != null ? c.editAvatar : null,
+              onDelete: c.chat?.avatar.value != null ? c.deleteAvatar : null,
+            ),
           ),
-        ),
-      ],
-    );
+        ],
+      );
+    });
   }
 
   /// Returns the [Block] displaying a [Chat.name].

--- a/lib/util/backoff.dart
+++ b/lib/util/backoff.dart
@@ -48,14 +48,14 @@ class Backoff {
 
           try {
             return await callback();
-          } catch (e, s) {
+          } catch (e, _) {
             if (backoff.inMilliseconds == 0) {
               backoff = _minBackoff;
             } else if (backoff < _maxBackoff) {
               backoff *= 2;
             }
 
-            Log.error('${e.toString()}, StackTrace: $s', 'Backoff');
+            Log.debug(e.toString(), 'Backoff');
           }
         }
       }),


### PR DESCRIPTION
## Synopsis

`Chat` has an avatar that should be cropped.




## Solution

This PR reuses the `CropAvatar` modal to crop the avatar on the `ChatInfo` page.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
