### PR TITLE
Add missing `isHidden` to `Chat.copyWith()`

### DIFF
--- a/lib/domain/model/chat.dart
+++ b/lib/domain/model/chat.dart
@@ -282,6 +282,7 @@ class Chat implements Comparable<Chat> {
       members: members,
       kindIndex: kindIndex,
       muted: muted,
+      isHidden: isHidden,
       directLink: directLink,
       createdAt: createdAt,
       updatedAt: updatedAt,


### PR DESCRIPTION
## Synopsis

`Chat`s still appear as non-hidden in the chats list when mass clearing.




## Solution

This happens due to `Chat.copyWith()` missing `isHidden`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
