### PR TITLE
Fix macOS application hanging up when attaching screenshots in `Chat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ All user visible changes to this project will be documented in this file. This p
         - Context menus having meaningless dividers. ([#1170])
     - Chats tab:
         - Inability to paste clipboard into search field when chat is open. ([#1170])
+- macOS:
+    - Application becoming unresponsive when drag-n-dropping screenshots to chat. ([#1176])
 
 [#1170]: /../../pull/1170
+[#1176]: /../../pull/1176
 
 
 

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -1287,10 +1287,11 @@ class ChatController extends GetxController {
   /// Adds the specified [event] files to the [send] field.
   Future<void> dropFiles(PerformDropEvent event) async {
     for (final DropItem item in event.session.items) {
-      final PlatformFile? file = await item.dataReader?.asPlatformFile();
-      if (file != null) {
-        send.addPlatformAttachment(file);
-      }
+      item.dataReader?.asPlatformFile().then((e) {
+        if (e != null) {
+          send.addPlatformAttachment(e);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
## Synopsis

When screenshot is made and this screenshot is attached to macOS application, it hangs up.




## Solution

This PR fixes this by not awaiting the future.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
