### PR TITLE
Fix ghosts of `CallButton`s hanging when dragged fast enough (#1236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Media panel:
         - Incoming call displayed multiple times when declined quickly enough. ([#1219])
+        - Call buttons hanging in air when dragging from launchpad fast enough. ([#1237], [#1236])
 - Web:
     - Translate popup displaying in browsers. ([#1215])
     - Call audio ringtone not being played. ([#1218])
@@ -34,6 +35,8 @@ All user visible changes to this project will be documented in this file. This p
 [#1223]: /../../pull/1223
 [#1226]: /../../pull/1226
 [#1227]: /../../pull/1227
+[#1236]: /../../issues/1236
+[#1237]: /../../pull/1237
 
 
 

--- a/lib/ui/page/call/component/desktop.dart
+++ b/lib/ui/page/call/component/desktop.dart
@@ -385,6 +385,7 @@ Widget desktopCall(CallController c, BuildContext context) {
               onDragStarted: (b) {
                 c.showDragAndDropButtonsHint = false;
                 c.draggedButton.value = b;
+                c.draggedFromDock = false;
               },
               onDragEnded: (_) => c.draggedButton.value = null,
               onLeave: (_) => c.displayMore.value = true,
@@ -427,8 +428,10 @@ Widget desktopCall(CallController c, BuildContext context) {
                   onHover: enabled ? (d) => c.keepUi(true) : null,
                   onExit: enabled ? (d) => c.keepUi() : null,
                   onAccept: (CallButton data) {
-                    c.buttons.remove(data);
-                    c.draggedButton.value = null;
+                    if (!c.draggedFromDock) {
+                      c.buttons.remove(data);
+                      c.draggedButton.value = null;
+                    }
                   },
                   onWillAccept:
                       (CallButton? a) => a?.c == c && a?.isRemovable == true,
@@ -445,6 +448,7 @@ Widget desktopCall(CallController c, BuildContext context) {
                           data: e,
                           onDragStarted: () {
                             c.showDragAndDropButtonsHint = false;
+                            c.draggedFromDock = true;
                             c.draggedButton.value = e;
                           },
                           onDragCompleted: () => c.draggedButton.value = null,

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -229,6 +229,9 @@ class CallController extends GetxController {
   /// Currently dragged [CallButton].
   final Rx<CallButton?> draggedButton = Rx(null);
 
+  /// Indicator whether [draggedButton] is from [Launchpad].
+  bool draggedFromDock = false;
+
   /// [AnimationController] of a [MinimizableView] used to change the
   /// [minimized] value.
   AnimationController? minimizedAnimation;


### PR DESCRIPTION
Resolves #1236




## Synopsis

Overlay of `CallButton` may persist when dragged fast enough.




## Solution

This PR fixes that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
