### PR TITLE
Set ideal width and height of screen sharing to 1200p maximum

### DIFF
--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -1331,6 +1331,8 @@ class OngoingCall {
       if (screenDevice != null) {
         constraints.deviceId(screenDevice.deviceId());
       }
+      constraints.idealWidth(1920);
+      constraints.idealHeight(1200);
       constraints.idealFrameRate(30);
       settings.displayVideo(constraints);
     }


### PR DESCRIPTION
## Synopsis

Browsers can output screen sharing with the native resolution of the screen, which might be too much.




## Solution

This PR limits the maximum resolution of screen sharing by setting ideal constraints.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
