### PR TITLE
Execute `getUserMedia()` in `WebUtils.microphonePermission()` for Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,14 @@ All user visible changes to this project will be documented in this file. This p
     - Translate popup displaying in browsers. ([#1215])
     - Call audio ringtone not being played. ([#1218])
     - Preferred microphone and camera not being used in Safari. ([#1223])
+    - Microphone devices not being listed in PWA in Safari. ([#1227])
 
 [#1215]: /../../pull/1215
 [#1218]: /../../pull/1218
 [#1219]: /../../pull/1219
 [#1223]: /../../pull/1223
 [#1226]: /../../pull/1226
+[#1227]: /../../pull/1227
 
 
 

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -728,7 +728,9 @@ class WebUtils {
       granted = permission.state == 'granted';
     }
 
-    if (!granted) {
+    // PWA in Safari returns `true` regarding permission, yet doesn't allow to
+    // enumerate devices despite that.
+    if (!granted || WebUtils.isSafari) {
       final web.MediaStream stream =
           await web.window.navigator.mediaDevices
               .getUserMedia(web.MediaStreamConstraints(audio: true.toJS))


### PR DESCRIPTION
## Synopsis

Safari in PWA doesn't enumerate the microphone devices. This is caused by microphone permission being `true`, yet devices not being available without track acquisition.




## Solution

This PR fixes that by querying the microphone devices during permission in Safari.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
