### PR TITLE
Update default order of `CallButton`s (#1263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All user visible changes to this project will be documented in this file. This p
 
 - UI:
     - Media panel:
-        - Default order of call buttons in dock. ([#1263], [#1294])
+        - Default order of call buttons in dock. ([#1294], [#1263])
 
 ### Fixed
 
@@ -26,9 +26,9 @@ All user visible changes to this project will be documented in this file. This p
         - Inability to proceed to recover access with username not being empty. ([#1285])
 
 [#1263]: /../../issue/1263
-[#1294]: /../../pull/1294
 [#1280]: /../../pull/1280
 [#1285]: /../../pull/1285
+[#1294]: /../../pull/1294
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All user visible changes to this project will be documented in this file. This p
 
 [Diff](/../../compare/v0.5.1...v0.6.0) | [Milestone](/../../milestone/41)
 
+### Changed
+
+- UI:
+    - Media panel:
+        - Default order of call buttons in dock. ([#1263], [#1294])
+
 ### Fixed
 
 - UI:
@@ -19,6 +25,8 @@ All user visible changes to this project will be documented in this file. This p
     - Auth page:
         - Inability to proceed to recover access with username not being empty. ([#1285])
 
+[#1263]: /../../issue/1263
+[#1294]: /../../pull/1294
 [#1280]: /../../pull/1280
 [#1285]: /../../pull/1285
 

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -726,10 +726,10 @@ class CallController extends GetxController {
       if (persisted?.isNotEmpty != true) {
         persisted = {
           ScreenButton(this),
-          VideoButton(this),
-          EndCallButton(this),
           AudioButton(this),
+          VideoButton(this),
           MoreButton(this),
+          EndCallButton(this),
         };
       }
 


### PR DESCRIPTION
Resolves [Change default order of `CallButtons` in `Call` (#1263)](https://github.com/team113/messenger/issues/1263)

## Synopsis

Current default order of call buttons in dock is `Screen`, `Video`, `EndCall`, `Audio`, `More`.
It should be `Screen`, `Audio`, `Video`, `More`, `EndCall`.

## Solution

This PR updated the default order of call buttons in  dock.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
