### PR TITLE
Await for `Permission.microphone` to be acquired on every platform in `OngoingCall`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ All user visible changes to this project will be documented in this file. This p
 - Web:
     - Translate popup displaying in browsers. ([#1215])
     - Call audio ringtone not being played. ([#1218])
+    - Preferred microphone and camera not being used in Safari. ([#1223])
 
 [#1215]: /../../pull/1215
 [#1218]: /../../pull/1218
 [#1219]: /../../pull/1219
+[#1223]: /../../pull/1223
 
 
 

--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -18,6 +18,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:medea_flutter_webrtc/medea_flutter_webrtc.dart' as webrtc;
 import 'package:medea_jason/medea_jason.dart';
@@ -1605,9 +1606,16 @@ class OngoingCall {
   Future<void> _initLocalMedia() async {
     Log.debug('_initLocalMedia()', '$runtimeType');
 
-    if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
-      await Permission.microphone.request();
-      await Permission.camera.request();
+    try {
+      if (hasAudio || audioState.value.isEnabled) {
+        await Permission.microphone.request();
+      }
+
+      if (videoState.value.isEnabled) {
+        await Permission.camera.request();
+      }
+    } on MissingPluginException {
+      // No-op.
     }
 
     await _mediaSettingsGuard.protect(() async {

--- a/lib/provider/drift/drift.dart
+++ b/lib/provider/drift/drift.dart
@@ -424,7 +424,7 @@ final class CommonDriftProvider extends DisposableInterface {
           onError: (e) {
             if (e is! StateError &&
                 e is! CouldNotRollBackException &&
-                !e.isConnectionClosedException) {
+                !_isConnectionClosedException(e)) {
               controller?.addError(e);
             }
           },
@@ -733,7 +733,7 @@ Future<T?> _caught<T>(Future<T?>? function) async {
   } on CouldNotRollBackException {
     // No-op.
   } catch (e) {
-    if (!e.isConnectionClosedException) {
+    if (!_isConnectionClosedException(e)) {
       rethrow;
     }
   }
@@ -741,11 +741,8 @@ Future<T?> _caught<T>(Future<T?>? function) async {
   return null;
 }
 
-/// Extension adding ability to check whether this error is a `drift` race
-/// related one.
-extension on dynamic {
-  /// Indicates  whether this error is a `drift` race related one.
-  bool get isConnectionClosedException =>
-      toString().contains('ConnectionClosedException') ||
-      toString().contains('Channel was closed before receiving a response');
+/// Indicates  whether this error is a `drift` race related one.
+bool _isConnectionClosedException(dynamic e) {
+  return e.toString().contains('ConnectionClosedException') ||
+      e.toString().contains('Channel was closed before receiving a response');
 }

--- a/lib/ui/page/home/overlay/controller.dart
+++ b/lib/ui/page/home/overlay/controller.dart
@@ -28,6 +28,7 @@ import '/domain/repository/settings.dart';
 import '/domain/service/call.dart';
 import '/domain/service/chat.dart';
 import '/l10n/l10n.dart';
+import '/util/log.dart';
 import '/util/obs/obs.dart';
 import '/util/platform_utils.dart';
 import '/util/web/web_utils.dart';
@@ -67,6 +68,11 @@ class CallOverlayController extends GetxController {
   @override
   void onInit() {
     _subscription = _callService.calls.changes.listen((event) {
+      Log.debug(
+        '_callService.calls.changes -> ${event.op}: key(${event.key}), value(${event.value?.value})',
+        '$runtimeType',
+      );
+
       switch (event.op) {
         case OperationKind.added:
           if (WebUtils.containsCall(event.key!)) {


### PR DESCRIPTION
## Synopsis

The preferred device isn't used on Safari due to it asking for microphone/camera permission every time it is accessed.




## Solution

This PR fixes the issue by awaiting for the permission to be acquired and only then applying the preferred device preferences.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
