### PR TITLE
Fix `ChatService.chats` being empty on `Participant` modal of `PopupCall` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All user visible changes to this project will be documented in this file. This p
         - Infinite typing indicator occurring sometimes. ([#1243], [#1244])
     - Chat info page:
         - Infinite loader displayed under members list. ([#1246])
+    - Media panel:
+        - Users sometimes not being listed in add participant modal. ([#1272])
 - Web:
     - Invalid animation when swiping pages back in Safari on iOS. ([#1267])
 
@@ -31,6 +33,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1244]: /../../issues/1244
 [#1246]: /../../pull/1246
 [#1267]: /../../pull/1267
+[#1272]: /../../pull/1272
 
 
 

--- a/lib/domain/repository/chat.dart
+++ b/lib/domain/repository/chat.dart
@@ -63,7 +63,8 @@ abstract class AbstractChatRepository {
   /// Callback [onMemberRemoved] should be called once an [User] is removed from
   /// a [Chat].
   Future<void> init({
-    required Future<void> Function(ChatId, UserId) onMemberRemoved,
+    Future<void> Function(ChatId, UserId)? onMemberRemoved,
+    bool? pagination,
   });
 
   /// Clears the stored [chats].

--- a/lib/domain/service/chat.dart
+++ b/lib/domain/service/chat.dart
@@ -78,6 +78,14 @@ class ChatService extends DisposableService {
     super.onInit();
   }
 
+  /// Ensures the [chats] are initialized.
+  Future<void> ensureInitialized() async {
+    await _chatRepository.init(
+      onMemberRemoved: _onMemberRemoved,
+      pagination: true,
+    );
+  }
+
   /// Creates a group [Chat] with the provided members and the authenticated
   /// [MyUser], optionally [name]d.
   Future<RxChat> createGroupChat(

--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -2316,7 +2316,7 @@ class RxChatImpl extends RxChat {
                       }
                     }
 
-                    _chatRepository.onMemberRemoved(id, action.user.id);
+                    _chatRepository.onMemberRemoved?.call(id, action.user.id);
                     shouldPutChat = true;
                     break;
 

--- a/lib/ui/page/call/search/controller.dart
+++ b/lib/ui/page/call/search/controller.dart
@@ -136,6 +136,9 @@ class SearchController extends GetxController {
   /// Worker to react on the [contactsSearch] status changes.
   Worker? _contactsSearchWorker;
 
+  /// Worker to react on the [ChatService.status] changes.
+  Worker? _chatStatusWorker;
+
   /// Subscriptions to the [usersSearch] updates.
   StreamSubscription? _usersSearchSubscription;
 
@@ -219,6 +222,18 @@ class SearchController extends GetxController {
       populate();
     });
 
+    _chatService.ensureInitialized();
+    if (!_chatService.status.value.isSuccess) {
+      _chatStatusWorker = ever(_chatService.status, (status) {
+        if (status.isSuccess) {
+          _ensureScrollable();
+          populate();
+          _chatStatusWorker?.dispose();
+          _chatStatusWorker = null;
+        }
+      });
+    }
+
     _ensureScrollable();
     populate();
 
@@ -238,6 +253,7 @@ class SearchController extends GetxController {
     _contactsSearchWorker = null;
     _usersSearchSubscription?.cancel();
     _contactsSearchSubscription?.cancel();
+    _chatStatusWorker?.dispose();
     super.onClose();
   }
 


### PR DESCRIPTION
## Synopsis

`Participant` modal is empty when `Call` is displayed as a popup.




## Solution

This PR fixes that by ensuring the pagination of `ChatService.chats` is initialized.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
