### PR TITLE
Add required `<script>` tag for `pwa_install` package to `index.html`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All user visible changes to this project will be documented in this file. This p
         - Scroll back button not scrolling chat to its true bottom. ([#1302])
     - Auth page:
         - Inability to proceed to recover access with username not being empty. ([#1285])
+- Web:
+    - Web application install button incorrectly stating that [Progressive Web Application (PWA)](PWA) is already installed. ([#1303])
 
 [#1263]: /../../issue/1263
 [#1268]: /../../issue/1268
@@ -35,6 +37,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1291]: /../../pull/1291
 [#1294]: /../../pull/1294
 [#1302]: /../../pull/1302
+[#1303]: /../../pull/1303
 
 
 

--- a/web/index.html
+++ b/web/index.html
@@ -336,6 +336,38 @@
       { passive: false }
     );
   </script>
+
+  <!-- Capture PWA install prompt event. -->
+  <script>
+    let deferredPrompt;
+
+    window.addEventListener('beforeinstallprompt', (e) => {
+      deferredPrompt = e;
+    });
+
+    function promptInstall() {
+      deferredPrompt.prompt();
+    }
+
+    // Listen for app install event
+    window.addEventListener('appinstalled', () => {
+      deferredPrompt = null;
+      appInstalled();
+    });
+
+    // Track how PWA was launched (either from browser or as PWA)
+    function getLaunchMode() {
+      const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
+      if (deferredPrompt) hasPrompt();
+      if (document.referrer.startsWith('android-app://')) {
+        appLaunchedAsTWA();
+      } else if (navigator.standalone || isStandalone) {
+        appLaunchedAsPWA();
+      } else {
+        window.appLaunchedInBrowser();
+      }
+    }
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Synopsis

PWA install button always states that PWA is either already installed or unavailable.




## Solution

This is caused by `pwa_install` step about adding `<script>` tag is being ignored. This PR adds the required script to `index.html` file.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
