### PR TITLE
Fix scroll back button not scrolling `Chat` to its last item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Chat page:
         - Screenshots made to clipboard not pasted as attachments. ([#1280])
+        - Scroll back button not scrolling chat to its true bottom. ([#1302])
     - Auth page:
         - Inability to proceed to recover access with username not being empty. ([#1285])
 
@@ -33,6 +34,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1285]: /../../pull/1285
 [#1291]: /../../pull/1291
 [#1294]: /../../pull/1294
+[#1302]: /../../pull/1302
 
 
 

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -565,6 +565,7 @@ class ChatController extends GetxController {
         elements.clear();
         _fragment!.items.values.forEach(_add);
         _subscribeFor(fragment: _fragment);
+        _updateFabStates();
 
         status.value = RxStatus.success();
       }
@@ -967,6 +968,8 @@ class ChatController extends GetxController {
                 var result = _calculateListViewIndex();
                 initIndex = result.index;
                 initOffset = result.offset;
+
+                Future.delayed(Duration(milliseconds: 500), _updateFabStates);
               }
             }
           });
@@ -1034,6 +1037,7 @@ class ChatController extends GetxController {
       }
 
       SchedulerBinding.instance.addPostFrameCallback((_) {
+        Future.delayed(Duration(milliseconds: 500), _updateFabStates);
         _ensureScrollable();
       });
 
@@ -1144,6 +1148,8 @@ class ChatController extends GetxController {
       if (addToHistory && item != null) {
         this.addToHistory(item);
       }
+
+      _updateFabStates();
     } else {
       if (original != null) {
         final ListElementId elementId = ListElementId(original.at, original.id);
@@ -1175,6 +1181,8 @@ class ChatController extends GetxController {
               curve: Curves.ease,
             );
             _ignorePositionChanges = false;
+
+            _updateFabStates();
           });
         } else {
           if (_bottomLoader == null) {
@@ -1192,6 +1200,8 @@ class ChatController extends GetxController {
               curve: Curves.ease,
             );
             _ignorePositionChanges = false;
+
+            _updateFabStates();
           });
         }
       }
@@ -1245,6 +1255,8 @@ class ChatController extends GetxController {
           elements.remove(_bottomLoader?.id);
           _topLoader = null;
           _bottomLoader = null;
+
+          _updateFabStates();
         });
       }
     }
@@ -1265,6 +1277,12 @@ class ChatController extends GetxController {
       await animateTo(item.id, item: item, addToHistory: false);
       _updateFabStates();
     } else if (chat?.messages.isEmpty == false && listController.hasClients) {
+      if (chat?.hasNext.value != false) {
+        if (chat?.lastItem != null) {
+          return animateTo(chat!.lastItem!.id, item: chat!.lastItem);
+        }
+      }
+
       canGoDown.value = false;
 
       _itemToReturnTo = _topVisibleItem;


### PR DESCRIPTION
## Synopsis

Scroll back button can appear if there's more than 2 screens of scrolling between last item and currently displayed item. However, this button only scrolls down chat to the last fetched item, not the real last item.




## Solution

This PR fixes the issue by fetching the pagination in such cases.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
