### PR TITLE
Refactor `UpgradeWorker` to detect `flutter_bootstrap.js` changes for Web platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.4.0] · 2025-??-??
+[0.4.0]: /../../tree/v0.4.0
+
+[Diff](/../../compare/v0.3.3...v0.4.0) | [Milestone](/../../milestone/35)
+
+### Added
+
+- Web:
+    - Upgrade popup displaying when new deployment is available. ([#1181])
+
+[#1181]: /../../pull/1181
+
+
+
+
 ## [0.3.3] · 2025-03-07
 [0.3.3]: /../../tree/v0.3.3
 

--- a/helm/messenger/Chart.yaml
+++ b/helm/messenger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: messenger
 description: Open-source front-end part of messenger by team113.
 version: 0.1.3
-appVersion: 0.3.3
+appVersion: 0.3.4
 type: application
 sources:
   - https://github.com/team113/messenger

--- a/helm/messenger/conf/nginx.conf
+++ b/helm/messenger/conf/nginx.conf
@@ -91,6 +91,11 @@ server {
     try_files    /conf/$host.yaml /conf/$host.toml $uri.toml $uri.yaml  =404;
   }
 
+  location = /flutter_bootstrap.js {
+    expires      1m;
+    try_files    $uri $uri/  =404;
+  }
+
   location = /privacy {
     try_files    /assets/assets/privacy.html  =404;  # URI, not a file path
   }

--- a/helm/messenger/conf/nginx.conf
+++ b/helm/messenger/conf/nginx.conf
@@ -93,7 +93,6 @@ server {
 
   location = /flutter_bootstrap.js {
     expires      1m;
-    try_files    $uri $uri/  =404;
   }
 
   location = /privacy {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -115,7 +115,7 @@ PODS:
     - Flutter
   - image_picker_ios (0.0.1):
     - Flutter
-  - instrumentisto-libwebrtc-bin (133.0.6943.141)
+  - instrumentisto-libwebrtc-bin (134.0.6998.88)
   - integration_test (0.0.1):
     - Flutter
   - irondash_engine_context (0.0.1):
@@ -123,9 +123,9 @@ PODS:
   - just_audio (0.0.1):
     - Flutter
     - FlutterMacOS
-  - medea_flutter_webrtc (0.13.0):
+  - medea_flutter_webrtc (0.13.1):
     - Flutter
-    - instrumentisto-libwebrtc-bin (= 133.0.6943.141)
+    - instrumentisto-libwebrtc-bin (= 134.0.6998.88)
   - medea_jason (0.8.0):
     - Flutter
   - media_kit_libs_ios_video (1.0.4):
@@ -358,11 +358,11 @@ SPEC CHECKSUMS:
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   image_gallery_saver: 14711d79da40581063e8842a11acf1969d781ed7
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
-  instrumentisto-libwebrtc-bin: f17d6adc3850e647003ab692d5b6d1e6d7d1e211
+  instrumentisto-libwebrtc-bin: 5c2708895c97f5e4d5287b246d6f5a220ccf1c64
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   irondash_engine_context: 8e58ca8e0212ee9d1c7dc6a42121849986c88486
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
-  medea_flutter_webrtc: 3a63bfc15141337030dba87c83510c46728a11e7
+  medea_flutter_webrtc: 3907a091743b6e31d074fd7e0e0a1b2d0edcdbbd
   medea_jason: d188237d4b036308a3d0f69b78d46c6f43519e13
   media_kit_libs_ios_video: 5a18affdb97d1f5d466dc79988b13eff6c5e2854
   media_kit_native_event_loop: 5fba1a849a6c87a34985f1e178a0de5bd444a0cf

--- a/lib/domain/service/notification.dart
+++ b/lib/domain/service/notification.dart
@@ -75,7 +75,7 @@ class NotificationService extends DisposableService {
   /// push notifications in foreground.
   StreamSubscription? _foregroundSubscription;
 
-  /// Subscription to the [PlatformUtils.onActivityChanged] updating the
+  /// Subscription to the [PlatformUtilsImpl.onActivityChanged] updating the
   /// [_active].
   StreamSubscription? _onActivityChanged;
 

--- a/lib/ui/worker/upgrade.dart
+++ b/lib/ui/worker/upgrade.dart
@@ -21,6 +21,7 @@ import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:pub_semver/pub_semver.dart';
+import 'package:uuid/uuid.dart';
 import 'package:xml/xml.dart';
 
 import '/config.dart';
@@ -33,6 +34,7 @@ import '/ui/widget/upgrade_popup/view.dart';
 import '/util/log.dart';
 import '/util/message_popup.dart';
 import '/util/platform_utils.dart';
+import '/util/web/web_utils.dart';
 
 /// Worker fetching [Config.appcast] file and prompting [UpgradePopupView] on
 /// new [Release]s available.
@@ -48,23 +50,23 @@ class UpgradeWorker extends DisposableService {
   /// Latest [Release] fetched during the [fetchUpdates].
   Release? _latest;
 
+  /// Latest [String] representing `flutter_bootstrap.js` file fetched.
+  String? _lastBootstrapJs;
+
   /// [Duration] to display the [UpgradePopupView] after, when [_schedulePopup]
   /// is triggered.
   static const Duration _popupDelay = Duration(seconds: 1);
 
   /// [Duration] being the period of [_timer].
-  static const Duration _refreshPeriod = Duration(minutes: 5);
+  static const Duration _refreshPeriod = Duration(minutes: 2);
 
   @override
   void onReady() {
     Log.debug('onReady()', '$runtimeType');
 
-    // Web gets its updates out of the box with a simple page refresh.
-    if (!PlatformUtils.isWeb) {
-      fetchUpdates();
-    }
+    fetchUpdates();
 
-    if (Config.appcast.isNotEmpty) {
+    if (Config.appcast.isNotEmpty || PlatformUtils.isWeb) {
       _timer = Timer.periodic(_refreshPeriod, (_) {
         fetchUpdates();
       });
@@ -85,14 +87,24 @@ class UpgradeWorker extends DisposableService {
     await _skippedLocal?.upsert(release.name);
   }
 
+  /// Invokes [_fetchBootstrapJs] over [PlatformUtilsImpl.isWeb] and
+  /// [_fetchAppcast] otherwise to check against any updates being available.
+  Future<bool> fetchUpdates({bool force = false}) async {
+    if (PlatformUtils.isWeb) {
+      return await _fetchBootstrapJs();
+    }
+
+    return await _fetchAppcast(force: force);
+  }
+
   /// Fetches the [Config.appcast] file to [_schedulePopup], if new [Release] is
   /// detected.
   ///
   /// Returns `true`, if new update is detected.
   ///
   /// If [force] is `true`, then ignores the [_skippedLocal] stored one.
-  Future<bool> fetchUpdates({bool force = false}) async {
-    Log.debug('fetchUpdates(force: $force)', '$runtimeType');
+  Future<bool> _fetchAppcast({bool force = false}) async {
+    Log.debug('_fetchAppcast(force: $force)', '$runtimeType');
 
     if (Config.appcast.isEmpty) {
       return false;
@@ -182,7 +194,49 @@ class UpgradeWorker extends DisposableService {
         }
       }
     } catch (e) {
-      Log.info('Failed to fetch releases: $e', '$runtimeType');
+      Log.info('Failed to fetch `appcast.xml` releases: $e', '$runtimeType');
+    }
+
+    return false;
+  }
+
+  /// Fetches the `flutter_bootstrap.js` file hosted over [Config.origin] with
+  /// every Flutter Web build to check whether there's any new build available.
+  ///
+  /// Returns `true`, if new update is detected.
+  Future<bool> _fetchBootstrapJs() async {
+    Log.debug('_fetchBootstrapJs()', '$runtimeType');
+
+    try {
+      final response = await (await PlatformUtils.dio).get(
+        '${Config.origin}/flutter_bootstrap.js?${const Uuid().v4()}',
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw DioException.connectionError(
+          requestOptions: RequestOptions(),
+          reason: 'Status code ${response.statusCode}',
+        );
+      }
+
+      final String bootstrapJs = response.data as String;
+
+      if (_lastBootstrapJs != null && _lastBootstrapJs != bootstrapJs) {
+        _schedulePopup(
+          Release(
+            name: '${DateTime.now().microsecondsSinceEpoch}',
+            description: null,
+            publishedAt: DateTime.now(),
+            assets: [],
+          ),
+          critical: false,
+          silent: true,
+        );
+      }
+
+      _lastBootstrapJs = bootstrapJs;
+    } catch (e) {
+      Log.info('Failed to fetch `flutter_bootstrap.js`: $e', '$runtimeType');
     }
 
     return false;
@@ -203,6 +257,10 @@ class UpgradeWorker extends DisposableService {
           'label_update_is_available'.l10n,
           duration: const Duration(minutes: 5),
           onPressed: () async {
+            if (PlatformUtils.isWeb) {
+              await WebUtils.refresh();
+            }
+
             await UpgradePopupView.show(
               router.context!,
               release: release,

--- a/lib/ui/worker/upgrade.dart
+++ b/lib/ui/worker/upgrade.dart
@@ -257,7 +257,7 @@ class UpgradeWorker extends DisposableService {
       if (silent && !critical) {
         return MessagePopup.success(
           'label_update_is_available'.l10n,
-          duration: const Duration(minutes: 5),
+          duration: const Duration(days: 365),
           onPressed: () async {
             if (PlatformUtils.isWeb) {
               await WebUtils.refresh();

--- a/lib/ui/worker/upgrade.dart
+++ b/lib/ui/worker/upgrade.dart
@@ -272,11 +272,27 @@ class UpgradeWorker extends DisposableService {
         );
       }
 
-      await UpgradePopupView.show(
-        router.context!,
-        release: release,
-        critical: critical,
-      );
+      // Schedules the [UpgradePopupView] to be displayed only when context is
+      // not `null`.
+      Future<void> schedulePopup() async {
+        SchedulerBinding.instance.addPostFrameCallback((_) async {
+          if (isClosed) {
+            return;
+          }
+
+          if (router.context == null) {
+            return schedulePopup();
+          }
+
+          await UpgradePopupView.show(
+            router.context!,
+            release: release,
+            critical: critical,
+          );
+        });
+      }
+
+      schedulePopup();
     }
 
     if (delay) {

--- a/lib/ui/worker/upgrade.dart
+++ b/lib/ui/worker/upgrade.dart
@@ -90,11 +90,13 @@ class UpgradeWorker extends DisposableService {
   /// Invokes [_fetchBootstrapJs] over [PlatformUtilsImpl.isWeb] and
   /// [_fetchAppcast] otherwise to check against any updates being available.
   Future<bool> fetchUpdates({bool force = false}) async {
-    if (PlatformUtils.isWeb) {
+    if (Config.appcast.isNotEmpty) {
+      return await _fetchAppcast(force: force);
+    } else if (PlatformUtils.isWeb) {
       return await _fetchBootstrapJs();
     }
 
-    return await _fetchAppcast(force: force);
+    return false;
   }
 
   /// Fetches the [Config.appcast] file to [_schedulePopup], if new [Release] is

--- a/lib/ui/worker/upgrade.dart
+++ b/lib/ui/worker/upgrade.dart
@@ -260,7 +260,7 @@ class UpgradeWorker extends DisposableService {
           duration: const Duration(days: 365),
           onPressed: () async {
             if (PlatformUtils.isWeb) {
-              await WebUtils.refresh();
+              return await WebUtils.refresh();
             }
 
             await UpgradePopupView.show(

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -464,4 +464,9 @@ class WebUtils {
       Log.warning('Unable to unbind hot key: $e', 'WebUtils');
     }
   }
+
+  /// Refreshes the current browser's page.
+  static Future<void> refresh() async {
+    // No-op.
+  }
 }

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -900,6 +900,11 @@ class WebUtils {
 
     return false;
   }
+
+  /// Refreshes the current browser's page.
+  static Future<void> refresh() async {
+    web.window.location.reload();
+  }
 }
 
 /// Extension adding JSON manipulation methods to a [Rect].

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -87,7 +87,7 @@ PODS:
     - FlutterMacOS
   - macos_haptic_feedback (1.0.0):
     - FlutterMacOS
-  - medea_flutter_webrtc (0.13.0):
+  - medea_flutter_webrtc (0.13.1):
     - FlutterMacOS
   - medea_jason (0.8.0):
     - FlutterMacOS
@@ -100,6 +100,8 @@ PODS:
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
   - open_file_mac (0.0.1):
     - FlutterMacOS
   - package_info_plus (0.0.1):
@@ -292,7 +294,7 @@ SPEC CHECKSUMS:
   irondash_engine_context: 893c7d96d20ce361d7e996f39d360c4c2f9869ba
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   macos_haptic_feedback: 298e5c06ffc3838e80c557b24a74937a060798e6
-  medea_flutter_webrtc: c9bab94d2840c02125801f7c80d5a27c0a9e02cc
+  medea_flutter_webrtc: 0be940eba927d2821a580a76f588a214e919f5a6
   medea_jason: 351bd7aabdce16a9ac0dc461a59852cd77cbcd05
   media_kit_libs_macos_video: 85a23e549b5f480e72cae3e5634b5514bc692f65
   media_kit_native_event_loop: a80d071c835c612fd80173e79390a50ec409f1b1
@@ -315,6 +317,6 @@ SPEC CHECKSUMS:
   wakelock_plus: 21ddc249ac4b8d018838dbdabd65c5976c308497
   window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 
-PODFILE CHECKSUM: 1eb246b7252feb97518a5c5b6e33b324dc30a54d
+PODFILE CHECKSUM: d31615892e294512c5c96e376ac03ed16d1d001d
 
 COCOAPODS: 1.16.2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1330,10 +1330,10 @@ packages:
     dependency: "direct main"
     description:
       name: medea_flutter_webrtc
-      sha256: "58f0ba98cc52dbfb18455bd092bce6f69c50475ee4465339cc76a3a86a1f6949"
+      sha256: "216cbbb799392d4fc750a4a8db9abca2c27184c103c344166f24d1a0fb952a5c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.13.1"
   medea_jason:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.3.3
+version: 0.3.4
 publish_to: none
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,7 +67,7 @@ dependencies:
   log_me: ^0.1.2
   macos_haptic_feedback: ^1.0.0
   material_floating_search_bar: ^0.3.7
-  medea_flutter_webrtc: ^0.13.0
+  medea_flutter_webrtc: ^0.13.1
   medea_jason: ^0.8.0
   media_kit: ^1.1.5
   media_kit_libs_android_video: ^1.3.2

--- a/web/flutter_bootstrap.js
+++ b/web/flutter_bootstrap.js
@@ -20,7 +20,8 @@
 
 // Add `?v=` tag to `main.dart.js` file with service worker version to ensure
 // the file is re-fetched from the network on the changes.
-_flutter.buildConfig.builds[0].mainJsPath += "?v=" + '{{flutter_service_worker_version}}';
+_flutter.buildConfig.builds[0].mainJsPath +=
+    "?v=" + '{{flutter_service_worker_version}}';
 
 _flutter.loader.load({
     serviceWorker: {

--- a/web/flutter_bootstrap.js
+++ b/web/flutter_bootstrap.js
@@ -18,6 +18,10 @@
 {{flutter_js}}
 {{flutter_build_config}}
 
+// Add `?v=` tag to `main.dart.js` file with service worker version to ensure
+// the file is re-fetched from the network on the changes.
+_flutter.buildConfig.builds[0].mainJsPath += "?v=" + '{{flutter_service_worker_version}}';
+
 _flutter.loader.load({
     serviceWorker: {
         serviceWorkerVersion: '{{flutter_service_worker_version}}'


### PR DESCRIPTION
## Synopsis

`UpgradeWorker` is used to fetch the updates being available on desktop platforms. However, on Web there's currently no mechanism neither to detect the changes nor the apply the changes.




## Solution

This PR makes `UpgradeWorker` to detect the changes in `flutter_bootstrap.js` in order to display an `upgrade available` popup and refresh the page. Additionally this PR adds the service worker version to the `main.dart.js` file so that is it re-fetched every time the service worker version is changed removing the necessity to refresh the page multiple times.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
