### PR TITLE
Fix `ImageCropper` using previous coordinates when scaling and moving crop area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All user visible changes to this project will be documented in this file. This p
 
 - UI:
     - Profile page:
-        - Avatar cropping. ([#1139], [#1130], [#530])
+        - Avatar cropping. ([#1143], [#1139], [#1130], [#530])
     - Chat page:
         - Image and file attachments pasting from pasteboard. ([#1141])
     - Chats tab:
@@ -27,6 +27,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1139]: /../../pull/1139
 [#1140]: /../../pull/1140
 [#1141]: /../../pull/1141
+[#1143]: /../../pull/1143
 
 
 

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -84,6 +84,11 @@ class Config {
   /// Intended to be used in E2E testing.
   static bool disableInfiniteAnimations = false;
 
+  /// Indicator whether all [DropRegion]s should be disabled.
+  ///
+  /// Intended to be used in E2E testing.
+  static bool disableDragArea = false;
+
   /// Product identifier of `User-Agent` header to put in network queries.
   static String userAgentProduct = 'Gapopa';
 

--- a/lib/domain/service/notification.dart
+++ b/lib/domain/service/notification.dart
@@ -59,10 +59,6 @@ class NotificationService extends DisposableService {
   /// on non-web platforms.
   FlutterLocalNotificationsPlugin? _plugin;
 
-  /// Subscription to the [PlatformUtils.onFocusChanged] updating the
-  /// [_focused].
-  StreamSubscription? _onFocusChanged;
-
   /// Subscription to the [FirebaseMessaging.onTokenRefresh] refreshing the
   /// [_token].
   StreamSubscription? _onTokenRefresh;
@@ -163,7 +159,6 @@ class NotificationService extends DisposableService {
   void onClose() {
     Log.debug('onClose()', '$runtimeType');
 
-    _onFocusChanged?.cancel();
     _onTokenRefresh?.cancel();
     _foregroundSubscription?.cancel();
     _onActivityChanged?.cancel();

--- a/lib/ui/page/home/page/chat/widget/custom_drop_target.dart
+++ b/lib/ui/page/home/page/chat/widget/custom_drop_target.dart
@@ -19,6 +19,8 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 
+import '/config.dart';
+
 /// Custom wrapper around [DropRegion] to simplify usage.
 class CustomDropTarget extends StatefulWidget {
   const CustomDropTarget({
@@ -52,7 +54,7 @@ class _CustomDropTargetState extends State<CustomDropTarget> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.onPerformDrop == null) {
+    if (widget.onPerformDrop == null || Config.disableDragArea) {
       return widget.builder(false);
     }
 

--- a/lib/ui/page/home/page/my_profile/crop_avatar/widget/image_cropper/widget.dart
+++ b/lib/ui/page/home/page/my_profile/crop_avatar/widget/image_cropper/widget.dart
@@ -15,6 +15,7 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -22,7 +23,6 @@ import 'package:flutter/material.dart';
 import '/themes.dart';
 import '/ui/page/call/widget/scaler.dart';
 import '/util/platform_utils.dart';
-import '/util/web/web_utils.dart';
 import 'enums.dart';
 import 'painter.dart';
 
@@ -85,12 +85,9 @@ class _ImageCropperState extends State<ImageCropper> {
       child: AspectRatio(
         aspectRatio: widget.size.aspectRatio,
         child: LayoutBuilder(builder: (context, constraints) {
-          final Rect real = Rect.fromLTWH(
-            _crop.left * constraints.maxWidth,
-            _crop.top * constraints.maxHeight,
-            _crop.width * constraints.maxWidth,
-            _crop.height * constraints.maxHeight,
-          );
+          final Rect real = _calculate(constraints);
+
+          // print('_crop: ${_crop.pretty}, real: ${real.pretty}');
 
           return Stack(
             alignment: Alignment.center,
@@ -110,12 +107,12 @@ class _ImageCropperState extends State<ImageCropper> {
                   cursor: SystemMouseCursors.grab,
                   child: GestureDetector(
                     onPanUpdate: (d) {
-                      final Offset delta = _offset(d.delta);
+                      final Rect real = _calculate(constraints);
 
                       _move(
                         Offset(
-                          (real.left + delta.dx) / constraints.maxWidth,
-                          (real.top + delta.dy) / constraints.maxHeight,
+                          (real.left + d.delta.dx) / constraints.maxWidth,
+                          (real.top + d.delta.dy) / constraints.maxHeight,
                         ),
                       );
                     },
@@ -159,6 +156,8 @@ class _ImageCropperState extends State<ImageCropper> {
                       (_) => dy,
                     };
 
+                    final Rect real = _calculate(constraints);
+
                     _resize(
                       CropHandle.topLeft,
                       Offset(
@@ -197,6 +196,8 @@ class _ImageCropperState extends State<ImageCropper> {
                       CropRotation.left => dy,
                       (_) => dy,
                     };
+
+                    final Rect real = _calculate(constraints);
 
                     _resize(
                       CropHandle.topRight,
@@ -237,6 +238,8 @@ class _ImageCropperState extends State<ImageCropper> {
                       (_) => dy,
                     };
 
+                    final Rect real = _calculate(constraints);
+
                     _resize(
                       CropHandle.bottomLeft,
                       Offset(
@@ -276,6 +279,8 @@ class _ImageCropperState extends State<ImageCropper> {
                       (_) => dy,
                     };
 
+                    final Rect real = _calculate(constraints);
+
                     _resize(
                       CropHandle.bottomRight,
                       Offset(
@@ -293,20 +298,6 @@ class _ImageCropperState extends State<ImageCropper> {
     );
   }
 
-  /// Returns the [Offset] with its delta corrected according to the platform
-  /// differences.
-  Offset _offset(Offset offset) {
-    if (PlatformUtils.isDesktop) {
-      if (WebUtils.isSafari) {
-        return Offset(offset.dx * 1.9, offset.dy * 1.9);
-      } else if (PlatformUtils.isWeb) {
-        return Offset(offset.dx * 1.45, offset.dy * 1.45);
-      }
-    }
-
-    return offset;
-  }
-
   // Returns a [Scaler] scaling the crop area.
   Widget _scaler({
     Key? key,
@@ -320,17 +311,9 @@ class _ImageCropperState extends State<ImageCropper> {
       child: Scaler(
         key: key,
         onDragUpdate: (dx, dy) {
-          final Offset delta = _offset(Offset(dx, dy));
-
           onDrag?.call(
-            switch (widget.rotation) {
-              CropRotation.down => -delta.dx,
-              (_) => delta.dx
-            },
-            switch (widget.rotation) {
-              CropRotation.down => -delta.dy,
-              (_) => delta.dy
-            },
+            switch (widget.rotation) { CropRotation.down => -dx, (_) => dx },
+            switch (widget.rotation) { CropRotation.down => -dy, (_) => dy },
           );
         },
         width: width ?? Scaler.size,
@@ -339,18 +322,32 @@ class _ImageCropperState extends State<ImageCropper> {
     );
   }
 
+  /// Returns the total [_crop] relative to the [constraints].
+  Rect _calculate(BoxConstraints constraints) {
+    return Rect.fromLTWH(
+      _crop.left * constraints.maxWidth,
+      _crop.top * constraints.maxHeight,
+      _crop.width * constraints.maxWidth,
+      _crop.height * constraints.maxHeight,
+    );
+  }
+
   /// Moves the crop rectangle based on the [point].
   void _move(Offset point) {
     final Rect crop = _crop.multiply(widget.size);
 
+    _crop = Rect.fromLTWH(point.dx, point.dy, _crop.width, _crop.height);
     _crop = Rect.fromLTWH(
-      (point.dx * widget.size.width).clamp(0, widget.size.width - crop.width),
+      (point.dx * widget.size.width).clamp(
+        0,
+        max(0, widget.size.width - crop.width),
+      ),
       (point.dy * widget.size.height).clamp(
         0,
-        widget.size.height - crop.height,
+        max(0, widget.size.height - crop.height),
       ),
-      crop.width,
-      crop.height,
+      min(widget.size.width, crop.width),
+      min(widget.size.height, crop.height),
     ).divide(widget.size);
 
     setState(() {});
@@ -402,6 +399,10 @@ class _ImageCropperState extends State<ImageCropper> {
           left = (point.dx * widget.size.width).clamp(minX, maxX);
         }
 
+        if (left == minX) {
+          return;
+        }
+
         minY = 0;
         maxY = bottom - _minimum;
         if (minY <= maxY) {
@@ -414,6 +415,10 @@ class _ImageCropperState extends State<ImageCropper> {
         maxX = widget.size.width;
         if (minX <= maxX) {
           right = (point.dx * widget.size.width).clamp(minX, maxX);
+        }
+
+        if (right >= maxX) {
+          return;
         }
 
         minY = 0;
@@ -430,6 +435,10 @@ class _ImageCropperState extends State<ImageCropper> {
           right = (point.dx * widget.size.width).clamp(minX, maxX);
         }
 
+        if (right >= maxX) {
+          return;
+        }
+
         minY = top + _minimum;
         maxY = widget.size.height;
         if (minY <= maxY) {
@@ -444,6 +453,10 @@ class _ImageCropperState extends State<ImageCropper> {
           left = (point.dx * widget.size.width).clamp(minX, maxX);
         }
 
+        if (left == maxX) {
+          return;
+        }
+
         minY = top + _minimum;
         maxY = widget.size.height;
         if (minY <= maxY) {
@@ -456,41 +469,22 @@ class _ImageCropperState extends State<ImageCropper> {
         break;
     }
 
-    final double width = right - left;
     final double height = bottom - top;
 
-    if (width / height > _ratio) {
-      switch (type) {
-        case CropHandle.topLeft:
-        case CropHandle.bottomLeft:
-          left = right - height * _ratio;
-          break;
+    switch (type) {
+      case CropHandle.topLeft:
+      case CropHandle.bottomLeft:
+        left = right - height * _ratio;
+        break;
 
-        case CropHandle.topRight:
-        case CropHandle.bottomRight:
-          right = left + height * _ratio;
-          break;
+      case CropHandle.topRight:
+      case CropHandle.bottomRight:
+        right = left + height * _ratio;
+        break;
 
-        default:
-          // No-op, as shouldn't be invoked.
-          break;
-      }
-    } else {
-      switch (type) {
-        case CropHandle.topLeft:
-        case CropHandle.topRight:
-          top = bottom - width / _ratio;
-          break;
-
-        case CropHandle.bottomRight:
-        case CropHandle.bottomLeft:
-          bottom = top + width / _ratio;
-          break;
-
-        default:
-          // No-op, as shouldn't be invoked.
-          break;
-      }
+      default:
+        // No-op, as shouldn't be invoked.
+        break;
     }
 
     setState(

--- a/lib/ui/page/home/page/my_profile/crop_avatar/widget/image_cropper/widget.dart
+++ b/lib/ui/page/home/page/my_profile/crop_avatar/widget/image_cropper/widget.dart
@@ -87,8 +87,6 @@ class _ImageCropperState extends State<ImageCropper> {
         child: LayoutBuilder(builder: (context, constraints) {
           final Rect real = _calculate(constraints);
 
-          // print('_crop: ${_crop.pretty}, real: ${real.pretty}');
-
           return Stack(
             alignment: Alignment.center,
             children: <Widget>[

--- a/lib/ui/page/home/page/my_profile/crop_avatar/widget/image_cropper/widget.dart
+++ b/lib/ui/page/home/page/my_profile/crop_avatar/widget/image_cropper/widget.dart
@@ -399,7 +399,7 @@ class _ImageCropperState extends State<ImageCropper> {
           left = (point.dx * widget.size.width).clamp(minX, maxX);
         }
 
-        if (left == minX) {
+        if (left <= minX || left >= maxX) {
           return;
         }
 
@@ -417,7 +417,7 @@ class _ImageCropperState extends State<ImageCropper> {
           right = (point.dx * widget.size.width).clamp(minX, maxX);
         }
 
-        if (right >= maxX) {
+        if (right <= minX || right >= maxX) {
           return;
         }
 
@@ -435,7 +435,7 @@ class _ImageCropperState extends State<ImageCropper> {
           right = (point.dx * widget.size.width).clamp(minX, maxX);
         }
 
-        if (right >= maxX) {
+        if (right <= minX || right >= maxX) {
           return;
         }
 
@@ -453,7 +453,7 @@ class _ImageCropperState extends State<ImageCropper> {
           left = (point.dx * widget.size.width).clamp(minX, maxX);
         }
 
-        if (left == maxX) {
+        if (left <= minX || left >= maxX) {
           return;
         }
 

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -795,7 +795,7 @@ class CustomMouseCursors {
           ..hotY = height / 2,
       );
     } catch (e) {
-      Log.error(
+      Log.warning(
         'Failed to initialize `$name` cursor due to: $e',
         'CustomMouseCursors',
       );

--- a/test/widget/chat_attachment_test.dart
+++ b/test/widget/chat_attachment_test.dart
@@ -90,6 +90,7 @@ void main() async {
   final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Config.files = 'test';
+  Config.disableDragArea = true;
 
   var graphQlProvider = MockGraphQlProvider();
   Get.put<GraphQlProvider>(graphQlProvider);

--- a/test/widget/chat_edit_message_test.dart
+++ b/test/widget/chat_edit_message_test.dart
@@ -23,6 +23,7 @@ import 'package:get/get.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:messenger/api/backend/schema.dart' hide ChatMessageTextInput;
 import 'package:messenger/api/backend/schema.dart' as api;
+import 'package:messenger/config.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/chat_item.dart';
 import 'package:messenger/domain/model/precise_date_time/precise_date_time.dart';
@@ -84,6 +85,8 @@ void main() async {
 
   final CommonDriftProvider common = CommonDriftProvider.memory();
   final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
+
+  Config.disableDragArea = true;
 
   var graphQlProvider = MockGraphQlProvider();
   Get.put<GraphQlProvider>(graphQlProvider);

--- a/test/widget/chat_reply_message_test.dart
+++ b/test/widget/chat_reply_message_test.dart
@@ -23,6 +23,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:messenger/api/backend/schema.dart';
+import 'package:messenger/config.dart';
 import 'package:messenger/domain/model/chat.dart';
 import 'package:messenger/domain/model/chat_item.dart';
 import 'package:messenger/domain/model/precise_date_time/precise_date_time.dart';
@@ -83,6 +84,8 @@ void main() async {
 
   final CommonDriftProvider common = CommonDriftProvider.memory();
   final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
+
+  Config.disableDragArea = true;
 
   var graphQlProvider = MockGraphQlProvider();
   Get.put<GraphQlProvider>(graphQlProvider);

--- a/test/widget/chat_update_attachments_test.dart
+++ b/test/widget/chat_update_attachments_test.dart
@@ -120,6 +120,7 @@ void main() async {
   final ScopedDriftProvider scoped = ScopedDriftProvider.memory();
 
   Config.files = '';
+  Config.disableDragArea = true;
 
   var graphQlProvider = MockGraphQlProvider();
   Get.put<GraphQlProvider>(graphQlProvider);


### PR DESCRIPTION
## Synopsis

`ImageCropper` behaves a little too slow when scaling or moving its crop area.




## Solution

This is caused by `ImageCropper` using the previous frame coordinates, whilst the callback may be invoked multiple times per frame.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
