### PR TITLE
Display incoming call when receiving tags ending with `-call` on Android

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,8 +1,9 @@
 # Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
 -keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
 -keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
--keep class com.google.gson.reflect.TypeToken
 -keep class * extends com.google.gson.reflect.TypeToken
+-keep class com.google.gson.reflect.TypeToken
+-keep class com.hiennv.flutter_callkit_incoming.** { *; }
 -keep public class * implements java.lang.reflect.Type
 
 -keep class androidx.window.extensions.WindowExtensions

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -296,8 +296,11 @@ Future<void> handlePushNotification(RemoteMessage message) async {
 
   Log.debug('handlePushNotification($message)', 'main');
 
-  if (message.notification?.android?.tag?.endsWith('_call') == true &&
-      message.data['chatId'] != null) {
+  final String? tag = message.notification?.android?.tag;
+  final bool isCall =
+      tag?.endsWith('_call') == true || tag?.endsWith('-call') == true;
+
+  if (isCall && message.data['chatId'] != null) {
     SharedPreferences? prefs;
     CredentialsDriftProvider? credentialsProvider;
     AccountDriftProvider? accountProvider;

--- a/lib/provider/gql/components/chat.dart
+++ b/lib/provider/gql/components/chat.dart
@@ -386,11 +386,11 @@ mixin ChatGraphQlMixin {
         document: PostChatMessageMutation(variables: variables).document,
         variables: variables.toJson(),
       ),
-      onException: (data) => PostChatMessageException((PostChatMessage$Mutation
-                      .fromJson(data)
-                  .postChatMessage
-              as PostChatMessage$Mutation$PostChatMessage$PostChatMessageError)
-          .code),
+      onException: (data) => PostChatMessageException(
+        (PostChatMessage$Mutation.fromJson(data).postChatMessage
+                as PostChatMessage$Mutation$PostChatMessage$PostChatMessageError)
+            .code,
+      ),
     );
     return PostChatMessage$Mutation.fromJson(result.data!).postChatMessage
         as PostChatMessage$Mutation$PostChatMessage$ChatEventsVersioned;

--- a/test/e2e/steps/sends_message.dart
+++ b/test/e2e/steps/sends_message.dart
@@ -129,12 +129,9 @@ final StepDefinitionGeneric sendsCountMessages =
     provider.token = context.world.sessions[user.name]?.token;
 
     final ChatId chatId = context.world.groups[name]!;
-    final List<Future> futures = List.generate(
-      count,
-      (i) => provider.postChatMessage(chatId, text: ChatMessageText('$i')),
-    );
-
-    await Future.wait(futures);
+    for (var i = 0; i < count; ++i) {
+      await provider.postChatMessage(chatId, text: ChatMessageText('$i'));
+    }
 
     provider.disconnect();
   },


### PR DESCRIPTION
## Synopsis

Call notifications aren't removed when declined or joined from different devices.




## Solution

...




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
