### PR TITLE
Guard `enumerateDevices()` and `onDeviceChange` in `OngoingCall` with `Mutex`

### DIFF
--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -219,7 +219,7 @@ class GraphQlClient {
       return await _transaction(options.operationName, () async {
         final QueryResult result = await (await _newClient(
           raw,
-        )).mutate(options).timeout(timeout);
+        )).mutate(options);
         GraphQlProviderExceptions.fire(result, onException);
         return result;
       });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -144,14 +144,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
-  base_x:
-    dependency: "direct main"
-    description:
-      name: base_x
-      sha256: "519abcdafd637d4b6bd7e72fabd8f9264935f804b9b9f6c5d8411c7d52cbf8fd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   async: ^2.10.0
   audio_session: ^0.1.18
   back_button_interceptor: ^7.0.0
-  base_x: ^2.0.1
   collection: ^1.18.0
   connectivity_plus: ^6.1.0
   crypto: ^3.0.3

--- a/test/unit/base62_to_uuid_test.dart
+++ b/test/unit/base62_to_uuid_test.dart
@@ -19,7 +19,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:messenger/ui/worker/call.dart';
 
 void main() async {
-  test('CacheWorker clears its files', () async {
+  test('Base62ToUuid converts Base62 to UUID correctly', () async {
     expect(
       '7FdwVhQEjVMHIaeB2t4487'.base62ToUuid(),
       'ee49e501-ce4c-4940-92d2-602c8266ffd7',

--- a/test/unit/base62_to_uuid_test.dart
+++ b/test/unit/base62_to_uuid_test.dart
@@ -1,0 +1,33 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:messenger/ui/worker/call.dart';
+
+void main() async {
+  test('CacheWorker clears its files', () async {
+    expect(
+      '7FdwVhQEjVMHIaeB2t4487'.base62ToUuid(),
+      'ee49e501-ce4c-4940-92d2-602c8266ffd7',
+    );
+
+    expect(
+      'bh3JQNDEHfRTrnIKic6c'.base62ToUuid(),
+      '00527b68-cb58-4da8-ad13-2e8a245cba92',
+    );
+  });
+}


### PR DESCRIPTION
## Synopsis

Due to races, `onDeviceChange` might fire earlier than `enumerateDevices()` method populates the `devices` field of `OngoingCall`. This causes the `onDeviceChange` method to consider `previous` devices as empty, which results in `speaker` device being chosen as the default one.




## Solution

This PR fixes the issue by using the `Mutex` to synchronize invokes of `enumerateDevices()` and `onDeviceChange`. Additionally, if devices are empty, `onDeviceChange` will try to invoke `enumerateDevices()`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
