### PR TITLE
Fix `StackOverflowError` when reordering `CallButton`s in `Dock`

### DIFF
--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -786,10 +786,14 @@ class CallController extends GetxController {
       AudioButton(this),
     ]);
 
-    _buttonsWorker = ever(buttons, (List<CallButton> list) {
-      _settingsRepository.setCallButtons(
-        list.map((e) => e.runtimeType.toString()).toList(),
-      );
+    List<CallButton> previousButtons = buttons.toList();
+    _buttonsWorker = ever(buttons, (List<CallButton> buttons) {
+      if (!const ListEquality().equals(previousButtons, buttons)) {
+        previousButtons = buttons.toList();
+        _settingsRepository.setCallButtons(
+          buttons.map((e) => e.runtimeType.toString()).toList(),
+        );
+      }
     });
 
     List<String>? previous =

--- a/lib/ui/worker/call.dart
+++ b/lib/ui/worker/call.dart
@@ -19,6 +19,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:base_x/base_x.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_callkit_incoming/entities/call_event.dart';
 import 'package:flutter_callkit_incoming/entities/call_kit_params.dart';
@@ -181,7 +182,7 @@ class CallWorker extends DisposableService {
     _settingsWorker = ever(_settingsRepository.applicationSettings, (
       ApplicationSettings? settings,
     ) {
-      if (settings?.muteKeys != lastKeys) {
+      if (!const ListEquality().equals(settings?.muteKeys, lastKeys)) {
         lastKeys = settings?.muteKeys?.toList();
 
         final bool shouldBind = _bind;


### PR DESCRIPTION
## Synopsis

`StackOverflowError` is thrown crashing the application when reordering `CallButton`s in `Dock`.




## Solution

This PR fixes the issue - due to `Settings` repository changes, the `CallButton`s being changed trigger the same function to repeat over and over again.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
