### PR TITLE
Use `cupertino_http` for iOS/macOS HTTP client (#930)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -8,6 +8,9 @@ PODS:
   - connectivity_plus (0.0.1):
     - Flutter
   - CryptoSwift (1.8.4)
+  - cupertino_http (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - device_info_plus (0.0.1):
     - Flutter
   - DKImagePickerController/Core (4.3.9):
@@ -137,6 +140,8 @@ PODS:
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
+  - objective_c (0.0.1):
+    - Flutter
   - open_file_ios (0.0.1):
     - Flutter
   - package_info_plus (0.4.5):
@@ -201,6 +206,7 @@ DEPENDENCIES:
   - app_links (from `.symlinks/plugins/app_links/ios`)
   - audio_session (from `.symlinks/plugins/audio_session/ios`)
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
+  - cupertino_http (from `.symlinks/plugins/cupertino_http/darwin`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Firebase/Messaging
@@ -219,6 +225,7 @@ DEPENDENCIES:
   - medea_jason (from `.symlinks/plugins/medea_jason/ios`)
   - media_kit_libs_ios_video (from `.symlinks/plugins/media_kit_libs_ios_video/ios`)
   - media_kit_video (from `.symlinks/plugins/media_kit_video/ios`)
+  - objective_c (from `.symlinks/plugins/objective_c/ios`)
   - open_file_ios (from `.symlinks/plugins/open_file_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
@@ -265,6 +272,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/audio_session/ios"
   connectivity_plus:
     :path: ".symlinks/plugins/connectivity_plus/ios"
+  cupertino_http:
+    :path: ".symlinks/plugins/cupertino_http/darwin"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   file_picker:
@@ -299,6 +308,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/media_kit_libs_ios_video/ios"
   media_kit_video:
     :path: ".symlinks/plugins/media_kit_video/ios"
+  objective_c:
+    :path: ".symlinks/plugins/objective_c/ios"
   open_file_ios:
     :path: ".symlinks/plugins/open_file_ios/ios"
   package_info_plus:
@@ -334,6 +345,7 @@ SPEC CHECKSUMS:
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   CryptoSwift: e64e11850ede528a02a0f3e768cec8e9d92ecb90
+  cupertino_http: 94ac07f5ff090b8effa6c5e2c47871d48ab7c86c
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
@@ -362,6 +374,7 @@ SPEC CHECKSUMS:
   media_kit_libs_ios_video: 5a18affdb97d1f5d466dc79988b13eff6c5e2854
   media_kit_video: 1746e198cb697d1ffb734b1d05ec429d1fcd1474
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  objective_c: 89e720c30d716b036faf9c9684022048eee1eee2
   open_file_ios: 5ff7526df64e4394b4fe207636b67a95e83078bb
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564

--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -494,12 +494,10 @@ class GraphQlClient {
     Client? httpClient;
     if (!PlatformUtils.isWeb &&
         (PlatformUtils.isMacOS || PlatformUtils.isIOS)) {
-      final config =
-          URLSessionConfiguration.ephemeralSessionConfiguration()
-            ..cache = URLCache.withCapacity(memoryCapacity: 2 * 1024 * 1024)
+      final URLSessionConfiguration config =
+          URLSessionConfiguration.defaultSessionConfiguration()
             ..allowsExpensiveNetworkAccess = true
-            ..allowsCellularAccess = true
-            ..httpAdditionalHeaders = {'User-Agent': 'Book Agent'};
+            ..allowsCellularAccess = true;
       httpClient = CupertinoClient.fromSessionConfiguration(config);
     }
 

--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -18,7 +18,6 @@
 import 'dart:async';
 
 import 'package:async/async.dart' show StreamGroup;
-import 'package:cupertino_http/cupertino_http.dart' hide ConnectionException;
 import 'package:dio/dio.dart' as dio show DioException, Options, Response;
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
@@ -36,6 +35,7 @@ import '/store/model/version.dart';
 import '/util/log.dart';
 import '/util/platform_utils.dart';
 import '/util/rate_limiter.dart';
+import '/util/web/web_utils.dart';
 import 'exceptions.dart';
 import 'websocket/interface.dart'
     if (dart.library.io) 'websocket/io.dart'
@@ -491,19 +491,9 @@ class GraphQlClient {
   Future<GraphQLClient> _newClient([RawClientOptions? raw]) async {
     Log.debug('_newClient($raw)', '$runtimeType');
 
-    Client? httpClient;
-    if (!PlatformUtils.isWeb &&
-        (PlatformUtils.isMacOS || PlatformUtils.isIOS)) {
-      final URLSessionConfiguration config =
-          URLSessionConfiguration.defaultSessionConfiguration()
-            ..allowsExpensiveNetworkAccess = true
-            ..allowsCellularAccess = true;
-      httpClient = CupertinoClient.fromSessionConfiguration(config);
-    }
-
     final httpLink = HttpLink(
       '${Config.url}:${Config.port}${Config.graphql}',
-      httpClient: httpClient,
+      httpClient: WebUtils.httpClient,
       defaultHeaders: {
         if (!PlatformUtils.isWeb) 'User-Agent': await PlatformUtils.userAgent,
       },

--- a/lib/util/media_utils.dart
+++ b/lib/util/media_utils.dart
@@ -71,7 +71,12 @@ class MediaUtilsImpl {
 
         try {
           _jason = await Jason.init();
-        } catch (_) {
+        } catch (e) {
+          Log.debug(
+            'Unable to invoke `Jason.init()` due to: $e',
+            '$runtimeType',
+          );
+
           // TODO: So the test would run. Jason currently only supports Web and
           //       Android, and unit tests run on a host machine.
           _jason = null;

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -19,12 +19,15 @@ import 'dart:async';
 import 'dart:ffi' hide Size;
 import 'dart:io';
 
+import 'package:cupertino_http/cupertino_http.dart'
+    show CupertinoClient, URLSessionConfiguration;
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:ffi/ffi.dart';
 import 'package:flutter/widgets.dart' show Rect;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     show NotificationResponse;
 import 'package:hotkey_manager/hotkey_manager.dart';
+import 'package:http/http.dart' show Client;
 import 'package:medea_jason/medea_jason.dart' as jason;
 import 'package:mutex/mutex.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -89,6 +92,19 @@ class WebUtils {
 
   /// Indicates whether the [protect] is currently locked.
   static FutureOr<bool> get isLocked => _guards['mutex']?.isLocked == true;
+
+  /// Returns custom [Client] to use for HTTP requests.
+  static Client? get httpClient {
+    if (PlatformUtils.isMacOS || PlatformUtils.isIOS) {
+      final URLSessionConfiguration config =
+          URLSessionConfiguration.defaultSessionConfiguration()
+            ..allowsExpensiveNetworkAccess = true
+            ..allowsCellularAccess = true;
+      return CupertinoClient.fromSessionConfiguration(config);
+    }
+
+    return null;
+  }
 
   /// Removes [Credentials] identified by the provided [UserId] from the
   /// browser's storage.

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -330,7 +330,7 @@ class WebUtils {
   }
 
   /// Returns custom [Client] to use for HTTP requests.
-  Client? get httpClient {
+  static Client? get httpClient {
     return null;
   }
 

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -30,6 +30,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     show NotificationResponse, NotificationResponseType;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
+import 'package:http/http.dart' show Client;
 import 'package:mutex/mutex.dart';
 import 'package:platform_detect/platform_detect.dart';
 import 'package:uuid/uuid.dart';
@@ -326,6 +327,11 @@ class WebUtils {
     }
 
     return _guards['mutex']?.isLocked == true || held;
+  }
+
+  /// Returns custom [Client] to use for HTTP requests.
+  Client? get httpClient {
+    return null;
   }
 
   /// Removes [Credentials] identified by the provided [UserId] from the

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -5,6 +5,9 @@ PODS:
     - FlutterMacOS
   - connectivity_plus (0.0.1):
     - FlutterMacOS
+  - cupertino_http (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - device_info_plus (0.0.1):
     - FlutterMacOS
   - file_selector_macos (0.0.1):
@@ -98,6 +101,8 @@ PODS:
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
+  - objective_c (0.0.1):
+    - FlutterMacOS
   - open_file_mac (0.0.1):
     - FlutterMacOS
   - package_info_plus (0.0.1):
@@ -154,6 +159,7 @@ DEPENDENCIES:
   - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
   - audio_session (from `Flutter/ephemeral/.symlinks/plugins/audio_session/macos`)
   - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
+  - cupertino_http (from `Flutter/ephemeral/.symlinks/plugins/cupertino_http/darwin`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
@@ -170,6 +176,7 @@ DEPENDENCIES:
   - medea_jason (from `Flutter/ephemeral/.symlinks/plugins/medea_jason/macos`)
   - media_kit_libs_macos_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos`)
   - media_kit_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos`)
+  - objective_c (from `Flutter/ephemeral/.symlinks/plugins/objective_c/macos`)
   - open_file_mac (from `Flutter/ephemeral/.symlinks/plugins/open_file_mac/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
@@ -207,6 +214,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/audio_session/macos
   connectivity_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
+  cupertino_http:
+    :path: Flutter/ephemeral/.symlinks/plugins/cupertino_http/darwin
   device_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
   file_selector_macos:
@@ -239,6 +248,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos
   media_kit_video:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos
+  objective_c:
+    :path: Flutter/ephemeral/.symlinks/plugins/objective_c/macos
   open_file_mac:
     :path: Flutter/ephemeral/.symlinks/plugins/open_file_mac/macos
   package_info_plus:
@@ -272,6 +283,7 @@ SPEC CHECKSUMS:
   app_links: 9028728e32c83a0831d9db8cf91c526d16cc5468
   audio_session: eaca2512cf2b39212d724f35d11f46180ad3a33e
   connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
+  cupertino_http: 94ac07f5ff090b8effa6c5e2c47871d48ab7c86c
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
   file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
   Firebase: a64bf6a8546e6eab54f1c715cd6151f39d2329f4
@@ -297,6 +309,7 @@ SPEC CHECKSUMS:
   media_kit_libs_macos_video: 85a23e549b5f480e72cae3e5634b5514bc692f65
   media_kit_video: fa6564e3799a0a28bff39442334817088b7ca758
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  objective_c: ec13431e45ba099cb734eb2829a5c1cd37986cba
   open_file_mac: 01874b6d6a2c1485ac9b126d7105b99102dea2cf
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -336,6 +336,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  cupertino_http:
+    dependency: "direct main"
+    description:
+      name: cupertino_http
+      sha256: b4dd5cbecd25d3662ec5c64c766673e7676e80dbd45b2c46a4a873ad632b3782
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   dart_style:
     dependency: transitive
     description:
@@ -1039,6 +1047,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  http_profile:
+    dependency: transitive
+    description:
+      name: http_profile
+      sha256: "7e679e355b09aaee2ab5010915c932cce3f2d1c11c3b2dc177891687014ffa78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   image:
     dependency: transitive
     description:
@@ -1460,6 +1476,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.1"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: "9f034ba1eeca53ddb339bc8f4813cb07336a849cd735559b60cdc068ecce2dc7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.0"
   open_file:
     dependency: "direct main"
     description:
@@ -1664,10 +1688,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.0.2"
   photo_view:
     dependency: "direct main"
     description:
@@ -1696,10 +1720,10 @@ packages:
     dependency: "direct main"
     description:
       name: platform_detect
-      sha256: "7394dc1d884e652785a37c3ff25c54e503c6d9fa2f35b55d5efc0a133dec122c"
+      sha256: a62f99417fc4fa2d099ce0ccdbb1bd3977920f2a64292c326271f049d4bc3a4f
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -2182,10 +2206,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
+      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.0+3"
   system_info2:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   collection: ^1.18.0
   connectivity_plus: ^6.1.0
   crypto: ^3.0.3
+  cupertino_http: ^2.1.1
   device_info_plus: ^11.1.0
   dio: ^5.1.2
   dough: ^2.0.0


### PR DESCRIPTION
Resolves #930




## Synopsis

> `http` package isn't perfect on iOS/macOS. E.g. the `SocketException: Bad file descriptor` error happens all the time there.




## Solution

This PR migrates to `cupertino_http`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
