### PR TITLE
Convert `AssetAudioSorce` to `Media` using `Config.origin` prefix instead of `asset:///`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ All user visible changes to this project will be documented in this file. This p
 
 - Web:
     - Translate popup displaying in browsers. ([#1215])
+    - Call audio ringtone not being played. ([#1218])
 
 [#1215]: /../../pull/1215
+[#1218]: /../../pull/1218
 
 
 

--- a/lib/util/audio_utils.dart
+++ b/lib/util/audio_utils.dart
@@ -22,6 +22,7 @@ import 'package:just_audio/just_audio.dart' as ja;
 import 'package:media_kit/media_kit.dart' hide AudioDevice;
 import 'package:mutex/mutex.dart';
 
+import '/config.dart';
 import '/pubspec.g.dart';
 import '/util/media_utils.dart';
 import 'log.dart';
@@ -413,9 +414,12 @@ class UrlAudioSource extends AudioSource {
 extension on AudioSource {
   /// Returns a [Media] corresponding to this [AudioSource].
   Media get media => switch (kind) {
-    AudioSourceKind.asset => Media(
-      'asset:///assets/${PlatformUtils.isWeb ? 'assets/' : ''}${(this as AssetAudioSource).asset}${PlatformUtils.isWeb ? '?${Pubspec.ref}' : ''}',
-    ),
+    AudioSourceKind.asset =>
+      PlatformUtils.isWeb
+          ? Media(
+            '${Config.origin}/assets/assets/${(this as AssetAudioSource).asset}?${Pubspec.ref}',
+          )
+          : Media('asset:///assets/${(this as AssetAudioSource).asset}'),
     AudioSourceKind.file => Media('file:///${(this as FileAudioSource).file}'),
     AudioSourceKind.url => Media((this as UrlAudioSource).url),
   };

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -52,7 +52,7 @@
       "purpose": "maskable"
     },
     {
-      "src": "icons/maskable_icon_x512.png",
+      "src": "icons/maskable-icon.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"


### PR DESCRIPTION
## Synopsis

Audio ringtone is not being played.




## Solution

This PR fixes that by using URL fetching instead of asset fetching.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
