### PR TITLE
Use `MessageFieldController.onKeyUp` to enter editing of last `ChatMessage` in `Chat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ All user visible changes to this project will be documented in this file. This p
     - Redesigned share link modal. ([#1191])
     - Redesigned logout modal. ([#1194])
     - Redesigned call window switch modal. ([#1194])
+    - Chat page:
+        - Message field gaining focus when entering chat. ([#1196])
+        - Key up presses editing last sent message. ([#1196])
 
 ### Fixed
 
@@ -46,6 +49,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1191]: /../../pull/1191
 [#1193]: /../../pull/1193
 [#1194]: /../../pull/1194
+[#1196]: /../../pull/1196
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -873,6 +873,8 @@ label_image_saved_to_gallery = Image saved to gallery.
 label_in_message = In message
 label_incoming_call = Incoming call
 label_info = Info
+label_installation_error = Installation error
+label_installation_error_description = Web App is already installed or not available in your browser
 label_interface = Interface
 label_introduction_description1 =
     Access to a guest account is maintained for one year or until:

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -202,6 +202,7 @@ btn_delete_for_all = Delete for all
 btn_delete_from_contacts = Delete from contacts
 btn_delete_from_favorites = Remove from favorites
 btn_delete_message = Delete message
+btn_discard = Discard
 btn_dismiss = Dismiss
 btn_do_not_allow = Do not allow
 btn_done = Done
@@ -793,6 +794,7 @@ label_direct_chat_link_description =
 label_direct_chat_link_in_chat_description =
     Users who come via a direct link automatically become full members of the group.
 label_disabled = Disabled
+label_discard_changes_question = Discard changes?
 label_display_audio_and_video_call_buttons = Display audio and video call buttons
 label_display_timestamps = Display timestamps
 label_download = Download

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -202,6 +202,7 @@ btn_delete_for_all = Удалить для всех
 btn_delete_from_contacts = Удалить из контактов
 btn_delete_from_favorites = Удалить из избранных
 btn_delete_message = Удалить сообщение
+btn_discard = Отменить
 btn_dismiss = Запретить
 btn_do_not_allow = Не разрешать
 btn_done = Готово
@@ -815,6 +816,7 @@ label_direct_chat_link_description =
 label_direct_chat_link_in_chat_description =
     Пользователи, пришедшие по прямой ссылке, автоматически становятся полноправными участниками группы.
 label_disabled = Отключены
+label_discard_changes_question = Отменить изменения?
 label_display_audio_and_video_call_buttons = Отображать кнопки аудио и видео звонка
 label_display_timestamps = Отображать метки времени
 label_download = Скачать

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -895,6 +895,8 @@ label_image_saved_to_gallery = Изображение сохранено в га
 label_in_message = В сообщении
 label_incoming_call = Входящий звонок
 label_info = Информация
+label_installation_error = Ошибка инсталляции
+label_installation_error_description = Веб приложение уже установлено или недоступно в Вашем браузере
 label_interface = Интерфейс
 label_introduction_description1 =
     Доступ к гостевому аккаунту сохраняется в течение одного года или пока:

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -458,8 +458,6 @@ class ChatController extends GetxController {
             editMessage(previous.value);
             return true;
           }
-        } else if (key == LogicalKeyboardKey.arrowDown) {
-          return true;
         }
 
         return false;

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -1302,32 +1302,28 @@ Widget _downloads(BuildContext context, MyProfileController c) {
     );
   });
 
-  final bool installed =
-      WebUtils.hasPwa || PWAInstall().launchMode != LaunchMode.browser;
-
   return Column(
     children: [
       LineDivider('label_version_semicolon'.l10nfmt({'version': Pubspec.ref})),
       SizedBox(height: 16),
-      if (installed || PWAInstall().installPromptEnabled) ...[
-        if (!PlatformUtils.isWeb) ...[latestButton, SizedBox(height: 8)],
-        FieldButton(
-          text: installed ? 'btn_pwa_is_installed' : 'btn_install_web_app'.l10n,
-          onPressed:
-              installed
-                  ? null
-                  : () async {
-                    if (PWAInstall().installPromptEnabled) {
-                      PWAInstall().promptInstall_();
-                    }
-                  },
-          trailing: Padding(
-            padding: const EdgeInsets.only(left: 4),
-            child: SvgIcon(SvgIcons.logo, height: 30),
-          ),
+      if (PlatformUtils.isWeb) ...[latestButton, SizedBox(height: 8)],
+      FieldButton(
+        text: 'btn_install_web_app'.l10n,
+        onPressed: () async {
+          if (PWAInstall().installPromptEnabled) {
+            PWAInstall().promptInstall_();
+          } else {
+            MessagePopup.error(
+              'Web App is already installed or not available in your browser',
+              title: 'Installation error',
+            );
+          }
+        },
+        trailing: Padding(
+          padding: const EdgeInsets.only(left: 4),
+          child: SvgIcon(SvgIcons.logo, height: 30),
         ),
-      ] else
-        latestButton,
+      ),
       SizedBox(height: 20),
       LineDivider('label_mobile_apps'.l10n),
       SizedBox(height: 16),

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -426,14 +426,16 @@ Widget _profile(BuildContext context, MyProfileController c) {
       ),
       const SizedBox(height: 16),
       const SizedBox(height: 8),
-      ReactiveTextField(
-        key: Key('NameField'),
-        state: c.name,
-        label: 'label_your_name'.l10n,
-        hint: '${c.myUser.value?.num}',
-        floatingLabelBehavior: FloatingLabelBehavior.always,
-        formatters: [LengthLimitingTextInputFormatter(100)],
-      ),
+      Obx(() {
+        return ReactiveTextField(
+          key: Key('NameField'),
+          state: c.name,
+          label: 'label_your_name'.l10n,
+          hint: '${c.myUser.value?.num}',
+          floatingLabelBehavior: FloatingLabelBehavior.always,
+          formatters: [LengthLimitingTextInputFormatter(100)],
+        );
+      }),
       const SizedBox(height: 21),
       FieldButton(
         key: Key('StatusButton'),
@@ -1306,24 +1308,26 @@ Widget _downloads(BuildContext context, MyProfileController c) {
     children: [
       LineDivider('label_version_semicolon'.l10nfmt({'version': Pubspec.ref})),
       SizedBox(height: 16),
-      if (PlatformUtils.isWeb) ...[latestButton, SizedBox(height: 8)],
-      FieldButton(
-        text: 'btn_install_web_app'.l10n,
-        onPressed: () async {
-          if (PWAInstall().installPromptEnabled) {
-            PWAInstall().promptInstall_();
-          } else {
-            MessagePopup.error(
-              'Web App is already installed or not available in your browser',
-              title: 'Installation error',
-            );
-          }
-        },
-        trailing: Padding(
-          padding: const EdgeInsets.only(left: 4),
-          child: SvgIcon(SvgIcons.logo, height: 30),
-        ),
-      ),
+      if (PlatformUtils.isWeb)
+        FieldButton(
+          text: 'btn_install_web_app'.l10n,
+          onPressed: () async {
+            if (PWAInstall().installPromptEnabled) {
+              PWAInstall().promptInstall_();
+            } else {
+              MessagePopup.error(
+                'label_installation_error_description'.l10n,
+                title: 'label_installation_error'.l10n,
+              );
+            }
+          },
+          trailing: Padding(
+            padding: const EdgeInsets.only(left: 4),
+            child: SvgIcon(SvgIcons.logo, height: 21),
+          ),
+        )
+      else
+        latestButton,
       SizedBox(height: 20),
       LineDivider('label_mobile_apps'.l10n),
       SizedBox(height: 16),

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -653,7 +653,8 @@ class ChatsTabController extends GetxController {
         }.where((e) => e != me).toList(),
       );
 
-      router.dialog(chat.chat.value, me);
+      router.chat(chat.id);
+      router.chatInfo(chat.id, push: true);
 
       closeGroupCreating();
     } on CreateGroupChatException catch (e) {

--- a/lib/ui/page/home/tab/menu/confirm/view.dart
+++ b/lib/ui/page/home/tab/menu/confirm/view.dart
@@ -186,7 +186,7 @@ class ConfirmLogoutView extends StatelessWidget {
                 Obx(() {
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 24),
-                    child: BigCheckboxButton(
+                    child: RowCheckboxButton(
                       key: const Key('KeepCredentialsSwitch'),
                       label: 'btn_save_my_credentials_for_one_click'.l10n,
                       value: c.keep.value,

--- a/lib/ui/widget/checkbox_button.dart
+++ b/lib/ui/widget/checkbox_button.dart
@@ -18,13 +18,12 @@
 import 'package:flutter/material.dart';
 
 import '/themes.dart';
-import '/util/platform_utils.dart';
 import 'svg/svg.dart';
 import 'widget_button.dart';
 
 /// [SvgIcons.sentWhite] button toggling [value] on and off.
-class BigCheckboxButton extends StatelessWidget {
-  const BigCheckboxButton({
+class RowCheckboxButton extends StatelessWidget {
+  const RowCheckboxButton({
     super.key,
     this.value = false,
     this.onPressed,
@@ -46,40 +45,25 @@ class BigCheckboxButton extends StatelessWidget {
 
     return WidgetButton(
       onPressed: () => onPressed?.call(!value),
-      child: Text.rich(
-        TextSpan(
-          children: [
-            WidgetSpan(
-              alignment: PlaceholderAlignment.bottom,
-              child: Transform.translate(
-                offset:
-                    PlatformUtils.isWeb
-                        ? PlatformUtils.isMobile
-                            ? const Offset(0, 5)
-                            : const Offset(0, 3)
-                        : const Offset(0, 3),
-                child: AnimatedContainer(
-                  duration: Duration(milliseconds: 200),
-                  margin: const EdgeInsets.only(right: 6),
-                  decoration: BoxDecoration(
-                    color:
-                        value ? style.colors.primary : style.colors.onPrimary,
-                    borderRadius: BorderRadius.circular(6),
-                    border: Border.all(color: style.colors.primary, width: 1),
-                  ),
-                  width: 24,
-                  height: 24,
-                  child:
-                      value ? Center(child: SvgIcon(SvgIcons.sentWhite)) : null,
-                ),
-              ),
+      child: Row(
+        children: [
+          AnimatedContainer(
+            duration: Duration(milliseconds: 200),
+
+            decoration: BoxDecoration(
+              color: value ? style.colors.primary : style.colors.onPrimary,
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(color: style.colors.primary, width: 1),
             ),
-            TextSpan(
-              text: label,
-              style: style.fonts.normal.regular.onBackground,
-            ),
-          ],
-        ),
+            width: 24,
+            height: 24,
+            child: value ? Center(child: SvgIcon(SvgIcons.sentWhite)) : null,
+          ),
+          SizedBox(width: 8),
+          Expanded(
+            child: Text(label, style: style.fonts.normal.regular.onBackground),
+          ),
+        ],
       ),
     );
   }

--- a/lib/ui/worker/call.dart
+++ b/lib/ui/worker/call.dart
@@ -900,11 +900,11 @@ extension KeyboardKeyToStringExtension on PhysicalKeyboardKey {
         PhysicalKeyboardKey.arrowUp: '↑',
         PhysicalKeyboardKey.controlLeft: '⌃',
         PhysicalKeyboardKey.shiftLeft: '⇧',
-        PhysicalKeyboardKey.altLeft: '⌥',
+        PhysicalKeyboardKey.altLeft: Platform.isMacOS ? '⌥' : 'ALT',
         PhysicalKeyboardKey.metaLeft: Platform.isMacOS ? '⌘' : '⊞',
         PhysicalKeyboardKey.controlRight: '⌃',
         PhysicalKeyboardKey.shiftRight: '⇧',
-        PhysicalKeyboardKey.altRight: '⌥',
+        PhysicalKeyboardKey.altRight: Platform.isMacOS ? '⌥' : 'ALT',
         PhysicalKeyboardKey.metaRight: Platform.isMacOS ? '⌘' : '⊞',
         PhysicalKeyboardKey.fn: 'fn',
       };

--- a/lib/ui/worker/call.dart
+++ b/lib/ui/worker/call.dart
@@ -805,7 +805,7 @@ extension MuteHotKeyExtension on ApplicationSettings {
       }
     }
 
-    if (keys.isEmpty) {
+    if (keys.where((e) => e.isNotEmpty).isEmpty) {
       modifiers.addAll(defaultHotKey.modifiers ?? []);
     }
 

--- a/lib/util/message_popup.dart
+++ b/lib/util/message_popup.dart
@@ -30,14 +30,14 @@ import 'localized_exception.dart';
 /// Helper to display a popup message in UI.
 class MessagePopup {
   /// Shows an error popup with the provided argument.
-  static Future<void> error(dynamic e) async {
+  static Future<void> error(dynamic e, {String title = 'label_error'}) async {
     var message = e is LocalizedExceptionMixin ? e.toMessage() : e.toString();
 
     await showDialog(
       context: router.context!,
       builder:
           (context) => AlertDialog(
-            title: Text('label_error'.l10n),
+            title: Text(title.l10n),
             content: Text(message),
             actions: [
               TextButton(
@@ -69,32 +69,34 @@ class MessagePopup {
               const SizedBox(height: 4),
               ModalPopupHeader(text: title),
               const SizedBox(height: 13),
-              Flexible(
-                child: ListView(
-                  shrinkWrap: true,
-                  children: [
-                    if (description.isNotEmpty)
-                      Padding(
-                        padding: ModalPopup.padding(context),
-                        child: Center(
-                          child: RichText(
-                            text: TextSpan(
-                              children: description,
-                              style: style.fonts.normal.regular.secondary,
+              if (description.isNotEmpty || additional.isNotEmpty) ...[
+                Flexible(
+                  child: ListView(
+                    shrinkWrap: true,
+                    children: [
+                      if (description.isNotEmpty)
+                        Padding(
+                          padding: ModalPopup.padding(context),
+                          child: Center(
+                            child: RichText(
+                              text: TextSpan(
+                                children: description,
+                                style: style.fonts.normal.regular.secondary,
+                              ),
                             ),
                           ),
                         ),
+                      ...additional.map(
+                        (e) => Padding(
+                          padding: ModalPopup.padding(context),
+                          child: e,
+                        ),
                       ),
-                    ...additional.map(
-                      (e) => Padding(
-                        padding: ModalPopup.padding(context),
-                        child: e,
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              const SizedBox(height: 25),
+                const SizedBox(height: 25),
+              ],
               Padding(
                 padding: ModalPopup.padding(context),
                 child: button(context),


### PR DESCRIPTION
## Synopsis

Key up presses should enable editing mode of the last `ChatMessage` posted.




## Solution

This PR implements that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
