### PR TITLE
Update `Chat.lastReadItem` when receiving `EventChatRead` events

### DIFF
--- a/lib/store/chat_rx.dart
+++ b/lib/store/chat_rx.dart
@@ -678,6 +678,7 @@ class RxChatImpl extends RxChat {
             await _chatRepository.readUntil(id, untilId);
 
             _lastReadItemKey = untilId;
+            chat.value.lastReadItem = untilId;
             dto.value.lastReadItem = untilId;
 
             final DtoChatItem? item = await _driftItems.read(untilId);


### PR DESCRIPTION
## Synopsis

`Chat.lastReadItem` contains an ID of the last read item. However, it seems that this ID is not frequently updated. Instead it should update every time `EventChatRead` is received.




## Solution

This PR does that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
