### PR TITLE
Send `Query.myUser` before `AuthService.refreshSession()` to ensure no connectivity errors

### DIFF
--- a/lib/provider/gql/components/user.dart
+++ b/lib/provider/gql/components/user.dart
@@ -47,14 +47,15 @@ mixin UserGraphQlMixin {
   /// ### Authentication
   ///
   /// Mandatory.
-  Future<GetMyUser$Query> getMyUser() async {
-    Log.debug('getMyUser()', '$runtimeType');
+  Future<GetMyUser$Query> getMyUser({bool raw = false}) async {
+    Log.debug('getMyUser(raw: $raw)', '$runtimeType');
 
     QueryResult res = await client.query(
       QueryOptions(
         operationName: 'GetMyUser',
         document: GetMyUserQuery().document,
       ),
+      raw: raw ? RawClientOptions(AccessTokenSecret('')) : null,
     );
     return GetMyUser$Query.fromJson(res.data!);
   }

--- a/lib/store/auth.dart
+++ b/lib/store/auth.dart
@@ -231,6 +231,12 @@ class AuthRepository extends DisposableInterface
     Log.debug('refreshSession($secret)', '$runtimeType');
 
     return _graphQlProvider.clientGuard.protect(() async {
+      try {
+        await _graphQlProvider.getMyUser(raw: true);
+      } on AuthorizationException {
+        // No-op, as this is expected.
+      }
+
       final response =
           (await _graphQlProvider.refreshSession(secret)).refreshSession
               as RefreshSession$Mutation$RefreshSession$CreateSessionOk;

--- a/test/e2e/mock/graphql.dart
+++ b/test/e2e/mock/graphql.dart
@@ -163,9 +163,10 @@ class MockGraphQlClient extends GraphQlClient {
 
   @override
   Future<QueryResult> query(
-    QueryOptions options, [
-    Exception Function(Map<String, dynamic>)? handleException,
-  ]) async {
+    QueryOptions options, {
+    RawClientOptions? raw,
+    Exception Function(Map<String, dynamic>)? onException,
+  }) async {
     if (delay != null) {
       await Future.delayed(delay!);
     }
@@ -175,7 +176,7 @@ class MockGraphQlClient extends GraphQlClient {
       throw const ConnectionException('Mocked');
     }
 
-    return super.query(options, handleException);
+    return super.query(options, raw: raw, onException: onException);
   }
 
   @override


### PR DESCRIPTION
## Synopsis

`RefreshSessionException` might occur because of browser killing the POST request on-flight. The request may successfully complete, yet browser may throw `net::ERR_TIMED_OUT`, `net::ERR_INTERNET_DISCONNECTED`, `net::ERR_CONNECTION_RESET`, `net::ERR_NETWORK_CHANGED`, etc.




## Solution

This PR tries to catch this error before trying to do such important mutation as refreshing the session.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
