### PR TITLE
Remove onDragging parameter (#1292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,11 @@ All user visible changes to this project will be documented in this file. This p
 
 [#1263]: /../../issue/1263
 [#1268]: /../../issue/1268
-[#1292]: /../../issue/1292
 [#1280]: /../../pull/1280
 [#1285]: /../../pull/1285
 [#1291]: /../../pull/1291
 [#1294]: /../../pull/1294
 [#1302]: /../../pull/1302
-[#1305]: /../../pull/1305
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,13 @@ All user visible changes to this project will be documented in this file. This p
 
 [#1263]: /../../issue/1263
 [#1268]: /../../issue/1268
+[#1292]: /../../issue/1292
 [#1280]: /../../pull/1280
 [#1285]: /../../pull/1285
 [#1291]: /../../pull/1291
 [#1294]: /../../pull/1294
 [#1302]: /../../pull/1302
+[#1305]: /../../pull/1305
 
 
 

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -1408,15 +1408,6 @@ Widget _storage(BuildContext context, MyProfileController c) {
                 color: style.colors.primaryHighlight,
               ),
             ),
-            onDragging: (i, lower, upper) {
-              if (lower is double) {
-                if (lower == 64.0 * GB) {
-                  CacheWorker.instance.setMaxSize(null);
-                } else {
-                  CacheWorker.instance.setMaxSize(lower.round());
-                }
-              }
-            },
             onDragCompleted: (i, lower, upper) {
               if (lower is double) {
                 if (lower == 64.0 * GB) {

--- a/test/unit/cache_worker_test.dart
+++ b/test/unit/cache_worker_test.dart
@@ -131,7 +131,7 @@ void main() async {
     await cacheProvider.clear();
   });
 
-  test('CacheWorker updatex max size according to slider', () async {
+  test('CacheWorker updates max size according to slider', () async {
     final CacheWorker worker = CacheWorker(cacheProvider, null);
     await worker.onInit();
 

--- a/test/unit/cache_worker_test.dart
+++ b/test/unit/cache_worker_test.dart
@@ -130,4 +130,26 @@ void main() async {
     await worker.clear();
     await cacheProvider.clear();
   });
+
+  test('CacheWorker updatex max size according to slider', () async {
+    final CacheWorker worker = CacheWorker(cacheProvider, null);
+    await worker.onInit();
+
+    void applySlider(double value) {
+      if (value == 64 * GB) {
+        CacheWorker.instance.setMaxSize(null);
+      } else {
+        CacheWorker.instance.setMaxSize(value.round());
+      }
+    }
+
+    applySlider(4.0 * GB);
+    expect(worker.info.value.maxSize, 4 * GB);
+
+    applySlider(64.0 * GB);
+    expect(worker.info.value.maxSize, null);
+
+    await worker.clear();
+    await cacheProvider.clear();
+  });
 }


### PR DESCRIPTION
Resolves team113/messenger#1292
## Synopsis

`onDragging` parameter in cache settings `FlutterSlider` would call tens of redundant upsert operations to database.


## Solution

Remove `onDragging` parameter and make sure nothing brakes

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
