### PR TITLE
Don't await upserting to `drift` in `Chat`s `Pagination`

### DIFF
--- a/lib/store/pagination/drift_graphql.dart
+++ b/lib/store/pagination/drift_graphql.dart
@@ -61,7 +61,10 @@ class DriftGraphQlPageProvider<T extends Object, C, K>
     final Page<T, C> remote = await graphQlProvider.around(key, cursor, count);
     Log.debug('after() -> ${remote.edges.length}');
 
-    await driftProvider.put(remote.edges);
+    // Await is omitted as it doesn't really form the page returned, it just
+    // stores the data fetched to the drift, which might be happening in
+    // parallel.
+    driftProvider.put(remote.edges);
 
     return remote;
   }
@@ -76,7 +79,10 @@ class DriftGraphQlPageProvider<T extends Object, C, K>
 
     final Page<T, C> remote = await graphQlProvider.after(key, cursor, count);
 
-    await driftProvider.put(remote.edges);
+    // Await is omitted as it doesn't really form the page returned, it just
+    // stores the data fetched to the drift, which might be happening in
+    // parallel.
+    driftProvider.put(remote.edges);
 
     return remote;
   }
@@ -91,7 +97,10 @@ class DriftGraphQlPageProvider<T extends Object, C, K>
 
     final Page<T, C> remote = await graphQlProvider.before(key, cursor, count);
 
-    await driftProvider.put(remote.edges);
+    // Await is omitted as it doesn't really form the page returned, it just
+    // stores the data fetched to the drift, which might be happening in
+    // parallel.
+    driftProvider.put(remote.edges);
 
     return remote;
   }

--- a/lib/ui/page/home/page/chat/message_field/controller.dart
+++ b/lib/ui/page/home/page/chat/message_field/controller.dart
@@ -453,7 +453,9 @@ class MessageFieldController extends GetxController {
           Log.debug('_pasteItem() -> suggested name is: $name', '$runtimeType');
 
           if (name != null) {
-            if (force || !PlatformUtils.isDesktop || formats.length > 3) {
+            final bool isMacOS = PlatformUtils.isMacOS && !PlatformUtils.isWeb;
+
+            if (force || !isMacOS || formats.length > 3) {
               e.getFile(file, (f) => _addReaderAttachment(f, suggested: name));
               handled = true;
               return true;

--- a/lib/ui/page/home/page/chat/message_field/controller.dart
+++ b/lib/ui/page/home/page/chat/message_field/controller.dart
@@ -451,8 +451,15 @@ class MessageFieldController extends GetxController {
         Log.debug('_pasteItem() -> suggested name is: $name', '$runtimeType');
 
         if (name != null) {
-          e.getFile(file, (f) => _addReaderAttachment(f, suggested: name));
-          handled = true;
+          if (!PlatformUtils.isDesktop || formats.length > 3) {
+            e.getFile(file, (f) => _addReaderAttachment(f, suggested: name));
+            handled = true;
+          } else {
+            Log.debug(
+              '_pasteItem() -> `formats.length` is no bigger than 3, thus by heuristic this is considered to be text',
+              '$runtimeType',
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Synopsis

`Chat`s are being displayed in the `Chats` tab too slow. It takes up to 2 seconds in order to next page of chats to appear.




## Solution

The loading consists of two parts:
- remote fetching ~ 400ms
- `drift` upserting ~ 1500ms

`Pagination` shouldn't await the last part. This shouldn't break anything.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
