### PR TITLE
Fix `onDidRemovePage` popping already popped pages (#1084)

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -211,6 +211,7 @@ class RouterState extends ChangeNotifier {
   /// Current [Routes.home] tab.
   HomeTab _tab = HomeTab.chats;
 
+  /// List of [routes] already [pop]ped so that those aren't removed twice.
   final List<String> _accounted = [];
 
   /// Current route (last in the [routes] history).
@@ -234,12 +235,11 @@ class RouterState extends ChangeNotifier {
     arguments = null;
 
     for (var e in routes) {
-      if (e != '/') {
+      if (e != '/' && e != to) {
         _accounted.add(e);
       }
     }
 
-    print('go($to) -> $_accounted');
     routes.value = [_guarded(to)];
     notifyListeners();
   }
@@ -264,7 +264,7 @@ class RouterState extends ChangeNotifier {
   /// If [routes] contain only one record, then removes segments of that record
   /// by `/` if any, otherwise replaces it with [Routes.home].
   void pop([String? page]) {
-    if (page != null && _accounted.remove(page)) {
+    if (_accounted.remove(page ?? routes.lastOrNull)) {
       return;
     }
 
@@ -302,8 +302,6 @@ class RouterState extends ChangeNotifier {
 
       notifyListeners();
     }
-
-    print('pop($page) -> $_accounted');
   }
 
   /// Removes the [routes] satisfying the provided [predicate].
@@ -924,8 +922,6 @@ class AppRouterDelegate extends RouterDelegate<RouteConfiguration>
             observers: [SentryNavigatorObserver(), ModalNavigatorObserver()],
             pages: _pages,
             onDidRemovePage: (Page<Object?> page) {
-              print('===== [router] onDidRemovePage -> $page');
-
               final bool success = page.canPop;
               if (success) {
                 _state.pop(page.name);

--- a/lib/ui/page/home/router.dart
+++ b/lib/ui/page/home/router.dart
@@ -148,10 +148,7 @@ class HomeRouterDelegate extends RouterDelegate<RouteConfiguration>
       key: navigatorKey,
       pages: _pages,
       observers: [SentryNavigatorObserver(), ModalNavigatorObserver()],
-      onDidRemovePage: (page) {
-        print('===== [home] onDidRemovePage -> $page');
-        _state.pop(page.name);
-      },
+      onDidRemovePage: (page) => _state.pop(page.name),
     );
   }
 

--- a/lib/ui/page/home/router.dart
+++ b/lib/ui/page/home/router.dart
@@ -148,7 +148,10 @@ class HomeRouterDelegate extends RouterDelegate<RouteConfiguration>
       key: navigatorKey,
       pages: _pages,
       observers: [SentryNavigatorObserver(), ModalNavigatorObserver()],
-      onDidRemovePage: (page) => _state.pop(page.name),
+      onDidRemovePage: (page) {
+        print('===== [home] onDidRemovePage -> $page');
+        _state.pop(page.name);
+      },
     );
   }
 


### PR DESCRIPTION
Resolves #1084




## Synopsis

#1084




## Solution

This PR introduces a list of routes being currently active, so that the ones already removed won't be removed.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
