### PR TITLE
Add `translate="no"` to `<html>` tag in `index.html` to hide translate popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.5.0] · 2025-??-??
+[0.5.0]: /../../tree/v0.5.0
+
+[Diff](/../../compare/v0.4.2...v0.5.0) | [Milestone](/../../milestone/38)
+
+### Fixed
+
+- Web:
+    - Translate popup displaying in browsers. ([#1215])
+
+[#1215]: /../../pull/1215
+
+
+
+
 ## [0.4.2] · 2025-04-22
 [0.4.2]: /../../tree/v0.4.2
 

--- a/helm/messenger/Chart.yaml
+++ b/helm/messenger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: messenger
 description: Open-source front-end part of messenger by team113.
 version: 0.1.3
-appVersion: 0.4.2
+appVersion: 0.4.3
 type: application
 sources:
   - https://github.com/team113/messenger

--- a/lib/util/media_utils.dart
+++ b/lib/util/media_utils.dart
@@ -71,7 +71,12 @@ class MediaUtilsImpl {
 
         try {
           _jason = await Jason.init();
-        } catch (_) {
+        } catch (e) {
+          Log.debug(
+            'Unable to invoke `Jason.init()` due to: $e',
+            '$runtimeType',
+          );
+
           // TODO: So the test would run. Jason currently only supports Web and
           //       Android, and unit tests run on a host machine.
           _jason = null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.4.2
+version: 0.4.3
 publish_to: none
 
 environment:

--- a/web/index.html
+++ b/web/index.html
@@ -18,7 +18,7 @@
  <https://www.gnu.org/licenses/agpl-3.0.html>.
 -->
 
-<html>
+<html class="notranslate" translate="no">
 
 <head>
   <!--
@@ -65,6 +65,7 @@
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="icons/ms-icon-144x144.png">
   <meta name="theme-color" content="#ffffff">
+  <meta name="google" content="notranslate" />
 
   <title>Gapopa</title>
   <link rel="manifest" href="manifest.json">


### PR DESCRIPTION
## Synopsis

It seems that certain users report translate popup to be displayed in Chrome browser. However, due to nature of Flutter application being a `<canvas>` element without any texts available to be translated, this popup does nothing.




## Solution

This PR adds `translate="no"` parameter to `<html>` tag to try preventing this popup from displaying.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
