### PR TITLE
Don't invoke `GraphQlProvider.refreshSession()` while application is inactive

### DIFF
--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -764,16 +764,28 @@ class AuthService extends DisposableService {
             'refreshSession($userId |-> $attempt): acquired the lock, while it was locked -> should refresh: ${_shouldRefresh(oldCreds)}',
             '$runtimeType',
           );
-
-          if (!_shouldRefresh(oldCreds)) {
-            // [Credentials] are fresh.
-            return _refreshRetryDelay = _initialRetryDelay;
-          }
         } else {
           Log.debug(
-            'refreshSession($userId |-> $attempt): acquired the lock, while it was unlocked',
+            'refreshSession($userId |-> $attempt): acquired the lock, while it was unlocked -> should refresh: ${_shouldRefresh(oldCreds)}',
             '$runtimeType',
           );
+        }
+
+        if (!_shouldRefresh(oldCreds)) {
+          if (oldCreds != null) {
+            if (credentials.value?.access.secret != oldCreds.access.secret ||
+                credentials.value?.refresh.secret != oldCreds.refresh.secret) {
+              Log.debug(
+                'refreshSession($userId |-> $attempt): `credentials.value` differ from `oldCreds`, thus (since `_shouldRefresh` is `false`) authorizing those',
+                '$runtimeType',
+              );
+
+              _authorized(oldCreds);
+            }
+          }
+
+          // [Credentials] are fresh.
+          return _refreshRetryDelay = _initialRetryDelay;
         }
 
         if (oldCreds == null) {

--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -20,8 +20,10 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter/material.dart' show visibleForTesting;
+import 'package:flutter/material.dart'
+    show AppLifecycleState, visibleForTesting;
 import 'package:get/get.dart';
+import 'package:mutex/mutex.dart';
 
 import '/config.dart';
 import '/domain/model/chat.dart';
@@ -90,14 +92,21 @@ class AuthService extends DisposableService {
   final Map<UserId, Timer> _refreshTimers = {};
 
   /// [_refreshTimers] interval.
-  final Duration _refreshTaskInterval = const Duration(seconds: 30);
+  final Duration _refreshTaskInterval = const Duration(seconds: 10);
 
   /// Minimal allowed [credentials] TTL.
-  final Duration _accessTokenMinTtl = const Duration(minutes: 2);
+  final Duration _accessTokenMinTtl = const Duration(minutes: 29);
 
   /// [StreamSubscription] to [WebUtils.onStorageChange] fetching new
   /// [Credentials].
   StreamSubscription? _storageSubscription;
+
+  /// [Mutex] being unlocked only when [AppLifecycleState] is in foreground.
+  final Mutex _lifecycleMutex = Mutex();
+
+  /// [Worker] reacting on the [RouterState.lifecycle] changes to lock/unlock
+  /// the [_lifecycleMutex].
+  Worker? _lifecycleWorker;
 
   /// [refreshSession] attempt number counter used purely for [Log]s.
   static int _refreshAttempt = 0;
@@ -124,6 +133,7 @@ class AuthService extends DisposableService {
     Log.debug('onClose()', '$runtimeType');
 
     _storageSubscription?.cancel();
+    _lifecycleWorker?.dispose();
     _refreshTimers.forEach((_, t) => t.cancel());
     _refreshTimers.clear();
 
@@ -204,6 +214,27 @@ class AuthService extends DisposableService {
             router.go(_unauthorized());
           }
         }
+      }
+    });
+
+    _lifecycleWorker = ever(router.lifecycle, (AppLifecycleState state) async {
+      Log.debug('_lifecycleWorker -> ${state.name}', '$runtimeType');
+
+      switch (state) {
+        case AppLifecycleState.resumed:
+        case AppLifecycleState.inactive:
+          if (_lifecycleMutex.isLocked) {
+            _lifecycleMutex.release();
+          }
+          break;
+
+        case AppLifecycleState.detached:
+        case AppLifecycleState.hidden:
+        case AppLifecycleState.paused:
+          if (!_lifecycleMutex.isLocked) {
+            await _lifecycleMutex.acquire();
+          }
+          break;
       }
     });
 
@@ -627,6 +658,23 @@ class AuthService extends DisposableService {
   /// the active one, if [userId] is not provided.
   Future<void> refreshSession({UserId? userId}) async {
     final int attempt = _refreshAttempt++;
+
+    if (!router.lifecycle.value.inForeground) {
+      Log.debug(
+        'refreshSession($userId |-> $attempt) waiting for application to be active...',
+        '$runtimeType',
+      );
+
+      await _lifecycleMutex.acquire();
+      Log.debug(
+        'refreshSession($userId |-> $attempt) waiting for application to be active... done! ✨',
+        '$runtimeType',
+      );
+
+      if (_lifecycleMutex.isLocked) {
+        _lifecycleMutex.release();
+      }
+    }
 
     final FutureOr<bool> futureOrBool = WebUtils.isLocked;
     final bool isLocked =

--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -92,10 +92,10 @@ class AuthService extends DisposableService {
   final Map<UserId, Timer> _refreshTimers = {};
 
   /// [_refreshTimers] interval.
-  final Duration _refreshTaskInterval = const Duration(seconds: 10);
+  final Duration _refreshTaskInterval = const Duration(seconds: 30);
 
   /// Minimal allowed [credentials] TTL.
-  final Duration _accessTokenMinTtl = const Duration(minutes: 29);
+  final Duration _accessTokenMinTtl = const Duration(minutes: 2);
 
   /// [StreamSubscription] to [WebUtils.onStorageChange] fetching new
   /// [Credentials].

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -2058,11 +2058,16 @@ class ChatController extends GetxController {
         _history.clear();
       }
 
-      if (_history.isNotEmpty ||
-          listController.position.pixels >
-              MediaQuery.of(onContext?.call() ?? router.context!).size.height *
-                      2 +
-                  200) {
+      bool isHighEnough = false;
+
+      final BuildContext? context = onContext?.call() ?? router.context;
+      if (context != null) {
+        isHighEnough =
+            listController.position.pixels >
+            MediaQuery.of(context).size.height * 2 + 200;
+      }
+
+      if (_history.isNotEmpty || isHighEnough) {
         canGoDown.value = true;
       } else {
         canGoDown.value = false;

--- a/test/unit/auth_test.dart
+++ b/test/unit/auth_test.dart
@@ -115,6 +115,8 @@ void main() async {
       AuthService(authRepository, getStorage, accountProvider, locksProvider),
     );
 
+    router = RouterState(authService);
+
     expect(await authService.init(), Routes.auth);
 
     await authService.signIn(
@@ -170,6 +172,8 @@ void main() async {
       ),
     );
 
+    router = RouterState(authService);
+
     expect(await authService.init(), null);
 
     expect(authService.status.value.isSuccess, true);
@@ -208,6 +212,8 @@ void main() async {
         locksProvider,
       ),
     );
+
+    router = RouterState(authService);
 
     expect(await authService.init(), Routes.auth);
     try {

--- a/test/unit/call_test.dart
+++ b/test/unit/call_test.dart
@@ -50,6 +50,7 @@ import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -147,6 +148,7 @@ void main() async {
         locksProvider,
       ),
     );
+    router = RouterState(authService);
     authService.init();
 
     UserRepository userRepository = Get.put(
@@ -322,6 +324,7 @@ void main() async {
         locksProvider,
       ),
     );
+    router = RouterState(authService);
     authService.init();
 
     final UserRepository userRepository = Get.put(
@@ -434,6 +437,7 @@ void main() async {
         locksProvider,
       ),
     );
+    router = RouterState(authService);
     authService.init();
 
     AbstractSettingsRepository settingsRepository = Get.put(

--- a/test/unit/chat_attachment_test.dart
+++ b/test/unit/chat_attachment_test.dart
@@ -49,6 +49,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -123,6 +124,7 @@ void main() async {
       locksProvider,
     ),
   );
+  router = RouterState(authService);
   authService.init();
 
   test('ChatService successfully uploads an attachment', () async {

--- a/test/unit/chat_avatar_test.dart
+++ b/test/unit/chat_avatar_test.dart
@@ -46,6 +46,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -169,6 +170,7 @@ void main() async {
         locksProvider,
       ),
     );
+    router = RouterState(authService);
     authService.init();
 
     final UserRepository userRepository = UserRepository(

--- a/test/unit/chat_delete_message_test.dart
+++ b/test/unit/chat_delete_message_test.dart
@@ -48,6 +48,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -228,6 +229,7 @@ void main() async {
       locksProvider,
     ),
   );
+  router = RouterState(authService);
   authService.init();
 
   final UserRepository userRepository = Get.put(

--- a/test/unit/chat_direct_link_test.dart
+++ b/test/unit/chat_direct_link_test.dart
@@ -48,6 +48,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/blocklist.dart';
 import 'package:messenger/store/call.dart';
@@ -181,6 +182,7 @@ void main() async {
         locksProvider,
       ),
     );
+    router = RouterState(authService);
     authService.init();
 
     final UserRepository userRepository = Get.put(

--- a/test/unit/chat_edit_message_test.dart
+++ b/test/unit/chat_edit_message_test.dart
@@ -48,6 +48,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -215,6 +216,7 @@ void main() async {
         locksProvider,
       ),
     );
+    router = RouterState(authService);
     authService.init();
 
     UserRepository userRepository = UserRepository(
@@ -309,6 +311,7 @@ void main() async {
           locksProvider,
         ),
       );
+      router = RouterState(authService);
       authService.init();
 
       final UserRepository userRepository = UserRepository(

--- a/test/unit/chat_hide_test.dart
+++ b/test/unit/chat_hide_test.dart
@@ -154,9 +154,8 @@ void main() async {
       locksProvider,
     ),
   );
-  authService.init();
-
   router = RouterState(authService);
+  authService.init();
 
   when(
     graphQlProvider.recentChatsTopEvents(3),

--- a/test/unit/chat_leave_test.dart
+++ b/test/unit/chat_leave_test.dart
@@ -44,6 +44,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -146,6 +147,7 @@ void main() async {
       locksProvider,
     ),
   );
+  router = RouterState(authService);
   authService.init();
 
   when(

--- a/test/unit/chat_members_test.dart
+++ b/test/unit/chat_members_test.dart
@@ -44,6 +44,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -282,6 +283,7 @@ void main() async {
         locksProvider,
       ),
     );
+    router = RouterState(authService);
     authService.init();
 
     final UserRepository userRepository = Get.put(

--- a/test/unit/chat_read_test.dart
+++ b/test/unit/chat_read_test.dart
@@ -45,6 +45,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -167,6 +168,7 @@ void main() async {
       locksProvider,
     ),
   );
+  router = RouterState(authService);
   authService.init();
 
   test('ChatService successfully reads messages', () async {

--- a/test/unit/chat_rename_test.dart
+++ b/test/unit/chat_rename_test.dart
@@ -44,6 +44,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -199,6 +200,7 @@ void main() async {
       locksProvider,
     ),
   );
+  router = RouterState(authService);
   authService.init();
 
   test('ChatService successfully changes chat name', () async {

--- a/test/unit/chat_reply_message_test.dart
+++ b/test/unit/chat_reply_message_test.dart
@@ -46,6 +46,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -163,6 +164,7 @@ void main() async {
       locksProvider,
     ),
   );
+  router = RouterState(authService);
   authService.init();
 
   test('ChatService successfully replies to a message', () async {

--- a/test/unit/chat_split_message_test.dart
+++ b/test/unit/chat_split_message_test.dart
@@ -50,6 +50,7 @@ import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -110,6 +111,7 @@ void main() async {
     ),
     permanent: true,
   );
+  router = RouterState(authService);
   authService.init();
 
   var chatData = {

--- a/test/unit/toggle_chat_mute_test.dart
+++ b/test/unit/toggle_chat_mute_test.dart
@@ -44,6 +44,7 @@ import 'package:messenger/provider/drift/user.dart';
 import 'package:messenger/provider/drift/version.dart';
 import 'package:messenger/provider/gql/exceptions.dart';
 import 'package:messenger/provider/gql/graphql.dart';
+import 'package:messenger/routes.dart';
 import 'package:messenger/store/auth.dart';
 import 'package:messenger/store/call.dart';
 import 'package:messenger/store/chat.dart';
@@ -200,6 +201,7 @@ void main() async {
         locksProvider,
       ),
     );
+    router = RouterState(authService);
     authService.init();
 
     AbstractSettingsRepository settingsRepository = Get.put(
@@ -276,6 +278,7 @@ void main() async {
           locksProvider,
         ),
       );
+      router = RouterState(authService);
       authService.init();
 
       AbstractSettingsRepository settingsRepository = Get.put(

--- a/test/widget/auth_test.dart
+++ b/test/widget/auth_test.dart
@@ -130,8 +130,6 @@ void main() async {
       ),
     );
 
-    authService.init();
-
     for (int i = 0; i < 25; i++) {
       await tester.runAsync(() => Future.delayed(1.milliseconds));
       await tester.pump(const Duration(seconds: 2));
@@ -141,6 +139,9 @@ void main() async {
     router.provider = MockedPlatformRouteInformationProvider();
     when(router.routes).thenReturn(RxList());
     when(router.obscuring).thenReturn(RxList());
+    when(router.lifecycle).thenReturn(Rx(AppLifecycleState.resumed));
+
+    authService.init();
 
     await tester.pumpWidget(createWidgetForTesting(child: const AuthView()));
     await tester.pumpAndSettle();

--- a/test/widget/chat_attachment_test.dart
+++ b/test/widget/chat_attachment_test.dart
@@ -410,10 +410,11 @@ void main() async {
         locksProvider,
       ),
     );
-    authService.init();
 
     router = RouterState(authService);
     router.provider = MockPlatformRouteInformationProvider();
+
+    authService.init();
 
     final UserRepository userRepository = Get.put(
       UserRepository(graphQlProvider, userProvider),

--- a/test/widget/chat_direct_link_chat_test.dart
+++ b/test/widget/chat_direct_link_chat_test.dart
@@ -134,10 +134,11 @@ void main() async {
       locksProvider,
     ),
   );
-  authService.init();
 
   router = RouterState(authService);
   router.provider = MockPlatformRouteInformationProvider();
+
+  authService.init();
 
   final settingsProvider = Get.put(SettingsDriftProvider(common));
   final userProvider = Get.put(UserDriftProvider(common, scoped));

--- a/test/widget/chat_edit_message_test.dart
+++ b/test/widget/chat_edit_message_test.dart
@@ -368,10 +368,11 @@ void main() async {
         locksProvider,
       ),
     );
-    authService.init();
 
     router = RouterState(authService);
     router.provider = MockPlatformRouteInformationProvider();
+
+    authService.init();
 
     AbstractSettingsRepository settingsRepository = Get.put(
       SettingsRepository(

--- a/test/widget/chat_hide_test.dart
+++ b/test/widget/chat_hide_test.dart
@@ -155,10 +155,11 @@ void main() async {
       locksProvider,
     ),
   );
-  authService.init();
 
   router = RouterState(authService);
   router.provider = MockPlatformRouteInformationProvider();
+
+  authService.init();
 
   Widget createWidgetForTesting({required Widget child}) {
     return MaterialApp(

--- a/test/widget/chat_rename_test.dart
+++ b/test/widget/chat_rename_test.dart
@@ -131,10 +131,11 @@ void main() async {
     accountProvider,
     locksProvider,
   );
-  authService.init();
 
   router = RouterState(authService);
   router.provider = MockPlatformRouteInformationProvider();
+
+  authService.init();
 
   final userProvider = Get.put(UserDriftProvider(common, scoped));
   final chatItemProvider = Get.put(ChatItemDriftProvider(common, scoped));
@@ -322,6 +323,10 @@ void main() async {
         locksProvider,
       ),
     );
+
+    router = RouterState(authService);
+    router.provider = MockPlatformRouteInformationProvider();
+
     authService.init();
 
     UserRepository userRepository = Get.put(

--- a/test/widget/chat_reply_message_test.dart
+++ b/test/widget/chat_reply_message_test.dart
@@ -409,10 +409,11 @@ void main() async {
       locksProvider,
     ),
   );
-  authService.init();
 
   router = RouterState(authService);
   router.provider = MockPlatformRouteInformationProvider();
+
+  authService.init();
 
   Widget createWidgetForTesting({required Widget child}) {
     return MaterialApp(

--- a/test/widget/chat_update_attachments_test.dart
+++ b/test/widget/chat_update_attachments_test.dart
@@ -421,10 +421,11 @@ void main() async {
         locksProvider,
       ),
     );
-    authService.init();
 
     router = RouterState(authService);
     router.provider = MockPlatformRouteInformationProvider();
+
+    authService.init();
 
     UserRepository userRepository = Get.put(
       UserRepository(graphQlProvider, userProvider),

--- a/test/widget/password_recovery_test.dart
+++ b/test/widget/password_recovery_test.dart
@@ -86,10 +86,11 @@ void main() async {
         locksProvider,
       ),
     );
-    authService.init();
 
     router = RouterState(authService);
     router.provider = MockPlatformRouteInformationProvider();
+
+    authService.init();
 
     when(
       graphQlProvider.createConfirmationCode(

--- a/test/widget/user_profile_test.dart
+++ b/test/widget/user_profile_test.dart
@@ -105,10 +105,11 @@ void main() async {
     accountProvider,
     locksProvider,
   );
-  authService.init();
 
   router = RouterState(authService);
   router.provider = MockPlatformRouteInformationProvider();
+
+  authService.init();
 
   final settingsProvider = Get.put(SettingsDriftProvider(common));
   final userProvider = Get.put(UserDriftProvider(common, scoped));


### PR DESCRIPTION
## Synopsis

Application can experience `TimeoutException`s during `refreshSession()`s due to device being in low battery or sleep mode - network request can be sent, yet not received. This causes request to be sent, processed on the backend side and then the next request fails, causing application to lose authorization.




## Solution

This PR tries to fix that by preventing application from refreshing the session during background states.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
