### PR TITLE
Use Xcode 16 in `build` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,11 @@ jobs:
           cache: gradle
         if: ${{ contains('apk appbundle', matrix.platform) }}
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.2'
+        if: ${{ contains('ios', matrix.platform) }}
+
       - name: Configure FCM (Firebase Cloud Messaging)
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/service_account.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '16.2'
-        if: ${{ contains('ios', matrix.platform) }}
+        if: ${{ matrix.platform == 'ipa' }}
 
       - name: Configure FCM (Firebase Cloud Messaging)
         env:


### PR DESCRIPTION
## Synopsis

Apple refuses to accept the iOS builds due to iOS 17.5 SDK being used (it requires iOS 18 SDK now). This is caused by Xcode 15 version being used on `macos-latest` by default.




## Solution

This PR adds the `xcode-setup` step so that `macos-latest` uses Xcode 16.2, which [is installed on the CI](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
