### PR TITLE
Use `ObscuredSelectionArea` while `router.obscuring` is not empty (#1187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,14 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - User page:
         - Missing localization for biography expand button. ([#1185], [#1186])
+        - Inability to input block reason in Safari and Firefox. ([#1190], [#1187])
 
 [#1181]: /../../pull/1181
 [#1182]: /../../pull/1182
 [#1185]: /../../pull/1185
 [#1186]: /../../issues/1186
+[#1187]: /../../issues/1187
+[#1190]: /../../pull/1190
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -678,6 +678,7 @@ label_call_title =
             *[other] Calling...
         }
     }
+label_call_window = Call window
 label_calls = Calls
 label_calls_displaying = In separate window or within app
 label_camera = Camera

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -699,6 +699,7 @@ label_call_title =
             *[other] Звоним...
         }
     }
+label_call_window = Окно звонка
 label_calls = Звонки
 label_calls_displaying = В отдельном окне или в приложении
 label_camera = Камера

--- a/lib/ui/page/home/page/chat/info/view.dart
+++ b/lib/ui/page/home/page/chat/info/view.dart
@@ -44,6 +44,7 @@ import '/ui/page/home/widget/direct_link.dart';
 import '/ui/page/home/widget/highlighted_container.dart';
 import '/ui/widget/animated_button.dart';
 import '/ui/widget/member_tile.dart';
+import '/ui/widget/obscured_selection_area.dart';
 import '/ui/widget/primary_button.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/svg/svg.dart';
@@ -107,7 +108,7 @@ class ChatInfoView extends StatelessWidget {
             appBar: CustomAppBar(title: _bar(c, context)),
             body: Scrollbar(
               controller: c.scrollController,
-              child: SelectionArea(
+              child: ObscuredSelectionArea(
                 contextMenuBuilder: (_, __) => const SizedBox(),
                 child: ScrollablePositionedList.builder(
                   key: const Key('ChatInfoScrollable'),

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -51,6 +51,7 @@ import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
 import '/ui/widget/menu_interceptor/menu_interceptor.dart';
+import '/ui/widget/obscured_selection_area.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/safe_area/safe_area.dart';
 import '/ui/widget/selected_dot.dart';
@@ -751,7 +752,7 @@ class ChatView extends StatelessWidget {
                                 }
                               }
 
-                              return SelectionArea(
+                              return ObscuredSelectionArea(
                                 key: Key('${c.selecting.value}'),
                                 onSelectionChanged:
                                     (a) => c.selection.value = a,

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -50,7 +50,7 @@ import '/ui/widget/animated_button.dart';
 import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
-import '/ui/widget/menu_interceptor/menu_interceptor.dart';
+import '/ui/widget/obscured_menu_interceptor.dart';
 import '/ui/widget/obscured_selection_area.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/safe_area/safe_area.dart';
@@ -703,7 +703,9 @@ class ChatView extends StatelessWidget {
                             // Required for the [Stack] to take [Scaffold]'s
                             // size.
                             IgnorePointer(
-                              child: ContextMenuInterceptor(child: Container()),
+                              child: ObscuredMenuInterceptor(
+                                child: Container(),
+                              ),
                             ),
                             Obx(() {
                               final Widget child = FlutterListView(
@@ -758,7 +760,7 @@ class ChatView extends StatelessWidget {
                                     (a) => c.selection.value = a,
                                 contextMenuBuilder: (_, __) => const SizedBox(),
                                 selectionControls: EmptyTextSelectionControls(),
-                                child: ContextMenuInterceptor(child: child),
+                                child: ObscuredMenuInterceptor(child: child),
                               );
                             }),
                             Obx(() {

--- a/lib/ui/page/home/page/chat/widget/selection_text.dart
+++ b/lib/ui/page/home/page/chat/widget/selection_text.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show SelectedContent;
 
 import '/ui/widget/menu_interceptor/menu_interceptor.dart';
+import '/ui/widget/obscured_selection_area.dart';
 import '/util/platform_utils.dart';
 
 /// [Text] wrapped in a [SelectionArea] if [selectable].
@@ -92,7 +93,7 @@ class _SelectionTextState extends State<SelectionText> {
           child: child,
         );
       } else {
-        child = SelectionArea(
+        child = ObscuredSelectionArea(
           onSelectionChanged: widget.onChanged,
           child: child,
         );

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -263,6 +263,9 @@ class MyProfileController extends GetxController {
   /// Worker to react on [RouterState.profileSection] changes.
   Worker? _profileWorker;
 
+  /// Worker to update [name], [login] and other fields on the [MyUser] changes.
+  Worker? _myUserWorker;
+
   /// [StreamSubscription] for the [MediaUtilsImpl.onDeviceChange] stream
   /// updating the [devices].
   StreamSubscription? _devicesSubscription;
@@ -511,6 +514,24 @@ class MyProfileController extends GetxController {
       },
     );
 
+    _myUserWorker = ever(myUser, (myUser) {
+      if (!name.focus.hasFocus) {
+        name.unchecked = myUser?.name?.val;
+      }
+
+      if (!about.focus.hasFocus) {
+        about.unchecked = myUser?.bio?.val;
+      }
+
+      if (!status.focus.hasFocus) {
+        status.unchecked = myUser?.status?.val;
+      }
+
+      if (!login.focus.hasFocus) {
+        login.unchecked = myUser?.login?.val;
+      }
+    });
+
     super.onInit();
   }
 
@@ -525,6 +546,7 @@ class MyProfileController extends GetxController {
     _profileWorker?.dispose();
     _devicesSubscription?.cancel();
     scrollController.dispose();
+    _myUserWorker?.dispose();
     super.onClose();
   }
 

--- a/lib/ui/page/home/page/my_profile/session/controller.dart
+++ b/lib/ui/page/home/page/my_profile/session/controller.dart
@@ -256,6 +256,8 @@ extension UserAgentExtension on UserAgent {
         return 'watchOS';
       } else if (system.startsWith('tvOS')) {
         return 'tvOS';
+      } else if (system.startsWith('Windows')) {
+        return 'Windows';
       } else {
         return system;
       }

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -210,7 +210,7 @@ Widget _block(BuildContext context, MyProfileController c, int i) {
                       ),
                       child: Center(
                         child: Text(
-                          'label_exclamation_mark'.l10n,
+                          'exclamation_mark'.l10n,
                           style: style.fonts.smallest.regular.onPrimary,
                         ),
                       ),

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -35,6 +35,7 @@ import '/ui/page/home/widget/big_avatar.dart';
 import '/ui/page/home/widget/block.dart';
 import '/ui/page/home/widget/highlighted_container.dart';
 import '/ui/widget/animated_button.dart';
+import '/ui/widget/obscured_selection_area.dart';
 import '/ui/widget/primary_button.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/svg/svg.dart';
@@ -93,7 +94,7 @@ class UserView extends StatelessWidget {
             appBar: CustomAppBar(title: _bar(c, context)),
             body: Scrollbar(
               controller: c.scrollController,
-              child: SelectionArea(
+              child: ObscuredSelectionArea(
                 contextMenuBuilder: (_, __) => const SizedBox(),
                 child: ScrollablePositionedList.builder(
                   key: const Key('UserScrollable'),

--- a/lib/ui/widget/modal_popup.dart
+++ b/lib/ui/widget/modal_popup.dart
@@ -17,6 +17,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../routes.dart';
 import '/themes.dart';
 import '/ui/widget/svg/svgs.dart';
 import '/util/platform_utils.dart';
@@ -49,7 +50,7 @@ abstract class ModalPopup {
     EdgeInsets desktopPadding = const EdgeInsets.fromLTRB(0, 0, 0, 10),
     bool isDismissible = true,
     Color? background,
-  }) {
+  }) async {
     final style = Theme.of(context).style;
 
     if (context.isMobile) {
@@ -107,8 +108,7 @@ abstract class ModalPopup {
         },
       );
     } else {
-      return showGeneralDialog(
-        context: context,
+      final route = RawDialogRoute<T>(
         barrierColor: style.barrierColor,
         barrierDismissible: isDismissible,
         pageBuilder: (_, __, ___) {
@@ -143,6 +143,16 @@ abstract class ModalPopup {
           );
         },
       );
+
+      router.obscuring.add(route);
+      print('====== router.obscuring.add -> ${router.obscuring}');
+
+      try {
+        return await Navigator.of(context, rootNavigator: true).push<T>(route);
+      } finally {
+        router.obscuring.remove(route);
+        print('====== router.obscuring.remove -> ${router.obscuring}');
+      }
     }
   }
 }

--- a/lib/ui/widget/modal_popup.dart
+++ b/lib/ui/widget/modal_popup.dart
@@ -17,7 +17,7 @@
 
 import 'package:flutter/material.dart';
 
-import '../../routes.dart';
+import '/routes.dart';
 import '/themes.dart';
 import '/ui/widget/svg/svgs.dart';
 import '/util/platform_utils.dart';
@@ -54,16 +54,24 @@ abstract class ModalPopup {
     final style = Theme.of(context).style;
 
     if (context.isMobile) {
-      return showModalBottomSheet(
-        context: context,
-        barrierColor: style.barrierColor,
+      final NavigatorState navigator = Navigator.of(
+        context,
+        rootNavigator: true,
+      );
+
+      final route = ModalBottomSheetRoute<T>(
+        modalBarrierColor: style.barrierColor,
         isScrollControlled: true,
         backgroundColor: background ?? style.colors.background,
         isDismissible: isDismissible,
         enableDrag: isDismissible,
         elevation: 0,
+        capturedThemes: InheritedTheme.capture(
+          from: context,
+          to: navigator.context,
+        ),
         transitionAnimationController: BottomSheet.createAnimationController(
-          Navigator.of(context),
+          navigator,
         )..duration = const Duration(milliseconds: 350),
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.only(
@@ -107,6 +115,14 @@ abstract class ModalPopup {
           );
         },
       );
+
+      router.obscuring.add(route);
+
+      try {
+        return await Navigator.of(context, rootNavigator: true).push<T>(route);
+      } finally {
+        router.obscuring.remove(route);
+      }
     } else {
       final route = RawDialogRoute<T>(
         barrierColor: style.barrierColor,
@@ -145,13 +161,11 @@ abstract class ModalPopup {
       );
 
       router.obscuring.add(route);
-      print('====== router.obscuring.add -> ${router.obscuring}');
 
       try {
         return await Navigator.of(context, rootNavigator: true).push<T>(route);
       } finally {
         router.obscuring.remove(route);
-        print('====== router.obscuring.remove -> ${router.obscuring}');
       }
     }
   }

--- a/lib/ui/widget/obscured_menu_interceptor.dart
+++ b/lib/ui/widget/obscured_menu_interceptor.dart
@@ -1,0 +1,88 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '/routes.dart';
+import '/util/platform_utils.dart';
+import '/util/web/web_utils.dart';
+import 'menu_interceptor/menu_interceptor.dart';
+
+/// [ContextMenuInterceptor] respecting the [RouterState.obscuring].
+///
+/// Workarounds an issue with [TextField]s becoming unresponsive under Web
+/// platforms:
+/// https://github.com/flutter/flutter/issues/157579
+class ObscuredMenuInterceptor extends StatefulWidget {
+  const ObscuredMenuInterceptor({
+    super.key,
+    this.margin = EdgeInsets.zero,
+    required this.child,
+    this.enabled = true,
+    this.debug = false,
+  });
+
+  /// [EdgeInsets] being the margin of the interception.
+  final EdgeInsets margin;
+
+  /// Widget being wrapped.
+  final Widget child;
+
+  /// Indicator whether this widget should be active or not.
+  final bool enabled;
+
+  /// Indicator whether a semi-transparent red background should be renderer or
+  /// not, used for debug purposes.
+  final bool debug;
+
+  @override
+  State<ObscuredMenuInterceptor> createState() =>
+      _ObscuredMenuInterceptorState();
+}
+
+/// State of a [ObscuredMenuInterceptor] maintaining the [GlobalKey].
+class _ObscuredMenuInterceptorState extends State<ObscuredMenuInterceptor> {
+  /// [GlobalKey] to use with [KeyedSubtree] to keep child from rebuilding.
+  final GlobalKey _key = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isApplicable =
+        PlatformUtils.isWeb && (WebUtils.isSafari || WebUtils.isFirefox);
+
+    final Widget child = KeyedSubtree(key: _key, child: widget.child);
+    final Widget interceptor = ContextMenuInterceptor(
+      margin: widget.margin,
+      enabled: widget.enabled,
+      debug: widget.debug,
+      child: child,
+    );
+
+    if (!isApplicable) {
+      return interceptor;
+    }
+
+    return Obx(() {
+      if (router.obscuring.isNotEmpty) {
+        return child;
+      }
+
+      return interceptor;
+    });
+  }
+}

--- a/lib/ui/widget/obscured_selection_area.dart
+++ b/lib/ui/widget/obscured_selection_area.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:get/get.dart';
+
+import '/routes.dart';
+
+class ObscuredSelectionArea extends StatefulWidget {
+  const ObscuredSelectionArea({
+    super.key,
+    this.focusNode,
+    this.selectionControls,
+    this.contextMenuBuilder = _defaultContextMenuBuilder,
+    this.magnifierConfiguration,
+    this.onSelectionChanged,
+    required this.child,
+  });
+
+  /// Configuration for the magnifier in the selection region.
+  final TextMagnifierConfiguration? magnifierConfiguration;
+
+  /// An optional focus node to use as the focus node for this widget.
+  final FocusNode? focusNode;
+
+  /// Delegate to build the selection handles and toolbar.
+  ///
+  /// If it is null, the platform specific selection control is used.
+  final TextSelectionControls? selectionControls;
+
+  /// Builds the text selection toolbar when requested by the user.
+  final SelectableRegionContextMenuBuilder? contextMenuBuilder;
+
+  /// Called when the selected content changes.
+  final ValueChanged<SelectedContent?>? onSelectionChanged;
+
+  /// Child widget [SelectionArea] applies to.
+  final Widget child;
+
+  @override
+  State<ObscuredSelectionArea> createState() => _ObscuredSelectionAreaState();
+
+  static Widget _defaultContextMenuBuilder(
+    BuildContext context,
+    SelectableRegionState selectableRegionState,
+  ) {
+    return AdaptiveTextSelectionToolbar.selectableRegion(
+      selectableRegionState: selectableRegionState,
+    );
+  }
+}
+
+class _ObscuredSelectionAreaState extends State<ObscuredSelectionArea> {
+  final GlobalKey _key = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      if (router.obscuring.isNotEmpty) {
+        return KeyedSubtree(key: _key, child: widget.child);
+      }
+
+      return SelectionArea(
+        magnifierConfiguration: widget.magnifierConfiguration,
+        focusNode: widget.focusNode,
+        selectionControls: widget.selectionControls,
+        contextMenuBuilder: widget.contextMenuBuilder,
+        onSelectionChanged: widget.onSelectionChanged,
+        child: KeyedSubtree(key: _key, child: widget.child),
+      );
+    });
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1330,10 +1330,10 @@ packages:
     dependency: "direct main"
     description:
       name: medea_flutter_webrtc
-      sha256: "8629fd8583e312d8f8c0b08b9095fa06e443da4e5dccf80dd95a8f87e9e5bc94"
+      sha256: "216cbbb799392d4fc750a4a8db9abca2c27184c103c344166f24d1a0fb952a5c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.2"
+    version: "0.13.1"
   medea_jason:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1330,10 +1330,10 @@ packages:
     dependency: "direct main"
     description:
       name: medea_flutter_webrtc
-      sha256: "216cbbb799392d4fc750a4a8db9abca2c27184c103c344166f24d1a0fb952a5c"
+      sha256: "8629fd8583e312d8f8c0b08b9095fa06e443da4e5dccf80dd95a8f87e9e5bc94"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.1"
+    version: "0.13.2"
   medea_jason:
     dependency: "direct main"
     description:

--- a/test/widget/auth_test.dart
+++ b/test/widget/auth_test.dart
@@ -137,6 +137,7 @@ void main() async {
     router = MockRouterState();
     router.provider = MockedPlatformRouteInformationProvider();
     when(router.routes).thenReturn(RxList());
+    when(router.obscuring).thenReturn(RxList());
 
     await tester.pumpWidget(createWidgetForTesting(child: const AuthView()));
     await tester.pumpAndSettle();


### PR DESCRIPTION
Resolves #1187




## Synopsis

Reason cannot be inputted in Safari and Firefox.




## Solution

This PR fixes the issue by using `router.obscured` to determine whether `SelectionArea` should be rendered at all or not.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
