### PR TITLE
Use `{mode: 'shared'}` for Web Locks API when reading data from `drift`

### DIFF
--- a/lib/provider/drift/background.dart
+++ b/lib/provider/drift/background.dart
@@ -73,17 +73,20 @@ class BackgroundDriftProvider extends DriftProviderBase {
       return existing;
     }
 
-    return await safe<DtoBackground?>((db) async {
-      final stmt = db.select(db.background)
-        ..where((u) => u.userId.equals(id.val));
-      final BackgroundRow? row = await stmt.getSingleOrNull();
+    return await safe<DtoBackground?>(
+      (db) async {
+        final stmt = db.select(db.background)
+          ..where((u) => u.userId.equals(id.val));
+        final BackgroundRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _BackgroundDb.fromDb(row);
-    });
+        return _BackgroundDb.fromDb(row);
+      },
+      exclusive: false,
+    );
   }
 
   /// Deletes the [DtoBackground] identified by the provided [id] from the

--- a/lib/provider/drift/blocklist.dart
+++ b/lib/provider/drift/blocklist.dart
@@ -88,17 +88,21 @@ class BlocklistDriftProvider extends DriftProviderBaseWithScope {
       return existing;
     }
 
-    return await safe<DtoBlocklistRecord?>((db) async {
-      final stmt = db.select(db.blocklist)
-        ..where((u) => u.userId.equals(id.val));
-      final BlocklistRow? row = await stmt.getSingleOrNull();
+    return await safe<DtoBlocklistRecord?>(
+      (db) async {
+        final stmt = db.select(db.blocklist)
+          ..where((u) => u.userId.equals(id.val));
+        final BlocklistRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _BlocklistDb.fromDb(row);
-    }, tag: 'blocklist.read($id)');
+        return _BlocklistDb.fromDb(row);
+      },
+      tag: 'blocklist.read($id)',
+      exclusive: false,
+    );
   }
 
   /// Deletes the [DtoBlocklistRecord] identified by the provided [id] from the
@@ -124,17 +128,21 @@ class BlocklistDriftProvider extends DriftProviderBaseWithScope {
 
   /// Returns the recent [DtoBlocklistRecord]s being in a historical view order.
   Future<List<DtoBlocklistRecord>> records({int? limit}) async {
-    final result = await safe((db) async {
-      final stmt = db.select(db.blocklist);
+    final result = await safe(
+      (db) async {
+        final stmt = db.select(db.blocklist);
 
-      stmt.orderBy([(u) => OrderingTerm.desc(u.at)]);
+        stmt.orderBy([(u) => OrderingTerm.desc(u.at)]);
 
-      if (limit != null) {
-        stmt.limit(limit);
-      }
+        if (limit != null) {
+          stmt.limit(limit);
+        }
 
-      return (await stmt.get()).map(_BlocklistDb.fromDb).toList();
-    }, tag: 'blocklist.records(limit: $limit)');
+        return (await stmt.get()).map(_BlocklistDb.fromDb).toList();
+      },
+      tag: 'blocklist.records(limit: $limit)',
+      exclusive: false,
+    );
 
     return result ?? [];
   }

--- a/lib/provider/drift/call_credentials.dart
+++ b/lib/provider/drift/call_credentials.dart
@@ -63,17 +63,21 @@ class CallCredentialsDriftProvider extends DriftProviderBaseWithScope {
       return existing;
     }
 
-    return await safe<ChatCallCredentials?>((db) async {
-      final stmt = db.select(db.callCredentials)
-        ..where((u) => u.callId.equals(id.val));
-      final CallCredentialsRow? row = await stmt.getSingleOrNull();
+    return await safe<ChatCallCredentials?>(
+      (db) async {
+        final stmt = db.select(db.callCredentials)
+          ..where((u) => u.callId.equals(id.val));
+        final CallCredentialsRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _CallCredentialsDb.fromDb(row);
-    }, tag: 'call_credentials.read($id)');
+        return _CallCredentialsDb.fromDb(row);
+      },
+      tag: 'call_credentials.read($id)',
+      exclusive: false,
+    );
   }
 
   /// Deletes the [ChatCallCredentials] identified by the provided [id] from the database.

--- a/lib/provider/drift/call_rect.dart
+++ b/lib/provider/drift/call_rect.dart
@@ -114,13 +114,16 @@ class CallRectDriftProvider extends DriftProviderBaseWithScope {
 
   /// Returns all the [Rect] stored in the database.
   Future<List<(ChatId, Rect)>> _all() async {
-    final result = await safe<List<(ChatId, Rect)>?>((db) async {
-      final result = await db.select(db.callRectangles).get();
-      return result
-          .map(
-              (e) => (ChatId(e.chatId), _RectJson.fromJson(jsonDecode(e.rect))))
-          .toList();
-    });
+    final result = await safe<List<(ChatId, Rect)>?>(
+      (db) async {
+        final result = await db.select(db.callRectangles).get();
+        return result
+            .map((e) =>
+                (ChatId(e.chatId), _RectJson.fromJson(jsonDecode(e.rect))))
+            .toList();
+      },
+      exclusive: false,
+    );
 
     return result ?? [];
   }

--- a/lib/provider/drift/chat.dart
+++ b/lib/provider/drift/chat.dart
@@ -161,6 +161,7 @@ class ChatDriftProvider extends DriftProviderBaseWithScope {
         return _ChatDb.fromDb(row);
       },
       tag: 'chat.read($id)',
+      exclusive: false,
       force: force,
     );
   }
@@ -187,41 +188,50 @@ class ChatDriftProvider extends DriftProviderBaseWithScope {
 
   /// Returns the recent [DtoChat]s being in a historical view order.
   Future<List<DtoChat>> recent({int? limit}) async {
-    final result = await safe((db) async {
-      final stmt = db.select(db.chats);
+    final result = await safe(
+      (db) async {
+        final stmt = db.select(db.chats);
 
-      stmt.where((u) => u.isHidden.equals(false) & u.id.like('local_%').not());
-      stmt.orderBy([(u) => OrderingTerm.desc(u.updatedAt)]);
+        stmt.where(
+            (u) => u.isHidden.equals(false) & u.id.like('local_%').not());
+        stmt.orderBy([(u) => OrderingTerm.desc(u.updatedAt)]);
 
-      if (limit != null) {
-        stmt.limit(limit);
-      }
+        if (limit != null) {
+          stmt.limit(limit);
+        }
 
-      return (await stmt.get()).map(_ChatDb.fromDb).toList();
-    }, tag: 'chat.recent(limit: $limit)');
+        return (await stmt.get()).map(_ChatDb.fromDb).toList();
+      },
+      tag: 'chat.recent(limit: $limit)',
+      exclusive: false,
+    );
 
     return result ?? [];
   }
 
   /// Returns the favorite [DtoChat]s being in a historical view order.
   Future<List<DtoChat>> favorite({int? limit}) async {
-    final result = await safe((db) async {
-      final stmt = db.select(db.chats);
+    final result = await safe(
+      (db) async {
+        final stmt = db.select(db.chats);
 
-      stmt.where(
-        (u) =>
-            u.isHidden.equals(false) &
-            u.favoritePosition.isNotNull() &
-            u.id.like('local_%').not(),
-      );
-      stmt.orderBy([(u) => OrderingTerm.desc(u.favoritePosition)]);
+        stmt.where(
+          (u) =>
+              u.isHidden.equals(false) &
+              u.favoritePosition.isNotNull() &
+              u.id.like('local_%').not(),
+        );
+        stmt.orderBy([(u) => OrderingTerm.desc(u.favoritePosition)]);
 
-      if (limit != null) {
-        stmt.limit(limit);
-      }
+        if (limit != null) {
+          stmt.limit(limit);
+        }
 
-      return (await stmt.get()).map(_ChatDb.fromDb).toList();
-    }, tag: 'chat.favorite(limit: $limit)');
+        return (await stmt.get()).map(_ChatDb.fromDb).toList();
+      },
+      tag: 'chat.favorite(limit: $limit)',
+      exclusive: false,
+    );
 
     return result ?? [];
   }

--- a/lib/provider/drift/chat_credentials.dart
+++ b/lib/provider/drift/chat_credentials.dart
@@ -63,17 +63,20 @@ class ChatCredentialsDriftProvider extends DriftProviderBaseWithScope {
       return existing;
     }
 
-    return await safe<ChatCallCredentials?>((db) async {
-      final stmt = db.select(db.chatCredentials)
-        ..where((u) => u.chatId.equals(id.val));
-      final ChatCredentialsRow? row = await stmt.getSingleOrNull();
+    return await safe<ChatCallCredentials?>(
+      (db) async {
+        final stmt = db.select(db.chatCredentials)
+          ..where((u) => u.chatId.equals(id.val));
+        final ChatCredentialsRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _CallCredentialsDb.fromDb(row);
-    });
+        return _CallCredentialsDb.fromDb(row);
+      },
+      exclusive: false,
+    );
   }
 
   /// Deletes the [ChatCallCredentials] identified by the provided [id] from the database.

--- a/lib/provider/drift/credentials.dart
+++ b/lib/provider/drift/credentials.dart
@@ -76,10 +76,13 @@ class CredentialsDriftProvider extends DriftProviderBase {
 
   /// Returns all the [Credentials] stored in the database.
   Future<List<Credentials>> all() async {
-    final result = await safe((db) async {
-      final stmt = await db.select(db.tokens).get();
-      return stmt.map((e) => _CredentialsDb.fromDb(e)).toList();
-    });
+    final result = await safe(
+      (db) async {
+        final stmt = await db.select(db.tokens).get();
+        return stmt.map((e) => _CredentialsDb.fromDb(e)).toList();
+      },
+      exclusive: false,
+    );
 
     return result ?? [];
   }
@@ -110,16 +113,20 @@ class CredentialsDriftProvider extends DriftProviderBase {
       return existing;
     }
 
-    final result = await safe<Credentials?>((db) async {
-      final stmt = db.select(db.tokens)..where((u) => u.userId.equals(id.val));
-      final TokenRow? row = await stmt.getSingleOrNull();
+    final result = await safe<Credentials?>(
+      (db) async {
+        final stmt = db.select(db.tokens)
+          ..where((u) => u.userId.equals(id.val));
+        final TokenRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _CredentialsDb.fromDb(row);
-    });
+        return _CredentialsDb.fromDb(row);
+      },
+      exclusive: false,
+    );
 
     if (result == null) {
       return null;

--- a/lib/provider/drift/download.dart
+++ b/lib/provider/drift/download.dart
@@ -63,10 +63,13 @@ class DownloadDriftProvider extends DriftProviderBase {
 
   /// Returns the download paths stored in the database.
   Future<List<(String, String)>> values() async {
-    final result = await safe<List<(String, String)>?>((db) async {
-      final result = await db.select(db.downloads).get();
-      return result.map((e) => (e.checksum, e.path)).toList();
-    });
+    final result = await safe<List<(String, String)>?>(
+      (db) async {
+        final result = await db.select(db.downloads).get();
+        return result.map((e) => (e.checksum, e.path)).toList();
+      },
+      exclusive: false,
+    );
 
     return result ?? <(String, String)>[];
   }
@@ -78,12 +81,15 @@ class DownloadDriftProvider extends DriftProviderBase {
       return existing;
     }
 
-    return await safe<String?>((db) async {
-      final stmt = db.select(db.downloads)
-        ..where((u) => u.checksum.equals(checksum));
-      final DownloadRow? row = await stmt.getSingleOrNull();
-      return row?.path;
-    });
+    return await safe<String?>(
+      (db) async {
+        final stmt = db.select(db.downloads)
+          ..where((u) => u.checksum.equals(checksum));
+        final DownloadRow? row = await stmt.getSingleOrNull();
+        return row?.path;
+      },
+      exclusive: false,
+    );
   }
 
   /// Deletes all the download paths stored in the database.

--- a/lib/provider/drift/draft.dart
+++ b/lib/provider/drift/draft.dart
@@ -67,16 +67,21 @@ class DraftDriftProvider extends DriftProviderBaseWithScope {
       return existing;
     }
 
-    return await safe<ChatMessage?>((db) async {
-      final stmt = db.select(db.drafts)..where((u) => u.chatId.equals(id.val));
-      final DraftRow? row = await stmt.getSingleOrNull();
+    return await safe<ChatMessage?>(
+      (db) async {
+        final stmt = db.select(db.drafts)
+          ..where((u) => u.chatId.equals(id.val));
+        final DraftRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _DraftDb.fromDb(row);
-    }, tag: 'draft.read($id)');
+        return _DraftDb.fromDb(row);
+      },
+      tag: 'draft.read($id)',
+      exclusive: false,
+    );
   }
 
   /// Deletes the [ChatMessage] identified by the provided [id] from the

--- a/lib/provider/drift/drift.dart
+++ b/lib/provider/drift/drift.dart
@@ -679,20 +679,12 @@ abstract class DriftProviderBaseWithScope extends DisposableInterface {
     bool force = false,
   }) async {
     if (PlatformUtils.isWeb && !force) {
-      final Stopwatch watch = Stopwatch()..start();
-
       // WAL doesn't work in Web, thus guard all the writes/reads with Web Locks
       // API: https://github.com/simolus3/sqlite3.dart/issues/200
       return await WebUtils.protect(
         tag: '${_scoped.db?.userId}',
         exclusive: exclusive,
-        () async {
-          print(
-            '======= await WebUtils.protect(${exclusive ? 'exclusive' : 'shared'}) took ${watch.elapsed}',
-          );
-
-          return await _scoped.wrapped(callback);
-        },
+        () async => await _scoped.wrapped(callback),
       );
     }
 

--- a/lib/provider/drift/session.dart
+++ b/lib/provider/drift/session.dart
@@ -66,16 +66,19 @@ class SessionDriftProvider extends DriftProviderBaseWithScope {
 
   /// Returns the [Session] stored in the database by the provided [id], if any.
   Future<Session?> read(SessionId id) async {
-    return await safe<Session?>((db) async {
-      final stmt = db.select(db.sessions)..where((u) => u.id.equals(id.val));
-      final SessionRow? row = await stmt.getSingleOrNull();
+    return await safe<Session?>(
+      (db) async {
+        final stmt = db.select(db.sessions)..where((u) => u.id.equals(id.val));
+        final SessionRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _SessionDb.fromDb(row);
-    });
+        return _SessionDb.fromDb(row);
+      },
+      exclusive: false,
+    );
   }
 
   /// Deletes the [Session] identified by the provided [id] from the database.

--- a/lib/provider/drift/settings.dart
+++ b/lib/provider/drift/settings.dart
@@ -86,17 +86,20 @@ class SettingsDriftProvider extends DriftProviderBase {
       return existing;
     }
 
-    return await safe<DtoSettings?>((db) async {
-      final stmt = db.select(db.settings)
-        ..where((u) => u.userId.equals(id.val));
-      final SettingsRow? row = await stmt.getSingleOrNull();
+    return await safe<DtoSettings?>(
+      (db) async {
+        final stmt = db.select(db.settings)
+          ..where((u) => u.userId.equals(id.val));
+        final SettingsRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _SettingsDb.fromDb(row);
-    });
+        return _SettingsDb.fromDb(row);
+      },
+      exclusive: false,
+    );
   }
 
   /// Deletes the [DtoSettings] identified by the provided [id] from the

--- a/lib/provider/drift/skipped_version.dart
+++ b/lib/provider/drift/skipped_version.dart
@@ -48,11 +48,15 @@ class SkippedVersionDriftProvider extends DriftProviderBase {
 
   /// Returns the skipped version stored in the database.
   Future<String?> read() async {
-    return await safe<String?>((db) async {
-      final stmt = db.select(db.skippedVersions)..where((e) => e.id.equals(0));
-      final SkippedVersionRow? row = await stmt.getSingleOrNull();
-      return row?.skipped;
-    });
+    return await safe<String?>(
+      (db) async {
+        final stmt = db.select(db.skippedVersions)
+          ..where((e) => e.id.equals(0));
+        final SkippedVersionRow? row = await stmt.getSingleOrNull();
+        return row?.skipped;
+      },
+      exclusive: false,
+    );
   }
 
   /// Deletes the skipped version stored from the database.

--- a/lib/provider/drift/user.dart
+++ b/lib/provider/drift/user.dart
@@ -98,16 +98,20 @@ class UserDriftProvider extends DriftProviderBaseWithScope {
       return existing;
     }
 
-    return await safe<DtoUser?>((db) async {
-      final stmt = db.select(db.users)..where((u) => u.id.equals(id.val));
-      final UserRow? row = await stmt.getSingleOrNull();
+    return await safe<DtoUser?>(
+      (db) async {
+        final stmt = db.select(db.users)..where((u) => u.id.equals(id.val));
+        final UserRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return UserDb.fromDb(row);
-    }, tag: 'user.read($id)');
+        return UserDb.fromDb(row);
+      },
+      tag: 'user.read($id)',
+      exclusive: false,
+    );
   }
 
   /// Deletes the [DtoUser] identified by the provided [id] from the database.

--- a/lib/provider/drift/version.dart
+++ b/lib/provider/drift/version.dart
@@ -74,12 +74,15 @@ class VersionDriftProvider extends DriftProviderBase {
         return;
       }
 
-      final result = await safe((db) async {
-        final stmt = await db.select(db.versions).get();
-        return stmt
-            .map((e) => (UserId(e.userId), _SessionDataDb.fromDb(e)))
-            .toList();
-      });
+      final result = await safe(
+        (db) async {
+          final stmt = await db.select(db.versions).get();
+          return stmt
+              .map((e) => (UserId(e.userId), _SessionDataDb.fromDb(e)))
+              .toList();
+        },
+        exclusive: false,
+      );
 
       for (var e in result ?? <(UserId, SessionData)>[]) {
         data[e.$1] = e.$2;
@@ -122,17 +125,20 @@ class VersionDriftProvider extends DriftProviderBase {
       return existing;
     }
 
-    return await safe<SessionData?>((db) async {
-      final stmt = db.select(db.versions)
-        ..where((u) => u.userId.equals(id.val));
-      final VersionRow? row = await stmt.getSingleOrNull();
+    return await safe<SessionData?>(
+      (db) async {
+        final stmt = db.select(db.versions)
+          ..where((u) => u.userId.equals(id.val));
+        final VersionRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _SessionDataDb.fromDb(row);
-    });
+        return _SessionDataDb.fromDb(row);
+      },
+      exclusive: false,
+    );
   }
 
   /// Deletes the [SessionData] identified by the provided [id] from the

--- a/lib/provider/drift/window.dart
+++ b/lib/provider/drift/window.dart
@@ -84,16 +84,20 @@ class WindowRectDriftProvider extends DriftProviderBase {
       return _prefs;
     }
 
-    return await safe<WindowPreferences?>((db) async {
-      final stmt = db.select(db.windowRectangles)..where((u) => u.id.equals(0));
-      final WindowRectangleRow? row = await stmt.getSingleOrNull();
+    return await safe<WindowPreferences?>(
+      (db) async {
+        final stmt = db.select(db.windowRectangles)
+          ..where((u) => u.id.equals(0));
+        final WindowRectangleRow? row = await stmt.getSingleOrNull();
 
-      if (row == null) {
-        return null;
-      }
+        if (row == null) {
+          return null;
+        }
 
-      return _prefs = _WindowPreferencesDb.fromDb(row);
-    });
+        return _prefs = _WindowPreferencesDb.fromDb(row);
+      },
+      exclusive: false,
+    );
   }
 
   /// Deletes the stored [WindowPreferences] from the database.

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -104,6 +104,7 @@ class WebUtils {
   /// code block at the same time.
   static Future<T> protect<T>(
     Future<T> Function() callback, {
+    bool exclusive = true,
     String tag = 'mutex',
   }) {
     Mutex? mutex = _guards[tag];

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -114,6 +114,7 @@ external bool _hasFocus();
 @JS('navigator.locks.request')
 external JSPromise<JSAny?> _requestLock(
   String resource,
+  JSObject options,
   JSExportedDartFunction callback,
 );
 
@@ -337,9 +338,10 @@ class WebUtils {
   /// code block at the same time.
   static Future<T> protect<T>(
     Future<T> Function() callback, {
+    bool exclusive = true,
     String tag = 'mutex',
   }) async {
-    Mutex? mutex = _guards[tag];
+    Mutex? mutex = exclusive ? _guards[tag] : Mutex();
     if (mutex == null) {
       mutex = Mutex();
       _guards[tag] = mutex;
@@ -366,7 +368,11 @@ class WebUtils {
       }
 
       try {
-        await _requestLock(tag, function.toJS).toDart;
+        await _requestLock(
+          tag,
+          {'mode': exclusive ? 'exclusive' : 'shared'}.jsify() as JSObject,
+          function.toJS,
+        ).toDart;
       } catch (e) {
         // If completer is completed, then the exception is already handled.
         if (!completer.isCompleted) {


### PR DESCRIPTION
## Synopsis

`drift` doesn't support WAL under web, rendering it impossible to do writes from multiple tabs. Thus a Web Locks API mutex is used for every `drift` operation. However, the mutex used is exclusive and blocks every other operation until completed.




## Solution

This PR improves the situation by using RW mutexes instead of exclusive mutexes, making the reads faster.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
