### PR TITLE
Use `PlatformUtils.libraryDirectory` for `drift` database directory

### DIFF
--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -439,13 +439,13 @@ fcm_group_title =
     }{$user2Name ->
         [x] {$user2Num ->
                 [x] {""}
-               *[other] {$user2Num}
+               *[other] , {$user2Num}
             }
        *[other] , {$user2Name}
     }{$user3Name ->
         [x] {$user3Num ->
                 [x] {""}
-               *[other] {$user3Num}
+               *[other] , {$user3Num}
             }
        *[other] , {$user3Name}
     } {$moreMembers ->

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -442,13 +442,13 @@ fcm_group_title =
     }{$user2Name ->
         [x] {$user2Num ->
                 [x] {""}
-               *[other] {$user2Num}
+               *[other] , {$user2Num}
             }
        *[other] , {$user2Name}
     }{$user3Name ->
         [x] {$user3Num ->
                 [x] {""}
-               *[other] {$user3Num}
+               *[other] , {$user3Num}
             }
        *[other] , {$user3Name}
     } {$moreMembers ->

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -232,7 +232,7 @@ class Config {
           ? e.name == const String.fromEnvironment('SOCAPP_LOG_LEVEL')
           : e.name == document['log']?['level'],
       orElse: () =>
-          kDebugMode || kProfileMode ? me.LogLevel.debug : me.LogLevel.info,
+          kDebugMode || kProfileMode ? me.LogLevel.debug : me.LogLevel.debug,
     );
 
     appcast = const bool.hasEnvironment('SOCAPP_APPCAST_URL')

--- a/lib/domain/model/native_file.dart
+++ b/lib/domain/model/native_file.dart
@@ -125,8 +125,15 @@ class NativeFile {
   Stream<List<int>>? _mergedStream;
 
   /// Returns the extensions of files considered to be images.
-  static List<String> get images =>
-      ['jpg', 'jpeg', 'png', 'gif', 'jfif', 'svg', 'webp'];
+  static const List<String> images = [
+    'jpg',
+    'jpeg',
+    'png',
+    'gif',
+    'jfif',
+    'svg',
+    'webp'
+  ];
 
   /// Returns an extension of this file.
   String get extension => name.split('.').last;

--- a/lib/provider/drift/connection/ffi.dart
+++ b/lib/provider/drift/connection/ffi.dart
@@ -24,6 +24,7 @@ import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart';
 import 'package:sqlite3_flutter_libs/sqlite3_flutter_libs.dart';
 
+import '/config.dart';
 import '/domain/model/user.dart';
 import '/util/ios_utils.dart';
 import '/util/platform_utils.dart';
@@ -36,7 +37,11 @@ QueryExecutor connect([UserId? userId]) {
     if (PlatformUtils.isIOS) {
       dbFolder = Directory(await IosUtils.getSharedDirectory());
     } else {
-      dbFolder = await getApplicationDocumentsDirectory();
+      dbFolder = Directory(
+        '${(await getLibraryDirectory()).path}/${Config.userAgentProduct}/',
+      );
+
+      print('================ dbFolder -> $dbFolder');
     }
 
     final File file = File(

--- a/lib/provider/drift/connection/ffi.dart
+++ b/lib/provider/drift/connection/ffi.dart
@@ -40,7 +40,9 @@ QueryExecutor connect([UserId? userId]) {
       dbFolder = await PlatformUtils.libraryDirectory;
     }
 
-    Log.debug('connect() -> `drift` will place its files to `$dbFolder`.');
+    Log.debug(
+      'connect() -> `drift` will place its files to `${dbFolder.path}`.',
+    );
 
     final File file = File(
       p.join(dbFolder.path, '${userId?.val ?? 'common'}.sqlite'),

--- a/lib/provider/drift/connection/ffi.dart
+++ b/lib/provider/drift/connection/ffi.dart
@@ -24,7 +24,6 @@ import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart';
 import 'package:sqlite3_flutter_libs/sqlite3_flutter_libs.dart';
 
-import '/config.dart';
 import '/domain/model/user.dart';
 import '/util/ios_utils.dart';
 import '/util/platform_utils.dart';
@@ -37,10 +36,7 @@ QueryExecutor connect([UserId? userId]) {
     if (PlatformUtils.isIOS) {
       dbFolder = Directory(await IosUtils.getSharedDirectory());
     } else {
-      final directory = await PlatformUtils.libraryDirectory ??
-          await getApplicationDocumentsDirectory();
-      dbFolder = Directory('${directory.path}/${Config.userAgentProduct}/');
-
+      dbFolder = await PlatformUtils.libraryDirectory;
       print('================ dbFolder -> $dbFolder');
     }
 

--- a/lib/provider/drift/connection/ffi.dart
+++ b/lib/provider/drift/connection/ffi.dart
@@ -37,9 +37,9 @@ QueryExecutor connect([UserId? userId]) {
     if (PlatformUtils.isIOS) {
       dbFolder = Directory(await IosUtils.getSharedDirectory());
     } else {
-      dbFolder = Directory(
-        '${(await getLibraryDirectory()).path}/${Config.userAgentProduct}/',
-      );
+      final directory = await PlatformUtils.libraryDirectory ??
+          await getApplicationDocumentsDirectory();
+      dbFolder = Directory('${directory.path}/${Config.userAgentProduct}/');
 
       print('================ dbFolder -> $dbFolder');
     }

--- a/lib/provider/drift/connection/ffi.dart
+++ b/lib/provider/drift/connection/ffi.dart
@@ -19,6 +19,7 @@ import 'dart:io';
 
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
+import 'package:log_me/log_me.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart';
@@ -37,8 +38,9 @@ QueryExecutor connect([UserId? userId]) {
       dbFolder = Directory(await IosUtils.getSharedDirectory());
     } else {
       dbFolder = await PlatformUtils.libraryDirectory;
-      print('================ dbFolder -> $dbFolder');
     }
+
+    Log.debug('connect() -> `drift` will place its files to `$dbFolder`.');
 
     final File file = File(
       p.join(dbFolder.path, '${userId?.val ?? 'common'}.sqlite'),

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -177,6 +177,10 @@ class ChatsTabController extends GetxController {
   /// current frame.
   bool _scrollIsInvoked = false;
 
+  /// [ChatService.paginated] length fetched during [ChatService.next] invoke
+  /// used to guard against the method spamming again and again.
+  int? _chatsInitiallyFetched;
+
   /// Returns [MyUser]'s [UserId].
   UserId? get me => _authService.userId;
 
@@ -891,8 +895,16 @@ class ChatsTabController extends GetxController {
         // fill the view and there's more pages available, then fetch those pages.
         if (scrollController.position.maxScrollExtent < 50 &&
             _chatService.nextLoading.isFalse) {
+          final int amount = _chatService.paginated.length;
+
           await _chatService.next();
-          _ensureScrollable();
+
+          _chatsInitiallyFetched = _chatService.paginated.length;
+
+          // Don't spam this method again and again if no chats were fetched.
+          if (_chatsInitiallyFetched != amount) {
+            _ensureScrollable();
+          }
         }
       });
     }

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -316,25 +316,34 @@ class PlatformUtilsImpl {
   }
 
   /// Returns a path to the cache directory.
-  FutureOr<Directory?> get libraryDirectory async {
+  FutureOr<Directory> get libraryDirectory async {
     if (_libraryDirectory != null) {
-      return _libraryDirectory;
+      return _libraryDirectory!;
     }
+
+    Directory? directory;
 
     try {
       if (isLinux) {
-        _libraryDirectory ??= dataHome;
-        return _libraryDirectory!;
+        directory ??= dataHome;
       } else {
-        return _libraryDirectory ??= await getLibraryDirectory();
+        directory = await getLibraryDirectory();
       }
     } on UnimplementedError {
-      return _libraryDirectory ??= await cacheDirectory;
+      directory =
+          await cacheDirectory ?? await getApplicationDocumentsDirectory();
     } on MissingPlatformDirectoryException {
-      return _libraryDirectory ??= await cacheDirectory;
+      directory ??= await cacheDirectory;
     } on MissingPluginException {
-      return null;
+      directory = Directory('');
     }
+
+    // Windows already contains both product name and company name in the path.
+    if (PlatformUtils.isWindows) {
+      return directory!;
+    }
+
+    return Directory('${directory?.path}/${Config.userAgentProduct}');
   }
 
   /// Indicates whether the application is in active state.

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -328,6 +328,8 @@ class PlatformUtilsImpl {
       } else {
         return _libraryDirectory ??= await getLibraryDirectory();
       }
+    } on UnimplementedError {
+      return _libraryDirectory ??= await cacheDirectory;
     } on MissingPlatformDirectoryException {
       return _libraryDirectory ??= await cacheDirectory;
     } on MissingPluginException {

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -32,6 +32,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:share_plus/share_plus.dart';
 import 'package:window_manager/window_manager.dart';
+import 'package:xdg_directories/xdg_directories.dart';
 
 import '/config.dart';
 import '/routes.dart';
@@ -61,6 +62,9 @@ class PlatformUtilsImpl {
 
   /// Temporary directory.
   Directory? _temporaryDirectory;
+
+  /// Library directory.
+  Directory? _libraryDirectory;
 
   /// `User-Agent` header to put in the network requests.
   String? _userAgent;
@@ -309,6 +313,26 @@ class PlatformUtilsImpl {
     _temporaryDirectory =
         Directory('${(await getTemporaryDirectory()).path}${Config.downloads}');
     return _temporaryDirectory!;
+  }
+
+  /// Returns a path to the cache directory.
+  FutureOr<Directory?> get libraryDirectory async {
+    if (_libraryDirectory != null) {
+      return _libraryDirectory;
+    }
+
+    try {
+      if (isLinux) {
+        _libraryDirectory ??= dataHome;
+        return _libraryDirectory!;
+      } else {
+        return _libraryDirectory ??= await getLibraryDirectory();
+      }
+    } on MissingPlatformDirectoryException {
+      return _libraryDirectory ??= await cacheDirectory;
+    } on MissingPluginException {
+      return null;
+    }
   }
 
   /// Indicates whether the application is in active state.

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -329,23 +329,23 @@ class PlatformUtilsImpl {
       if (isLinux) {
         directory ??= dataHome;
       } else {
-        directory = await getLibraryDirectory();
+        directory ??= await getLibraryDirectory();
       }
-    } on UnimplementedError {
-      directory =
-          await cacheDirectory ?? await getApplicationDocumentsDirectory();
-    } on MissingPlatformDirectoryException {
-      directory ??= await cacheDirectory;
     } on MissingPluginException {
       directory = Directory('');
+    } catch (_) {
+      directory ??= await cacheDirectory;
+      directory ??= await getApplicationDocumentsDirectory();
     }
 
     // Windows already contains both product name and company name in the path.
-    if (PlatformUtils.isWindows) {
-      return directory!;
+    //
+    // Android already contains the bundle identifier in the path.
+    if (PlatformUtils.isWindows || PlatformUtils.isAndroid) {
+      return directory;
     }
 
-    return Directory('${directory?.path}/${Config.userAgentProduct}');
+    return Directory('${directory.path}/${Config.userAgentProduct}');
   }
 
   /// Indicates whether the application is in active state.

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -315,7 +315,9 @@ class PlatformUtilsImpl {
     return _temporaryDirectory!;
   }
 
-  /// Returns a path to the cache directory.
+  /// Returns a path to the library directory.
+  ///
+  /// Should be used to put local storage files and caches that aren't temporal.
   FutureOr<Directory> get libraryDirectory async {
     if (_libraryDirectory != null) {
       return _libraryDirectory!;

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -35,6 +35,7 @@ import 'package:window_manager/window_manager.dart';
 import 'package:xdg_directories/xdg_directories.dart';
 
 import '/config.dart';
+import '/domain/model/native_file.dart';
 import '/routes.dart';
 import '/ui/worker/cache.dart';
 import '/util/log.dart';
@@ -665,15 +666,24 @@ class PlatformUtilsImpl {
     List<String>? allowedExtensions,
   }) async {
     try {
+      FileType accounted = type;
+      if (type == FileType.custom && isMobile) {
+        if (allowedExtensions == NativeFile.images) {
+          accounted = FileType.image;
+          allowedExtensions = null;
+        }
+      }
+
       return await FilePicker.platform.pickFiles(
-        type: type,
+        type: accounted,
         allowCompression: allowCompression,
         compressionQuality: compressionQuality,
         allowMultiple: allowMultiple,
         withData: withData,
         withReadStream: withReadStream,
         lockParentWindow: lockParentWindow,
-        allowedExtensions: allowedExtensions,
+        allowedExtensions:
+            accounted == FileType.custom ? allowedExtensions : null,
       );
     } on PlatformException catch (e) {
       if (e.code == 'already_active') {

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -132,7 +132,7 @@ PODS:
   - sqlite3_flutter_libs (0.0.1):
     - Flutter
     - FlutterMacOS
-    - sqlite3 (~> 3.47.1)
+    - sqlite3 (~> 3.47.2)
     - sqlite3/dbstatvtab
     - sqlite3/fts5
     - sqlite3/perf-threadsafe
@@ -299,7 +299,7 @@ SPEC CHECKSUMS:
   share_plus: 1fa619de8392a4398bfaf176d441853922614e89
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqlite3: 7559e33dae4c78538df563795af3a86fc887ee71
-  sqlite3_flutter_libs: 1b4e98da20ebd4e9b1240269b78cdcf492dbe9f3
+  sqlite3_flutter_libs: 58ae36c0dd086395d066b4fe4de9cdca83e717b3
   super_native_extensions: 85efee3a7495b46b04befcfc86ed12069264ebf3
   url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
   wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2451,7 +2451,7 @@ packages:
     source: hosted
     version: "1.1.2"
   xdg_directories:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: xdg_directories
       sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -113,6 +113,7 @@ dependencies:
   win32_registry: ^1.1.3
   window_manager: ^0.4.3
   windows_taskbar: ^1.1.1
+  xdg_directories: ^1.1.0
   xml: ^6.5.0
   yaml: ^3.1.2
 


### PR DESCRIPTION
## Synopsis

Currently `drift` uses `getApplicationDocumentsDirectory()` for its files, which may not be appropriate place to place multiple `.db` files.




## Solution

This PR makes `drift` to use `PlatformUtils.libraryDirectory` for Android and desktop and `dataHome` for Linux.

Android:
`/data/user/0/com.team113.messenger/cache`

iOS:
Shared directory.

macOS:
`/Users/***/Library/Containers/com.team113.messenger/Data/Library/Gapopa`

Windows:
`C:\Users\***\AppData\Local\IT ENGINEERING MANAGEMENT INC\Gapopa`

Linux:
`/home/***/.local/share/Gapopa`




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
