### PR TITLE
Disable native swipe back gesture in Safari on iOS to fix invalid route animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,15 @@ All user visible changes to this project will be documented in this file. This p
         - Infinite typing indicator occurring sometimes. ([#1243], [#1244])
     - Chat info page:
         - Infinite loader displayed under members list. ([#1246])
+- Web:
+    - Invalid animation when swiping pages back in Safari on iOS. ([#1267])
 
 [#1050]: /../../issues/1050
 [#1244]: /../../issues/1244
 [#1243]: /../../pull/1243
 [#1244]: /../../issues/1244
 [#1246]: /../../pull/1246
+[#1267]: /../../pull/1267
 
 
 

--- a/web/index.html
+++ b/web/index.html
@@ -185,6 +185,7 @@
       </div>
     </div>
   </div>
+
   <!-- Request notifications permission on the first user interaction. -->
   <script>
     var click = document.onclick;
@@ -197,6 +198,7 @@
       document.onclick = click;
     }
   </script>
+
   <!-- TODO: Remove when https://bugzilla.mozilla.org/show_bug.cgi?id=934640 is
              resolved -->
   <!-- Polyfill for `indexedDB.databases()`.
@@ -239,6 +241,7 @@
       };
     }
   </script>
+
   <!-- Animate the blinking loader -->
   <script>
     let interval;
@@ -275,6 +278,7 @@
       }
     });
   </script>
+
   <!-- TODO: Styles page related, should be removed at some point. -->
   <script defer src="/script/FileSaver.min.js"></script>
   <script>
@@ -282,6 +286,7 @@
       saveAs(url, name);
     }
   </script>
+
   <!-- Clean the whole IndexedDB. -->
   <script>
     async function cleanIndexedDB(except) {
@@ -293,6 +298,7 @@
       }
     }
   </script>
+
   <!-- Initialize the Firebase Cloud Messaging. -->
   <script>
     if ("serviceWorker" in navigator) {
@@ -301,6 +307,7 @@
       });
     }
   </script>
+
   <!-- Return the currently held locks of Navigator. -->
   <script>
     async function getLocks() {
@@ -308,11 +315,26 @@
       return locks.held;
     }
   </script>
+
   <!-- Indicate whether Web Locks API is available. -->
   <script>
     function locksAvailable() {
       return navigator.locks !== undefined;
     }
+  </script>
+
+  <!-- TODO: Remove when is flutter/flutter#114324 fixed:
+             https://github.com/flutter/flutter/issues/114324 -->
+  <!-- Disable swipe back/forward gesture on iOS due to invalid animation. -->
+  <script>
+    document.addEventListener(
+      'touchstart',
+      (startEvent) => {
+        if (startEvent.touches.length > 1) return;
+        startEvent.preventDefault();
+      },
+      { passive: false }
+    );
   </script>
 </body>
 


### PR DESCRIPTION
## Synopsis

Swiping back in Safari on iOS has animation problems.




## Solution

Disable the gesture until Flutter fixes the issues.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
