### PR TITLE
Fix `Credentials` struct invalid parsing in `NotificationService` extension on iOS

### DIFF
--- a/ios/NotificationServiceExtension/NotificationService.swift
+++ b/ios/NotificationServiceExtension/NotificationService.swift
@@ -103,8 +103,8 @@ class NotificationService: UNNotificationServiceExtension {
 
         let decoder = JSONDecoder()
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.mmmZ"
-        dateFormatter.locale = Locale(identifier: "en_US")
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSX"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
 
@@ -115,14 +115,14 @@ class NotificationService: UNNotificationServiceExtension {
 
         var fresh = creds
 
-        if Date() > creds.access.expireAt {
+        if Date() > creds.access.expireAt.val {
           if #available(iOS 12.0, macOS 12.0, *) {
             if let refreshed = await refreshToken(creds: creds) {
               fresh = refreshed
 
               let encoder = JSONEncoder()
               let dateFormatter = DateFormatter()
-              dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.mmmZ"
+              dateFormatter.dateFormat = "yyyy-MM-ddTHH:mm:ss.mmmZ"
               dateFormatter.locale = Locale(identifier: "en_US")
               dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
               encoder.dateEncodingStrategy = .formatted(dateFormatter)
@@ -198,11 +198,11 @@ class NotificationService: UNNotificationServiceExtension {
           return Credentials(
             access: Token(
               secret: response.data.refreshSession.accessToken.secret,
-              expireAt: response.data.refreshSession.accessToken.expiresAt
+              expireAt: DateType(val: response.data.refreshSession.accessToken.expiresAt)
             ),
             refresh: Token(
               secret: response.data.refreshSession.refreshToken.secret,
-              expireAt: response.data.refreshSession.refreshToken.expiresAt
+              expireAt: DateType(val: response.data.refreshSession.refreshToken.expiresAt)
             ),
             userId: response.data.refreshSession.user.id
           )
@@ -262,7 +262,11 @@ class NotificationService: UNNotificationServiceExtension {
 
   struct Token: Codable {
     let secret: String
-    let expireAt: Date
+    let expireAt: DateType
+  }
+
+  struct DateType: Codable {
+    let val: Date
   }
 
   struct RefreshSessionResponse: Decodable {
@@ -322,9 +326,9 @@ class NotificationService: UNNotificationServiceExtension {
 
       // Time in microseconds to consider `lockedAt` value as being outdated
       // or stale, so it can be safely overwritten.
-      let lockedAtTtl: Int = 30_000_000 // 30s
+      let lockedAtTtl: Int = 30_000_000  // 30s
 
-      let retryDelay = UInt64(0.2 * Double(NSEC_PER_SEC)) // 200ms
+      let retryDelay = UInt64(0.2 * Double(NSEC_PER_SEC))  // 200ms
 
       var acquired: Bool = false
       while !acquired {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -43,6 +44,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
## Synopsis

Acknowledge of push notifications isn't working on iOS devices.




## Solution

This happens due to JSON parsing error during `Credentials` struct, since `Date` object is now stored as `val` instead of value itself. This PR accounts that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
