### PR TITLE
Fix `closeSearch()` not resetting when `startGroupCreating()` is invoked in `ChatController`

### DIFF
--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -621,6 +621,8 @@ class ChatsTabController extends GetxController {
   void startGroupCreating() {
     groupCreating.value = true;
     _toggleSearch();
+    search.value?.search.clear();
+    search.value?.query.value = '';
     router.navigation.value = false;
     search.value?.populate();
   }

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -284,7 +284,7 @@ class ChatsTabView extends StatelessWidget {
                             : null,
                         onPressed: () {
                           if (c.searching.value) {
-                            c.closeSearch();
+                            c.closeSearch(c.groupCreating.isFalse);
                           } else if (c.selecting.value) {
                             c.toggleSelecting();
                           } else if (c.groupCreating.value) {

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -103,8 +103,6 @@ PODS:
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
-  - nanopb/decode (3.30910.0)
-  - nanopb/encode (3.30910.0)
   - objective_c (0.0.1):
     - FlutterMacOS
   - open_file_mac (0.0.1):
@@ -339,6 +337,6 @@ SPEC CHECKSUMS:
   wakelock_plus: 21ddc249ac4b8d018838dbdabd65c5976c308497
   window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 
-PODFILE CHECKSUM: d31615892e294512c5c96e376ac03ed16d1d001d
+PODFILE CHECKSUM: 1eb246b7252feb97518a5c5b6e33b324dc30a54d
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Synopsis

When something is typed to the search field on `Chats` tab and then group creation is opened, the members list is empty.




## Solution

This PR fixes that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
