### PR TITLE
Use `FutureOrBuilder` for `RxUser` related `FutureOr` resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.6.0] · 2025-??-??
+[0.6.0]: /../../tree/v0.6.0
+
+[Diff](/../../compare/v0.5.0...v0.6.0) | [Milestone](/../../milestone/40)
+
+### Fixed
+
+- UI:
+    - Chat page:
+        - Duplicating read users avatars under messages. ([#1243])
+        - Invalid message's author being displayed sometimes. ([#1243], [#1050])
+    - Chats tab:
+        - Infinite typing indicator occurring sometimes. ([#1243], [#1244])
+
+[#1050]: /../../issues/1050
+[#1244]: /../../issues/1244
+[#1243]: /../../pull/1243
+[#1244]: /../../issues/1244
+
+
+
+
 ## [0.5.0] · 2025-05-09
 [0.5.0]: /../../tree/v0.5.0
 

--- a/helm/messenger/Chart.yaml
+++ b/helm/messenger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: messenger
 description: Open-source front-end part of messenger by team113.
 version: 0.1.3
-appVersion: 0.5.0
+appVersion: 0.5.1
 type: application
 sources:
   - https://github.com/team113/messenger

--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -431,6 +431,8 @@ class GraphQlClient {
         delayBetweenReconnectionAttempts: null,
         inactivityTimeout: const Duration(seconds: 15),
         connectFn: (Uri uri, Iterable<String>? protocols) async {
+          Log.debug('connectFn($uri, $protocols)', '$runtimeType');
+
           final GraphQLWebSocketChannel socket =
               websocket
                   .connect(

--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -241,8 +241,18 @@ class GraphQlClient {
   Stream<QueryResult> subscribe(
     SubscriptionOptions options, {
     FutureOr<Version?> Function()? ver,
+    bool resubscribe = true,
   }) {
-    return SubscriptionHandle(_subscribe, options, ver: ver).stream;
+    return SubscriptionHandle(
+      _subscribe,
+      (e) {
+        _subscriptions.remove(e);
+        e?.dispose();
+      },
+      options,
+      ver: ver,
+      resubscribe: resubscribe,
+    ).stream;
   }
 
   /// Makes an HTTP POST request with an exposed [onSendProgress].
@@ -324,12 +334,13 @@ class GraphQlClient {
   /// and returns a [Stream] which either emits received data or an error.
   ///
   /// Re-subscription is required on [ResubscriptionRequiredException] errors.
-  Future<Stream<QueryResult>> _subscribe(SubscriptionOptions options) async {
+  Future<SubscriptionConnection> _subscribe(SubscriptionOptions options) async {
     final stream = await _subscriptionLimiter.execute<Stream<QueryResult>>(
       () async => (await client).subscribe(options),
     );
 
-    final connection = SubscriptionConnection(
+    SubscriptionConnection? connection;
+    connection = SubscriptionConnection(
       stream.expand((event) {
         Object? e = GraphQlProviderExceptions.parse(event);
 
@@ -347,7 +358,8 @@ class GraphQlClient {
     );
 
     _subscriptions.add(connection);
-    return connection.stream;
+
+    return connection;
   }
 
   /// Middleware that wraps the provided [fn] execution and attempts to handle
@@ -619,13 +631,31 @@ class SubscriptionConnection {
   /// Source [Stream] of a [QueryResult]s.
   final Stream<QueryResult> _stream;
 
+  /// Indicates whether this [SubscriptionConnection] has already invoked
+  /// [dispose].
+  bool _disposed = false;
+
   /// Indicates whether there is a subscriber on the [stream] or not.
   bool get hasListener => _addonController.hasListener;
+
+  /// Indicates whether this [SubscriptionConnection] has already invoked
+  /// [dispose].
+  bool get disposed => _disposed;
 
   /// Returns a merged stream of the subscription this [SubscriptionConnection]
   /// represents and an addon stream.
   Stream<QueryResult> get stream =>
       StreamGroup.merge([_addonController.stream, _stream]);
+
+  /// Disposes the [StreamController]s associated with this connection.
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+
+    _addonController.close();
+    _disposed = true;
+  }
 
   /// Sends or enqueues an error event to the [stream].
   void addError(Object error, [StackTrace? stackTrace]) =>
@@ -635,17 +665,36 @@ class SubscriptionConnection {
 /// Steady [StreamController] listening to the provided GraphQL subscription
 /// events and resubscribing on the errors.
 class SubscriptionHandle {
-  SubscriptionHandle(this._listen, this._options, {this.ver});
+  SubscriptionHandle(
+    this._listen,
+    this._cancel,
+    this._options, {
+    this.ver,
+    this.resubscribe = true,
+  });
 
   /// Callback, called when a [Version] to pass the [SubscriptionOptions] is
   /// required.
   final FutureOr<Version?> Function()? ver;
 
+  /// Indicator whether resubscription should happen automatically on
+  /// [ResubscriptionRequiredException] or not.
+  final bool resubscribe;
+
   /// Callback, called to get the [Stream] of [QueryResult]s itself.
-  final FutureOr<Stream<QueryResult>> Function(SubscriptionOptions) _listen;
+  final FutureOr<SubscriptionConnection> Function(SubscriptionOptions) _listen;
+
+  /// Callback, called to cancel the provided [SubscriptionConnection].
+  final void Function(SubscriptionConnection?) _cancel;
 
   /// [SubscriptionOptions] to pass to the [_listen].
   SubscriptionOptions _options;
+
+  /// Last [SubscriptionConnection] retrieved from [_listen].
+  SubscriptionConnection? _connection;
+
+  /// [Mutex] guarding [_listen] invokes.
+  final Mutex _mutex = Mutex();
 
   /// [StreamController] of the [stream] exposed containing the events.
   late final StreamController<QueryResult> _controller =
@@ -674,43 +723,53 @@ class SubscriptionHandle {
   Future<void> _subscribe() async {
     Log.debug('subscribe()', '$runtimeType');
 
-    _subscription?.cancel();
+    await _mutex.protect(() async {
+      _subscription?.cancel();
 
-    try {
-      _subscription = (await _listen(_options)).listen(
-        (e) {
-          if (_backoff != null) {
-            Log.info('Successfully resubscribed 👍', _options.operationName);
+      try {
+        _cancel(_connection);
+        _connection = null;
 
-            _backoffDuration = Duration.zero;
-            _backoff?.cancel();
-            _backoff = null;
-          }
+        _connection = await _listen(_options);
+        _subscription = _connection?.stream.listen(
+          (e) {
+            if (_backoff != null) {
+              Log.info('Successfully resubscribed 👍', _options.operationName);
 
-          _controller.add(e);
-        },
-        onDone: _resubscribe,
-        onError: (e) {
-          _controller.addError(e);
-          if (e is ResubscriptionRequiredException) {
-            _resubscribe();
-          } else if (e is StaleVersionException) {
-            _resubscribe(noVersion: true);
-          } else {
-            _resubscribe();
-          }
-        },
-        cancelOnError: true,
-      );
-    } catch (e) {
-      _controller.addError(e);
-      _resubscribe();
-    }
+              _backoffDuration = Duration.zero;
+              _backoff?.cancel();
+              _backoff = null;
+            }
+
+            _controller.add(e);
+          },
+          onDone: resubscribe ? _resubscribe : null,
+          onError: (e) {
+            _controller.addError(e);
+
+            if (e is ResubscriptionRequiredException && resubscribe) {
+              _resubscribe();
+            } else if (e is StaleVersionException && resubscribe) {
+              _resubscribe(noVersion: true);
+            } else {
+              _resubscribe();
+            }
+          },
+          cancelOnError: true,
+        );
+      } catch (e) {
+        _controller.addError(e);
+        _resubscribe();
+      }
+    });
   }
 
   /// Resubscribes to the events.
   void _resubscribe({bool noVersion = false}) async {
     Log.info('Reconnecting in $_backoffDuration...', _options.operationName);
+
+    _cancel(_connection);
+    _connection = null;
 
     _options = SubscriptionOptions(
       document: _options.document,

--- a/lib/provider/gql/components/chat.dart
+++ b/lib/provider/gql/components/chat.dart
@@ -1092,6 +1092,7 @@ mixin ChatGraphQlMixin {
         document: KeepTypingSubscription(variables: variables).document,
         variables: variables.toJson(),
       ),
+      resubscribe: false,
     );
   }
 

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -84,6 +84,7 @@ import '/provider/gql/exceptions.dart'
         PostChatMessageException,
         ReadChatException,
         RemoveChatMemberException,
+        ResubscriptionRequiredException,
         ToggleChatMuteException,
         UnblockUserException,
         UnfavoriteChatException,
@@ -1707,7 +1708,16 @@ class ChatController extends GetxController {
     await _typingGuard.protect(() async {
       if (_typingSubscription == null) {
         Log.debug('_keepTyping()', '$runtimeType');
-        _typingSubscription ??= _chatService.keepTyping(id).listen((_) {});
+        _typingSubscription ??= _chatService
+            .keepTyping(id)
+            .listen(
+              (_) {},
+              onError: (e) {
+                if (e is! ResubscriptionRequiredException) {
+                  throw e;
+                }
+              },
+            );
       }
 
       _typingTimer?.cancel();

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -1713,7 +1713,10 @@ class ChatController extends GetxController {
             .listen(
               (_) {},
               onError: (e) {
-                if (e is! ResubscriptionRequiredException) {
+                if (e is ResubscriptionRequiredException) {
+                  _stopTyping();
+                  _keepTyping();
+                } else {
                   throw e;
                 }
               },

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -1707,9 +1707,9 @@ class ChatController extends GetxController {
     await _typingGuard.protect(() async {
       if (_typingSubscription == null) {
         Log.debug('_keepTyping()', '$runtimeType');
+        _typingSubscription ??= _chatService.keepTyping(id).listen((_) {});
       }
 
-      _typingSubscription ??= _chatService.keepTyping(id).listen((_) {});
       _typingTimer?.cancel();
       _typingTimer = Timer(_typingTimeout, _stopTyping);
     });
@@ -2410,10 +2410,13 @@ class ListElementId implements Comparable<ListElementId> {
 
 /// Element to display in a [FlutterListView].
 abstract class ListElement {
-  const ListElement(this.id);
+  ListElement(this.id);
 
   /// [ListElementId] of this [ListElement].
   final ListElementId id;
+
+  /// [GlobalKey] of the element to prevent it from rebuilding.
+  final GlobalKey key = GlobalKey();
 }
 
 /// [ListElement] representing a [ChatMessage].

--- a/lib/ui/page/home/page/chat/message_field/view.dart
+++ b/lib/ui/page/home/page/chat/message_field/view.dart
@@ -45,6 +45,7 @@ import '/ui/page/home/widget/retry_image.dart';
 import '/ui/widget/animated_button.dart';
 import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/animations.dart';
+import '/ui/widget/future_or_builder.dart';
 import '/ui/widget/safe_area/safe_area.dart';
 import '/ui/widget/svg/svg.dart';
 import '/ui/widget/text_field.dart';
@@ -825,8 +826,6 @@ class MessageFieldView extends StatelessWidget {
   }) {
     final style = Theme.of(context).style;
 
-    final FutureOr<RxUser?> userOrFuture = c.getUser(item.author.id);
-
     final bool fromMe = item.author.id == c.me;
 
     if (edited) {
@@ -987,16 +986,14 @@ class MessageFieldView extends StatelessWidget {
       );
     }
 
-    final Widget expanded = FutureBuilder<RxUser?>(
-      future: userOrFuture is RxUser? ? null : userOrFuture,
-      initialData: userOrFuture is RxUser? ? userOrFuture : null,
-      builder: (context, snapshot) {
+    final Widget expanded = FutureOrBuilder<RxUser?>(
+      futureOr: () => c.getUser(item.author.id),
+      builder: (context, user) {
         final Color color =
-            snapshot.data?.user.value.id == c.me
+            user?.user.value.id == c.me
                 ? style.colors.primary
-                : style
-                    .colors
-                    .userColors[(snapshot.data?.user.value.num.val.sum() ?? 3) %
+                : style.colors.userColors[(user?.user.value.num.val.sum() ??
+                        3) %
                     style.colors.userColors.length];
 
         return Container(
@@ -1010,10 +1007,10 @@ class MessageFieldView extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              snapshot.data != null
+              user != null
                   ? Obx(() {
                     return Text(
-                      snapshot.data!.title,
+                      user.title,
                       style: style.fonts.medium.regular.onBackground.copyWith(
                         color: color,
                       ),

--- a/lib/ui/page/home/page/chat/message_field/view.dart
+++ b/lib/ui/page/home/page/chat/message_field/view.dart
@@ -987,6 +987,7 @@ class MessageFieldView extends StatelessWidget {
     }
 
     final Widget expanded = FutureOrBuilder<RxUser?>(
+      key: Key('${item.id}_2_${item.author.id}'),
       futureOr: () => c.getUser(item.author.id),
       builder: (context, user) {
         final Color color =

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -50,6 +50,7 @@ import '/ui/widget/animated_button.dart';
 import '/ui/widget/animated_switcher.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
+import '/ui/widget/future_or_builder.dart';
 import '/ui/widget/obscured_menu_interceptor.dart';
 import '/ui/widget/obscured_selection_area.dart';
 import '/ui/widget/progress_indicator.dart';
@@ -1023,18 +1024,25 @@ class ChatView extends StatelessWidget {
         throw Exception('Unreachable');
       }
 
-      final FutureOr<RxUser?> user = c.getUser(e.value.author.id);
-
       return Padding(
         padding: EdgeInsets.only(
           top: previousSame || previous is UnreadMessagesElement ? 0 : 9,
           bottom: isLast ? ChatController.lastItemBottomOffset : 0,
         ),
-        child: FutureBuilder<RxUser?>(
-          future: user is Future<RxUser?> ? user : null,
-          initialData: user is Future<RxUser?> ? null : user,
+        child: FutureOrBuilder<RxUser?>(
+          key: element.key,
+          futureOr: () => c.getUser(e.value.author.id),
           builder:
-              (_, snapshot) => Obx(() {
+              (_, user) => Obx(() {
+                // if (e.value is ChatMessage) {
+                //   final msg = e.value as ChatMessage;
+                //   if (msg.text?.val == 'wer') {
+                //     print(
+                //       '== build() msg -> user is not Future -> user?.id(${user?.id}, user?.title(${user?.title}), snapshot.title(${snapshot?.title})',
+                //     );
+                //   }
+                // }
+
                 return HighlightedContainer(
                   highlight:
                       c.highlighted.value == element.id ||
@@ -1060,7 +1068,7 @@ class ChatView extends StatelessWidget {
                                     m.memberId != c.me &&
                                     m.memberId != e.value.author.id,
                               ),
-                      user: snapshot.data,
+                      user: user,
                       getUser: c.getUser,
                       getItem: c.getItem,
                       onHide: () => c.hideChatItem(e.value),
@@ -1125,17 +1133,15 @@ class ChatView extends StatelessWidget {
         ),
       );
     } else if (element is ChatForwardElement) {
-      final FutureOr<RxUser?> user = c.getUser(element.authorId);
-
       return Padding(
         padding: EdgeInsets.only(
           top: previousSame || previous is UnreadMessagesElement ? 0 : 9,
           bottom: isLast ? ChatController.lastItemBottomOffset : 0,
         ),
-        child: FutureBuilder<RxUser?>(
-          future: user is Future<RxUser?> ? user : null,
+        child: FutureOrBuilder<RxUser?>(
+          futureOr: () => c.getUser(element.authorId),
           builder:
-              (_, snapshot) => Obx(() {
+              (_, user) => Obx(() {
                 return HighlightedContainer(
                   highlight:
                       c.highlighted.value == element.id ||
@@ -1162,7 +1168,7 @@ class ChatView extends StatelessWidget {
                                     m.memberId != c.me &&
                                     m.memberId != element.authorId,
                               ),
-                      user: snapshot.data ?? (user is RxUser? ? user : null),
+                      user: user,
                       getUser: c.getUser,
                       onHide: () async {
                         final List<Future> futures = [];

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -1130,6 +1130,7 @@ class ChatView extends StatelessWidget {
           bottom: isLast ? ChatController.lastItemBottomOffset : 0,
         ),
         child: FutureOrBuilder<RxUser?>(
+          key: Key('${element.id}_0_${element.authorId}'),
           futureOr: () => c.getUser(element.authorId),
           builder:
               (_, user) => Obx(() {

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -1034,15 +1034,6 @@ class ChatView extends StatelessWidget {
           futureOr: () => c.getUser(e.value.author.id),
           builder:
               (_, user) => Obx(() {
-                // if (e.value is ChatMessage) {
-                //   final msg = e.value as ChatMessage;
-                //   if (msg.text?.val == 'wer') {
-                //     print(
-                //       '== build() msg -> user is not Future -> user?.id(${user?.id}, user?.title(${user?.title}), snapshot.title(${snapshot?.title})',
-                //     );
-                //   }
-                // }
-
                 return HighlightedContainer(
                   highlight:
                       c.highlighted.value == element.id ||

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -418,6 +418,7 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
 
         content = [
           FutureOrBuilder<RxUser?>(
+            key: Key('${quote.hashCode}_3_${quote.author}'),
             futureOr: () => widget.getUser?.call(quote.author),
             builder: (context, user) {
               final Color color =
@@ -908,6 +909,7 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 1),
             child: FutureOrBuilder<RxUser?>(
+              key: Key('${item?.id}_4_${m.memberId}'),
               futureOr: () => widget.getUser?.call(m.memberId),
               builder: (context, member) {
                 return Tooltip(

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -49,6 +49,7 @@ import '/ui/page/home/widget/confirm_dialog.dart';
 import '/ui/page/home/widget/gallery_popup.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
+import '/ui/widget/future_or_builder.dart';
 import '/ui/widget/svg/svg.dart';
 import '/ui/widget/widget_button.dart';
 import '/util/platform_utils.dart';
@@ -415,21 +416,16 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
 
         timeInBubble = text == null && media.isNotEmpty && files.isEmpty;
 
-        final FutureOr<RxUser?>? user = widget.getUser?.call(quote.author);
-
         content = [
-          FutureBuilder<RxUser?>(
-            future: user is Future<RxUser?> ? user : null,
-            builder: (context, snapshot) {
-              final RxUser? data =
-                  snapshot.data ?? (user is RxUser? ? user : null);
-
+          FutureOrBuilder<RxUser?>(
+            futureOr: () => widget.getUser?.call(quote.author),
+            builder: (context, user) {
               final Color color =
-                  data?.user.value.id == widget.me
+                  user?.user.value.id == widget.me
                       ? style.colors.primary
                       : style
                           .colors
-                          .userColors[(data?.user.value.num.val.sum() ?? 3) %
+                          .userColors[(user?.user.value.num.val.sum() ?? 3) %
                           style.colors.userColors.length];
 
               return Row(
@@ -439,7 +435,7 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                       padding: const EdgeInsets.only(left: 12, right: 9),
                       child: SelectionText.rich(
                         TextSpan(
-                          text: data?.title ?? 'dot'.l10n * 3,
+                          text: user?.title ?? 'dot'.l10n * 3,
                           recognizer:
                               TapGestureRecognizer()
                                 ..onTap =
@@ -908,19 +904,14 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                 .firstWhereOrNull((e) => e.user.id == m.memberId)
                 ?.user;
 
-        final FutureOr<RxUser?>? member = widget.getUser?.call(m.memberId);
-
         avatars.add(
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 1),
-            child: FutureBuilder<RxUser?>(
-              future: member is Future<RxUser?> ? member : null,
-              builder: (context, snapshot) {
-                final RxUser? data =
-                    snapshot.data ?? (member is RxUser? ? member : null);
-
+            child: FutureOrBuilder<RxUser?>(
+              futureOr: () => widget.getUser?.call(m.memberId),
+              builder: (context, member) {
                 return Tooltip(
-                  message: data?.title ?? user?.title ?? ('dot'.l10n * 3),
+                  message: member?.title ?? user?.title ?? ('dot'.l10n * 3),
                   verticalOffset: 15,
                   padding: const EdgeInsets.fromLTRB(7, 3, 7, 3),
                   decoration: BoxDecoration(
@@ -928,9 +919,9 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                     borderRadius: BorderRadius.circular(20),
                   ),
                   child:
-                      data != null
+                      member != null
                           ? AvatarWidget.fromRxUser(
-                            data,
+                            member,
                             radius: AvatarRadius.smaller,
                           )
                           : AvatarWidget.fromUser(

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1444,15 +1444,6 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
       );
     }
 
-    // if (widget.item.value is ChatMessage) {
-    //   final msg = widget.item.value as ChatMessage;
-    //   if (msg.text?.val == 'wer') {
-    //     print(
-    //       '== build() msg -> widget.user.id(${widget.user?.id}), widget.user?.title(${widget.user?.title}), item.author.id(${item.author.id}), item.author.title(${item.author.title})',
-    //     );
-    //   }
-    // }
-
     final row = Row(
       crossAxisAlignment:
           _fromMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -486,6 +486,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
       Widget Function(BuildContext context, RxUser? user) builder,
     ) {
       return FutureOrBuilder<RxUser?>(
+        key: Key('${message.id}_5_$id'),
         futureOr: () => widget.getUser?.call(id),
         builder: (context, user) {
           if (user != null) {
@@ -1274,6 +1275,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
     }
 
     return FutureOrBuilder<RxUser?>(
+      key: Key('${item.hashCode}_6_${item.author}'),
       futureOr: () => widget.getUser?.call(item.author),
       builder: (_, user) {
         final Color color =
@@ -1373,6 +1375,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 1),
             child: FutureOrBuilder<RxUser?>(
+              key: Key('${widget.item.value.id}_1_${m.memberId}'),
               futureOr: () => widget.getUser?.call(m.memberId),
               builder: (context, member) {
                 return Tooltip(

--- a/lib/ui/page/home/tab/chats/widget/recent_chat.dart
+++ b/lib/ui/page/home/tab/chats/widget/recent_chat.dart
@@ -577,6 +577,7 @@ class RecentChatTile extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(right: 5),
                 child: FutureOrBuilder<RxUser?>(
+                  key: Key('${item.id}_7_${item.author.id}'),
                   futureOr: () => getUser?.call(item.author.id),
                   builder: (_, snapshot) {
                     final FutureOr<RxUser?> rxUser =
@@ -624,6 +625,7 @@ class RecentChatTile extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(right: 5),
                 child: FutureOrBuilder<RxUser?>(
+                  key: Key('${item.id}_8_${item.author.id}'),
                   futureOr: () => getUser?.call(item.author.id),
                   builder:
                       (_, user) =>

--- a/lib/ui/widget/future_or_builder.dart
+++ b/lib/ui/widget/future_or_builder.dart
@@ -1,0 +1,68 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// [FutureOr] builder returning the [T] value fetched.
+class FutureOrBuilder<T> extends StatefulWidget {
+  const FutureOrBuilder({
+    super.key,
+    required this.futureOr,
+    required this.builder,
+  });
+
+  /// Callback returning [FutureOr] itself.
+  ///
+  /// Used as a function to prevent possible reinvokes.
+  final FutureOr<T> Function() futureOr;
+
+  /// Callback, building the [T].
+  final Widget Function(BuildContext, T?) builder;
+
+  @override
+  State<FutureOrBuilder<T>> createState() => _FutureOrBuilderState<T>();
+}
+
+/// State of a [FutureOrBuilder] used for maintaining the data.
+class _FutureOrBuilderState<T> extends State<FutureOrBuilder<T>> {
+  /// Current snapshot of the [T] fetched, if any.
+  T? _data;
+
+  @override
+  void initState() {
+    final futureOr = widget.futureOr();
+
+    if (futureOr is T?) {
+      _data = futureOr as T?;
+    } else {
+      (futureOr as Future).then((e) {
+        if (mounted) {
+          setState(() => _data = e);
+        }
+      });
+    }
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context, _data);
+  }
+}

--- a/lib/ui/widget/future_or_builder.dart
+++ b/lib/ui/widget/future_or_builder.dart
@@ -62,6 +62,27 @@ class _FutureOrBuilderState<T> extends State<FutureOrBuilder<T>> {
   }
 
   @override
+  void didUpdateWidget(covariant FutureOrBuilder<T> oldWidget) {
+    if (oldWidget.key != widget.key) {
+      final futureOr = widget.futureOr();
+
+      if (futureOr is T?) {
+        if (mounted) {
+          setState(() => _data = futureOr as T?);
+        }
+      } else {
+        (futureOr as Future).then((e) {
+          if (mounted) {
+            setState(() => _data = e);
+          }
+        });
+      }
+    }
+
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
   Widget build(BuildContext context) {
     return widget.builder(context, _data);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.5.0
+version: 0.5.1
 publish_to: none
 
 environment:


### PR DESCRIPTION
Related to #1050
Related to #1208
Resolves #1244




## Synopsis

`FutureBuilder` might still return incorrect previous result passed to as a snapshot.




## Solution

This PR uses custom widget for `FutureOr`s resolving.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
