### PR TITLE
Fix `GetAttachments` GraphQL query fetching originals instead of quotes for replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.5.0] · 2025-??-??
+[0.5.0]: /../../tree/v0.5.0
+
+[Diff](/../../compare/v0.4.3...v0.5.0) | [Milestone](/../../milestone/39)
+
+### Fixed
+
+- UI:
+    - Chat page:
+        - Images in replied messages sometimes not being loaded. ([#1238])
+
+[#1238]: /../../pull/1238
+
+
+
+
 ## [0.4.3] · 2025-05-06
 [0.4.3]: /../../tree/v0.4.3
 

--- a/helm/messenger/Chart.yaml
+++ b/helm/messenger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: messenger
 description: Open-source front-end part of messenger by team113.
 version: 0.1.3
-appVersion: 0.4.3
+appVersion: 0.4.4
 type: application
 sources:
   - https://github.com/team113/messenger

--- a/lib/api/backend/extension/chat.dart
+++ b/lib/api/backend/extension/chat.dart
@@ -559,10 +559,10 @@ extension GetAttachmentsConversion on GetAttachments$Query$ChatItem {
 
       if (message.repliesTo.isNotEmpty) {
         for (var r in message.repliesTo) {
-          if (r.original?.node.$$typename == 'ChatMessage') {
+          if (r.$$typename == 'ChatMessageQuote') {
             var replied =
-                r.original?.node
-                    as GetAttachments$Query$ChatItem$Node$ChatMessage$RepliesTo$Original$Node$ChatMessage;
+                r
+                    as GetAttachments$Query$ChatItem$Node$ChatMessage$RepliesTo$ChatMessageQuote;
             attachments.addAll(replied.attachments.map((e) => e.toModel()));
           }
         }
@@ -601,12 +601,12 @@ extension GetAttachmentsChatForwardAttachmentConversion
 }
 
 /// Extension adding models construction from
-/// [GetAttachments$Query$ChatItem$Node$ChatMessage$RepliesTo$Original$Node$ChatMessage$Attachments].
+/// [GetAttachments$Query$ChatItem$Node$ChatMessage$RepliesTo$ChatMessageQuote$Attachments].
 extension GetAttachmentsChatMessageRepliesToAttachmentConversion
     on
-        GetAttachments$Query$ChatItem$Node$ChatMessage$RepliesTo$Original$Node$ChatMessage$Attachments {
+        GetAttachments$Query$ChatItem$Node$ChatMessage$RepliesTo$ChatMessageQuote$Attachments {
   /// Constructs a new [Attachment] from this
-  /// [GetAttachments$Query$ChatItem$Node$ChatMessage$RepliesTo$Original$Node$ChatMessage$Attachments].
+  /// [GetAttachments$Query$ChatItem$Node$ChatMessage$RepliesTo$ChatMessageQuote$Attachments].
   Attachment toModel() => _attachment(this);
 }
 

--- a/lib/api/backend/graphql/query/chat/GetAttachments.graphql
+++ b/lib/api/backend/graphql/query/chat/GetAttachments.graphql
@@ -21,19 +21,15 @@ query GetAttachments($id: ChatItemId!) {
             __typename
             ... on ChatMessage {
                 repliesTo {
-                    original {
-                        node {
+                    __typename
+                    ... on ChatMessageQuote {
+                        attachments {
                             __typename
-                            ... on ChatMessage {
-                                attachments {
-                                    __typename
-                                    ... on ImageAttachment {
-                                        ...ImageAttachment
-                                    }
-                                    ... on FileAttachment {
-                                        ...FileAttachment
-                                    }
-                                }
+                            ... on ImageAttachment {
+                                ...ImageAttachment
+                            }
+                            ... on FileAttachment {
+                                ...FileAttachment
                             }
                         }
                     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.4.3
+version: 0.4.4
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Synopsis

Images of replies might not get fetched or loaded sometimes. This happens due to originals not being available for those quotes, as the query fetches originals currently.




## Solution

This PR fixes that by fetching attachments from quotes instead of originals.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
