### PR TITLE
Fix `OngoingCall` notification displaying again after `decline()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,16 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Fixed
 
+- UI:
+    - Media panel:
+        - Incoming call displayed multiple times when declined quickly enough. ([#1219])
 - Web:
     - Translate popup displaying in browsers. ([#1215])
     - Call audio ringtone not being played. ([#1218])
 
 [#1215]: /../../pull/1215
 [#1218]: /../../pull/1218
+[#1219]: /../../pull/1219
 
 
 

--- a/lib/domain/model/session.dart
+++ b/lib/domain/model/session.dart
@@ -159,7 +159,7 @@ class RefreshToken {
   final PreciseDateTime expireAt;
 
   @override
-  String toString() => 'RefreshToken(secret: ***, expireAt: $expireAt)';
+  String toString() => 'RefreshToken(secret: $secret, expireAt: $expireAt)';
 }
 
 /// Type of [RefreshToken]'s secret.

--- a/lib/domain/model/session.dart
+++ b/lib/domain/model/session.dart
@@ -124,6 +124,9 @@ class AccessToken {
   /// [AccessToken]'s expiration and refresh the [Session] before an
   /// authentication error occurs.
   final PreciseDateTime expireAt;
+
+  @override
+  String toString() => 'AccessToken(secret: ***, expireAt: $expireAt)';
 }
 
 /// Type of [AccessToken]'s secret.
@@ -154,6 +157,9 @@ class RefreshToken {
   /// Expiration of a [RefreshToken] is not prolonged on refreshing, and remains
   /// the same for all the [RefreshToken]s obtained.
   final PreciseDateTime expireAt;
+
+  @override
+  String toString() => 'RefreshToken(secret: ***, expireAt: $expireAt)';
 }
 
 /// Type of [RefreshToken]'s secret.
@@ -213,5 +219,6 @@ class Credentials {
   }
 
   @override
-  String toString() => 'Credentials(userId: $userId)';
+  String toString() =>
+      'Credentials(userId: $userId, sessionId: $sessionId, access: $access refresh: $refresh)';
 }

--- a/lib/domain/repository/call.dart
+++ b/lib/domain/repository/call.dart
@@ -43,7 +43,13 @@ abstract class AbstractCallRepository {
   void operator []=(ChatId chatId, Rx<OngoingCall> call);
 
   /// Adds the provided [ChatCall] to the [calls], if not already.
-  Future<Rx<OngoingCall>?> add(ChatCall call);
+  ///
+  /// If [dontAddIfAccounted] is `true`, then this [call] won't be added if it
+  /// was [add]ed by anything earlier, even if it's already gone.
+  Future<Rx<OngoingCall>?> add(
+    ChatCall call, {
+    bool dontAddIfAccounted = false,
+  });
 
   /// Transforms the provided [WebStoredCall] into an [OngoingCall] and adds it,
   /// if not already.

--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -99,6 +99,9 @@ class AuthService extends DisposableService {
   /// [Credentials].
   StreamSubscription? _storageSubscription;
 
+  /// [refreshSession] attempt number counter used purely for [Log]s.
+  static int _refreshAttempt = 0;
+
   /// Initial [Duration] to set [_refreshRetryDelay] to.
   static const Duration _initialRetryDelay = Duration(seconds: 2);
 
@@ -623,6 +626,8 @@ class AuthService extends DisposableService {
   /// Refreshes [Credentials] of the account with the provided [userId] or of
   /// the active one, if [userId] is not provided.
   Future<void> refreshSession({UserId? userId}) async {
+    final int attempt = _refreshAttempt++;
+
     final FutureOr<bool> futureOrBool = WebUtils.isLocked;
     final bool isLocked =
         futureOrBool is bool ? futureOrBool : await futureOrBool;
@@ -631,7 +636,7 @@ class AuthService extends DisposableService {
     final bool areCurrent = userId == this.userId;
 
     Log.debug(
-      'refreshSession($userId) with `isLocked`: $isLocked',
+      'refreshSession($userId |-> $attempt) with `isLocked`: $isLocked',
       '$runtimeType',
     );
 
@@ -645,19 +650,34 @@ class AuthService extends DisposableService {
       // Wait for the lock to be released and check the [Credentials] again as
       // some other task may have already refreshed them.
       await WebUtils.protect(() async {
+        Log.debug(
+          'refreshSession($userId |-> $attempt) acquired both `dbLock` and `WebUtils.protect()`',
+          '$runtimeType',
+        );
+
         Credentials? oldCreds;
 
         if (userId != null) {
           oldCreds = await _credentialsProvider.read(userId, refresh: true);
+
+          Log.debug(
+            'refreshSession($userId |-> $attempt) read from `drift` the `oldCreds`: $oldCreds',
+            '$runtimeType',
+          );
         }
 
         if (areCurrent) {
+          Log.debug(
+            'refreshSession($userId |-> $attempt) `areCurrent` is `true`, which will apply `credentials.value` to `oldCreds` if ${oldCreds == null} -> ${credentials.value}',
+            '$runtimeType',
+          );
+
           oldCreds ??= credentials.value;
         }
 
         if (userId == null) {
-          Log.debug(
-            'refreshSession($userId): `userId` is `null`, unable to proceed',
+          Log.warning(
+            'refreshSession($userId |-> $attempt): `userId` is `null`, unable to proceed',
             '$runtimeType',
           );
 
@@ -676,7 +696,7 @@ class AuthService extends DisposableService {
             oldCreds.access.secret != credentials.value?.access.secret &&
             !_shouldRefresh(oldCreds)) {
           Log.debug(
-            'refreshSession($userId): false alarm, applying the retrieved fresh credentials',
+            'refreshSession($userId |-> $attempt): false alarm, applying the retrieved fresh credentials',
             '$runtimeType',
           );
 
@@ -693,7 +713,7 @@ class AuthService extends DisposableService {
 
         if (isLocked) {
           Log.debug(
-            'refreshSession($userId): acquired the lock, while it was locked, thus should proceed: ${_shouldRefresh(oldCreds)}',
+            'refreshSession($userId |-> $attempt): acquired the lock, while it was locked -> should refresh: ${_shouldRefresh(oldCreds)}',
             '$runtimeType',
           );
 
@@ -703,12 +723,17 @@ class AuthService extends DisposableService {
           }
         } else {
           Log.debug(
-            'refreshSession($userId): acquired the lock, while it was unlocked',
+            'refreshSession($userId |-> $attempt): acquired the lock, while it was unlocked',
             '$runtimeType',
           );
         }
 
         if (oldCreds == null) {
+          Log.debug(
+            'refreshSession($userId |-> $attempt): `oldCreds` are `null`, seems like during the lock those were removed -> unauthorized',
+            '$runtimeType',
+          );
+
           // These [Credentials] were removed while we've been waiting for the
           // lock to be released.
           if (areCurrent) {
@@ -724,6 +749,11 @@ class AuthService extends DisposableService {
             reconnect: areCurrent,
           );
 
+          Log.debug(
+            'refreshSession($userId |-> $attempt): success 🎉 -> writing to `drift`... ✍️',
+            '$runtimeType',
+          );
+
           if (areCurrent) {
             await _authorized(data);
           } else {
@@ -736,11 +766,16 @@ class AuthService extends DisposableService {
             _putCredentials(data);
           }
 
+          Log.debug(
+            'refreshSession($userId |-> $attempt): success 🎉 -> writing to `drift`... done ✅',
+            '$runtimeType',
+          );
+
           _refreshRetryDelay = _initialRetryDelay;
           status.value = RxStatus.success();
         } on RefreshSessionException catch (_) {
           Log.debug(
-            'refreshSession($userId): `RefreshSessionException` occurred, removing credentials',
+            'refreshSession($userId |-> $attempt): ⛔️ `RefreshSessionException` occurred ⛔️, removing credentials',
             '$runtimeType',
           );
 
@@ -768,7 +803,7 @@ class AuthService extends DisposableService {
       rethrow;
     } catch (e) {
       Log.debug(
-        'refreshSession($userId): Exception occurred: $e',
+        'refreshSession($userId |-> $attempt): ⛔️ exception occurred: $e',
         '$runtimeType',
       );
 
@@ -781,6 +816,11 @@ class AuthService extends DisposableService {
       if (_refreshRetryDelay.inSeconds < 12) {
         _refreshRetryDelay = _refreshRetryDelay * 2;
       }
+
+      Log.debug(
+        'refreshSession($userId |-> $attempt): backoff passed, trying again',
+        '$runtimeType',
+      );
 
       await refreshSession(userId: userId);
     }

--- a/lib/store/call.dart
+++ b/lib/store/call.dart
@@ -128,7 +128,10 @@ class CallRepository extends DisposableInterface
   }
 
   @override
-  Future<Rx<OngoingCall>?> add(ChatCall call) async {
+  Future<Rx<OngoingCall>?> add(
+    ChatCall call, {
+    bool dontAddIfAccounted = false,
+  }) async {
     Log.debug('add($call)', '$runtimeType');
 
     Rx<OngoingCall>? ongoing = calls[call.chatId];
@@ -159,6 +162,10 @@ class CallRepository extends DisposableInterface
     if (ongoing == null) {
       final DateTime? accountedAt = _accountedCalls[call.id];
       if (accountedAt != null) {
+        if (dontAddIfAccounted) {
+          return null;
+        }
+
         if (accountedAt.difference(DateTime.now()).abs() < _accountedTimeout) {
           // This call is already considered reported, thus don't add it again.
           return null;
@@ -828,6 +835,7 @@ class CallRepository extends DisposableInterface
       case IncomingChatCallsTopEventKind.added:
         e as EventIncomingChatCallsTopChatCallAdded;
         if (!_accountedCalls.containsKey(e.call.id)) {
+          print('=========== IncomingChatCallsTopEventKind.added');
           add(e.call);
         }
         break;

--- a/lib/store/call.dart
+++ b/lib/store/call.dart
@@ -89,6 +89,9 @@ class CallRepository extends DisposableInterface
   /// Subscription to a list of [IncomingChatCallsTopEvent]s.
   StreamQueue<IncomingChatCallsTopEvent>? _remoteSubscription;
 
+  /// [ChatItemId]s already [add]ed to prevent [OngoingCall]s being added again.
+  final Set<ChatItemId> _accountsCalls = {};
+
   /// Returns the current value of [MediaSettings].
   Rx<MediaSettings?> get media => _settingsRepo.mediaSettings;
 
@@ -150,6 +153,12 @@ class CallRepository extends DisposableInterface
     }
 
     if (ongoing == null) {
+      if (_accountsCalls.contains(call.id)) {
+        return null;
+      }
+
+      _accountsCalls.add(call.id);
+
       ongoing = Rx<OngoingCall>(
         OngoingCall(
           call.chatId,

--- a/lib/store/call.dart
+++ b/lib/store/call.dart
@@ -94,7 +94,7 @@ class CallRepository extends DisposableInterface
 
   /// [Duration] between [ChatCall]s added via [add] to be considered as a new
   /// call instead of already reported one.
-  static const Duration _accountedTimeout = Duration(seconds: 5);
+  static const Duration _accountedTimeout = Duration(seconds: 1);
 
   /// Returns the current value of [MediaSettings].
   Rx<MediaSettings?> get media => _settingsRepo.mediaSettings;
@@ -827,7 +827,9 @@ class CallRepository extends DisposableInterface
 
       case IncomingChatCallsTopEventKind.added:
         e as EventIncomingChatCallsTopChatCallAdded;
-        add(e.call);
+        if (!_accountedCalls.containsKey(e.call.id)) {
+          add(e.call);
+        }
         break;
 
       case IncomingChatCallsTopEventKind.removed:
@@ -836,6 +838,7 @@ class CallRepository extends DisposableInterface
         // If call is not yet connected to remote updates, then it's still
         // just a notification and it should be removed.
         if (call?.value.connected == false && call?.value.isActive == false) {
+          _accountedCalls.remove(e.call.id);
           remove(e.call.chatId);
         }
         break;

--- a/lib/store/call.dart
+++ b/lib/store/call.dart
@@ -359,6 +359,7 @@ class CallRepository extends DisposableInterface
       ongoing.value.setAudioEnabled(withAudio);
       ongoing.value.setVideoEnabled(withVideo);
       ongoing.value.setScreenShareEnabled(withScreen);
+      ongoing.refresh();
     } else {
       return null;
     }

--- a/lib/store/call.dart
+++ b/lib/store/call.dart
@@ -90,7 +90,7 @@ class CallRepository extends DisposableInterface
   StreamQueue<IncomingChatCallsTopEvent>? _remoteSubscription;
 
   /// [ChatItemId]s already [add]ed to prevent [OngoingCall]s being added again.
-  final Set<ChatItemId> _accountsCalls = {};
+  final Set<ChatItemId> _accountedCalls = {};
 
   /// Returns the current value of [MediaSettings].
   Rx<MediaSettings?> get media => _settingsRepo.mediaSettings;
@@ -153,11 +153,11 @@ class CallRepository extends DisposableInterface
     }
 
     if (ongoing == null) {
-      if (_accountsCalls.contains(call.id)) {
+      if (_accountedCalls.contains(call.id)) {
         return null;
       }
 
-      _accountsCalls.add(call.id);
+      _accountedCalls.add(call.id);
 
       ongoing = Rx<OngoingCall>(
         OngoingCall(

--- a/lib/store/call.dart
+++ b/lib/store/call.dart
@@ -835,7 +835,6 @@ class CallRepository extends DisposableInterface
       case IncomingChatCallsTopEventKind.added:
         e as EventIncomingChatCallsTopChatCallAdded;
         if (!_accountedCalls.containsKey(e.call.id)) {
-          print('=========== IncomingChatCallsTopEventKind.added');
           add(e.call);
         }
         break;

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -1167,9 +1167,9 @@ class ChatRepository extends DisposableInterface
   }
 
   /// Adds the provided [ChatCall] to the [AbstractCallRepository].
-  void addCall(ChatCall call) {
-    Log.debug('addCall($call)', '$runtimeType');
-    _callRepo.add(call);
+  void addCall(ChatCall call, {bool dontAddIfAccounted = false}) {
+    Log.debug('addCall($call, $dontAddIfAccounted)', '$runtimeType');
+    _callRepo.add(call, dontAddIfAccounted: dontAddIfAccounted);
   }
 
   /// Ends an [OngoingCall] happening in the [Chat] identified by the provided

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -1962,7 +1962,8 @@ class RxChatImpl extends RxChat {
 
           switch (event.kind) {
             case ChatEventKind.redialed:
-              // TODO: Implement EventChatCallMemberRedialed.
+              event as EventChatCallMemberRedialed;
+              _chatRepository.addCall(event.call);
               break;
 
             case ChatEventKind.cleared:
@@ -2373,7 +2374,7 @@ class RxChatImpl extends RxChat {
                 }
 
                 write((chat) => chat.value.ongoingCall = event.call);
-                _chatRepository.addCall(event.call);
+                _chatRepository.addCall(event.call, dontAddIfAccounted: true);
               }
               break;
 

--- a/test/unit/call_test.dart
+++ b/test/unit/call_test.dart
@@ -525,6 +525,7 @@ void main() async {
     expect(callService.calls.length, 0);
     await Future.delayed(const Duration(milliseconds: 16));
 
+    await Future.delayed(const Duration(seconds: 2));
     graphQlProvider.ongoingCallStream.add(
       QueryResult.internal(
         source: QueryResultSource.network,
@@ -532,7 +533,7 @@ void main() async {
           'incomingChatCallsTopEvents': {
             '__typename': 'EventIncomingChatCallsTopChatCallAdded',
             'call': {
-              'id': 'id',
+              'id': 'id1',
               'chatId': 'incoming',
               'author': _caller(),
               'answered': false,


### PR DESCRIPTION
## Synopsis

`OngoingCall` may be displayed again if declined fast enough.




## Solution

This PR fixes that by accounting the `add()` invokes in `CallRepository`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
