### PR TITLE
Use `DateTime.now()` instead of `Attachment` name when `MediaType` is `null`

### DIFF
--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -856,10 +856,13 @@ class ChatRepository extends DisposableInterface
       attachment.status.refresh();
 
       String filename = attachment.file.name;
+
       if (filename.replaceAll(' ', '').isEmpty) {
         final mime = attachment.file.mime;
         if (mime != null) {
           filename = '${DateTime.now().microsecondsSinceEpoch}.${mime.subtype}';
+        } else {
+          filename = '${DateTime.now().microsecondsSinceEpoch}';
         }
       }
 


### PR DESCRIPTION
## Synopsis

Empty filename might be thrown when drag-n-dropping emoji from macOS emoji picker to the chat.




## Solution

This PR fixes the issue.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
