### PR TITLE
Implement `Log` modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Profile page:
         - Voice processing settings for calls. ([#1287], [#1264])
+- Technical information and logs modal opened by double clicking logo's eye. ([#1319])
 
 ### Changed
 
@@ -27,6 +28,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1287]: /../../pull/1287
 [#1293]: /../../issue/1293
 [#1296]: /../../pull/1296
+[#1319]: /../../pull/1319
 
 
 

--- a/assets/conf.toml
+++ b/assets/conf.toml
@@ -114,6 +114,11 @@
 #   level = "debug" (if `kDebugMode` or `kProfileMode` is `true`)
 #   level = "info" (if `kReleaseMode` is `true`)
 
+# Maximum allowed amount of the log entries to keep in RAM.
+#
+# Default:
+#   amount = 2048
+
 [link]
 # Prefix of the direct chat link URL.
 #

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -107,6 +107,9 @@ class Config {
   /// Level of [Log]ger to log.
   static me.LogLevel logLevel = me.LogLevel.info;
 
+  /// Maximum allowed [Log.maxLogs] amount of log entries to keep.
+  static int logAmount = 2048;
+
   /// URL of a Sparkle Appcast XML file.
   ///
   /// Intended to be used in [UpgradeWorker] to notify users about new releases
@@ -234,6 +237,10 @@ class Config {
           kDebugMode || kProfileMode ? me.LogLevel.debug : me.LogLevel.debug,
     );
 
+    logAmount = const bool.hasEnvironment('SOCAPP_LOG_AMOUNT')
+        ? const int.fromEnvironment('SOCAPP_LOG_AMOUNT')
+        : (document['log']?['amount'] ?? 2048);
+
     appcast = const bool.hasEnvironment('SOCAPP_APPCAST_URL')
         ? const String.fromEnvironment('SOCAPP_APPCAST_URL')
         : (document['appcast']?['url'] ?? appcast);
@@ -342,6 +349,7 @@ class Config {
                 orElse: () => logLevel,
               );
             }
+            logAmount = _asInt(remote['log']?['amount']) ?? logAmount;
             origin = url;
           }
         }

--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -223,8 +223,6 @@ class AuthService extends DisposableService {
     _deltaWorker = ever(PlatformUtils.isDeltaSynchronized, (
       bool synchronized,
     ) async {
-      Log.debug('_deltaWorker -> $synchronized', '$runtimeType');
-
       if (synchronized) {
         if (_deltaMutex.isLocked) {
           _deltaMutex.release();

--- a/lib/domain/service/notification.dart
+++ b/lib/domain/service/notification.dart
@@ -102,6 +102,13 @@ class NotificationService extends DisposableService {
   /// successfully configured.
   bool get pushNotifications => _pushNotifications;
 
+  /// Returns the [DeviceToken] that is used for push notifications.
+  DeviceToken get token => DeviceToken(
+    apns: _apns == null ? null : ApnsDeviceToken(_apns ?? ''),
+    voip: _voip == null ? null : ApnsVoipDeviceToken(_voip ?? ''),
+    fcm: _token == null ? null : FcmRegistrationToken(_token ?? ''),
+  );
+
   /// Indicator whether this device's [Locale] contains a China country code.
   bool get _isChina => Platform.localeName.contains('CN');
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -91,6 +91,8 @@ Future<void> main() async {
     dateStamp: !PlatformUtils.isWeb,
   );
 
+  Log.maxLogs = Config.logAmount;
+
   // Initializes and runs the [App].
   Future<void> appRunner() async {
     MediaKit.ensureInitialized();

--- a/lib/ui/page/auth/view.dart
+++ b/lib/ui/page/auth/view.dart
@@ -27,6 +27,7 @@ import '/ui/page/home/widget/avatar.dart';
 import '/ui/page/home/widget/contact_tile.dart';
 import '/ui/page/login/controller.dart';
 import '/ui/page/login/view.dart';
+import '/ui/page/support/log/view.dart';
 import '/ui/widget/animated_button.dart';
 import '/ui/widget/download_button.dart';
 import '/ui/widget/modal_popup.dart';
@@ -332,6 +333,7 @@ class AuthView extends StatelessWidget {
                 return AnimatedLogo(
                   key: const ValueKey('Logo'),
                   index: c.logoFrame.value,
+                  onEyePressed: () => LogView.show(context),
                 );
               }),
               ...footer,

--- a/lib/ui/page/auth/widget/animated_logo.dart
+++ b/lib/ui/page/auth/widget/animated_logo.dart
@@ -22,12 +22,15 @@ import '/ui/widget/svg/svg.dart';
 
 /// Animated logo, displaying the [SvgImage] based on the provided [index].
 class AnimatedLogo extends StatelessWidget {
-  const AnimatedLogo({super.key, this.index = 0});
+  const AnimatedLogo({super.key, this.index = 0, this.onEyePressed});
 
   /// Index of logo animation.
   ///
   /// Should be in 0..9 range inclusive.
   final int index;
+
+  /// Callback, called when an eye of the logo is pressed.
+  final void Function()? onEyePressed;
 
   @override
   Widget build(BuildContext context) {
@@ -48,6 +51,20 @@ class AnimatedLogo extends StatelessWidget {
             return const Center(child: CustomProgressIndicator());
           },
         ),
+
+        if (onEyePressed != null)
+          Positioned(
+            left: 45,
+            top: 64,
+            child: GestureDetector(
+              onDoubleTap: onEyePressed,
+              child: Container(
+                color: Colors.transparent,
+                width: 30,
+                height: 36,
+              ),
+            ),
+          ),
       ],
     );
   }

--- a/lib/ui/page/support/log/controller.dart
+++ b/lib/ui/page/support/log/controller.dart
@@ -1,0 +1,104 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'package:get/get.dart';
+
+import '/domain/model/my_user.dart';
+import '/domain/model/push_token.dart';
+import '/domain/model/session.dart';
+import '/domain/repository/session.dart';
+import '/domain/service/auth.dart';
+import '/domain/service/my_user.dart';
+import '/domain/service/notification.dart';
+import '/domain/service/session.dart';
+import '/pubspec.g.dart';
+import '/util/log.dart';
+
+/// Controller of a [LogView].
+class LogController extends GetxController {
+  LogController(
+    this._authService,
+    this._myUserService,
+    this._sessionService,
+    this._notificationService,
+  );
+
+  /// [AuthService] used to retrieve the current [sessionId].
+  final AuthService _authService;
+
+  /// [MyUserService] used to retrieve the current [MyUser].
+  final MyUserService? _myUserService;
+
+  /// [SessionService] maintaining the [Session]s.
+  final SessionService? _sessionService;
+
+  /// [NotificationService] having the [DeviceToken] information.
+  final NotificationService? _notificationService;
+
+  /// Returns the currently authenticated [MyUser], if any.
+  Rx<MyUser?>? get myUser => _myUserService?.myUser;
+
+  /// Returns the [Session]s known to this device, if any.
+  RxList<RxSession>? get sessions => _sessionService?.sessions;
+
+  /// Returns the currently authenticated [SessionId], if any.
+  SessionId? get sessionId => _authService.credentials.value?.session.id;
+
+  /// Returns the [DeviceToken] of this device, if any.
+  DeviceToken? get token => _notificationService?.token;
+
+  /// Returns a report of the technical information and [Log]s.
+  String report() {
+    final Session? session = sessions
+        ?.firstWhereOrNull((e) => e.session.value.id == sessionId)
+        ?.session
+        .value;
+
+    return '''
+================ Report ================
+
+Created at: ${DateTime.now()}
+Application: ${Pubspec.ref}
+
+MyUser:
+${myUser?.toJson()}
+
+SessionId:
+$sessionId
+
+Session:
+${session?.toJson()}
+
+Token:
+$token
+
+================= Logs =================
+
+${Log.logs.map((e) => '[${e.at.toStamp}] [${e.level.name}] ${e.text}').join('\n')}
+
+========================================
+''';
+  }
+}
+
+/// Extention adding text representation in stamp view of [DateTime].
+extension DateTimeToStamp on DateTime {
+  /// Returns this [DateTime] formatted as a stamp.
+  String get toStamp {
+    return '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}:${second.toString().padLeft(2, '0')}.${millisecond.toString().padLeft(4, '0')}';
+  }
+}

--- a/lib/ui/page/support/log/view.dart
+++ b/lib/ui/page/support/log/view.dart
@@ -1,0 +1,306 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:log_me/log_me.dart' as me;
+import 'package:share_plus/share_plus.dart';
+
+import '/domain/service/my_user.dart';
+import '/domain/service/notification.dart';
+import '/domain/service/session.dart';
+import '/l10n/l10n.dart';
+import '/pubspec.g.dart';
+import '/themes.dart';
+import '/ui/widget/modal_popup.dart';
+import '/ui/widget/primary_button.dart';
+import '/ui/widget/svg/svg.dart';
+import '/ui/widget/widget_button.dart';
+import '/util/get.dart';
+import '/util/log.dart';
+import '/util/message_popup.dart';
+import '/util/platform_utils.dart';
+import 'controller.dart';
+
+/// View of the technical information and [Log]s.
+class LogView extends StatelessWidget {
+  const LogView({super.key});
+
+  /// Displays a [LogView] wrapped in a [ModalPopup].
+  static Future<T?> show<T>(BuildContext context) {
+    return showDialog(context: context, builder: (_) => LogView());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final style = Theme.of(context).style;
+
+    return GetBuilder(
+      init: LogController(
+        Get.find(),
+        Get.findOrNull<MyUserService>(),
+        Get.findOrNull<SessionService>(),
+        Get.findOrNull<NotificationService>(),
+      ),
+      builder: (LogController c) {
+        return Scaffold(
+          backgroundColor: style.colors.background,
+          body: SelectionArea(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ModalPopupHeader(text: 'Version: ${Pubspec.ref}'),
+                Flexible(
+                  child: Obx(() {
+                    return ListView(
+                      padding: EdgeInsets.all(8),
+                      shrinkWrap: true,
+                      children: [
+                        SelectionContainer.disabled(
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: PrimaryButton(
+                                  onPressed: () async {
+                                    try {
+                                      await PlatformUtils.copy(
+                                        text: c.report(),
+                                      );
+
+                                      MessagePopup.success('label_copied'.l10n);
+                                    } catch (e) {
+                                      MessagePopup.error(e);
+                                    }
+                                  },
+                                  title: 'Copy as text',
+                                ),
+                              ),
+                              SizedBox(width: 8),
+                              Expanded(
+                                child: PrimaryButton(
+                                  onPressed: () async {
+                                    try {
+                                      final file =
+                                          await PlatformUtils.createAndDownload(
+                                            'report_${DateTime.now().millisecondsSinceEpoch}.log',
+                                            Uint8List.fromList(
+                                              c.report().codeUnits,
+                                            ),
+                                          );
+
+                                      if (file != null &&
+                                          PlatformUtils.isMobile) {
+                                        await SharePlus.instance.share(
+                                          ShareParams(
+                                            files: [XFile(file.path)],
+                                          ),
+                                        );
+                                      }
+                                    } catch (e) {
+                                      MessagePopup.error(e);
+                                    }
+                                  },
+                                  title: 'Download as file',
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+
+                        _application(context, c),
+                        _myUser(context, c),
+                        _session(context, c),
+                        _token(context, c),
+
+                        // Logs.
+                        ListTile(
+                          leading: WidgetButton(
+                            onPressed: () {},
+                            onPressedWithDetails: (u) {
+                              PlatformUtils.copy(
+                                text: Log.logs
+                                    .map((e) => '[${e.at.toStamp}] ${e.text}')
+                                    .join('\n'),
+                              );
+
+                              MessagePopup.success(
+                                'label_copied'.l10n,
+                                at: u.globalPosition,
+                              );
+                            },
+                            child: SvgIcon(SvgIcons.copy),
+                          ),
+                          title: Text('Logs'),
+                        ),
+                        ...Log.logs.map((e) {
+                          return Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                e.at.toStamp,
+                                style: style.fonts.small.regular.onBackground,
+                              ),
+                              SizedBox(width: 4),
+                              Expanded(
+                                child: Text(
+                                  e.text,
+                                  style: switch (e.level) {
+                                    me.LogLevel.fatal =>
+                                      style.fonts.small.regular.danger,
+
+                                    me.LogLevel.error =>
+                                      style.fonts.small.regular.danger,
+
+                                    me.LogLevel.warning =>
+                                      style.fonts.small.regular.onBackground
+                                          .copyWith(
+                                            color: style.colors.warning,
+                                          ),
+
+                                    me.LogLevel.info =>
+                                      style.fonts.small.regular.onBackground
+                                          .copyWith(
+                                            color: style.colors.acceptAuxiliary,
+                                          ),
+
+                                    me.LogLevel.debug =>
+                                      style.fonts.small.regular.onBackground,
+
+                                    me.LogLevel.trace =>
+                                      style
+                                          .fonts
+                                          .small
+                                          .regular
+                                          .secondaryHighlightDarkest,
+
+                                    me.LogLevel.off || me.LogLevel.all =>
+                                      style
+                                          .fonts
+                                          .small
+                                          .regular
+                                          .secondaryHighlightDarkest,
+                                  },
+                                ),
+                              ),
+                            ],
+                          );
+                        }),
+                      ],
+                    );
+                  }),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// Builds the technical information version of application.
+  Widget _application(BuildContext context, LogController c) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListTile(
+          leading: WidgetButton(
+            onPressed: () {},
+            onPressedWithDetails: (u) {
+              PlatformUtils.copy(text: Pubspec.ref);
+              MessagePopup.success('label_copied'.l10n, at: u.globalPosition);
+            },
+            child: SvgIcon(SvgIcons.copy),
+          ),
+          title: Text('Application'),
+        ),
+        Text('Ref: ${Pubspec.ref}'),
+      ],
+    );
+  }
+
+  /// Builds the technical information about [MyUser].
+  Widget _myUser(BuildContext context, LogController c) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListTile(
+          leading: WidgetButton(
+            onPressed: () {},
+            onPressedWithDetails: (u) {
+              PlatformUtils.copy(text: '${c.myUser?.value?.toJson()}');
+              MessagePopup.success('label_copied'.l10n, at: u.globalPosition);
+            },
+            child: SvgIcon(SvgIcons.copy),
+          ),
+          title: Text('MyUser'),
+        ),
+        Text('${c.myUser?.value?.toJson()}'),
+      ],
+    );
+  }
+
+  /// Builds the technical information about current [Session].
+  Widget _session(BuildContext context, LogController c) {
+    final session = c.sessions
+        ?.firstWhereOrNull((e) => e.session.value.id == c.sessionId)
+        ?.session
+        .value
+        .toJson();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListTile(
+          leading: WidgetButton(
+            onPressed: () {},
+            onPressedWithDetails: (u) {
+              PlatformUtils.copy(text: '$session');
+              MessagePopup.success('label_copied'.l10n, at: u.globalPosition);
+            },
+            child: SvgIcon(SvgIcons.copy),
+          ),
+          title: Text('Session'),
+        ),
+        Text('ID: ${c.sessionId}'),
+        Text('$session'),
+      ],
+    );
+  }
+
+  /// Builds the technical information about a [DeviceToken] used.
+  Widget _token(BuildContext context, LogController c) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListTile(
+          leading: WidgetButton(
+            onPressed: () {},
+            onPressedWithDetails: (u) {
+              PlatformUtils.copy(text: '${c.token}');
+              MessagePopup.success('label_copied'.l10n, at: u.globalPosition);
+            },
+            child: SvgIcon(SvgIcons.copy),
+          ),
+          title: Text('Token'),
+        ),
+        Text('${c.token}'),
+      ],
+    );
+  }
+}

--- a/lib/ui/page/support/view.dart
+++ b/lib/ui/page/support/view.dart
@@ -31,9 +31,11 @@ import '/ui/page/login/widget/prefix_button.dart';
 import '/ui/page/work/widget/project_block.dart';
 import '/ui/widget/outlined_rounded_button.dart';
 import '/ui/widget/progress_indicator.dart';
+import '/ui/widget/widget_button.dart';
 import '/util/message_popup.dart';
 import '/util/platform_utils.dart';
 import 'controller.dart';
+import 'log/view.dart';
 
 /// [Routes.support] page.
 class SupportView extends StatelessWidget {
@@ -54,7 +56,7 @@ class SupportView extends StatelessWidget {
           ),
           body: ListView(
             children: [
-              const ProjectBlock(),
+              ProjectBlock(onPressed: () => LogView.show(context)),
               Block(
                 title: 'label_what_we_can_help_you_with'.l10n,
                 children: [
@@ -111,9 +113,22 @@ class SupportView extends StatelessWidget {
                     }),
                     const SizedBox(height: 8),
                   ],
-                  Text(
-                    'label_version_semicolon'.l10nfmt({'version': Pubspec.ref}),
-                    style: style.fonts.small.regular.secondary,
+
+                  WidgetButton(
+                    onPressed: () {},
+                    onPressedWithDetails: (u) {
+                      PlatformUtils.copy(text: Pubspec.ref);
+                      MessagePopup.success(
+                        'label_copied'.l10n,
+                        at: u.globalPosition,
+                      );
+                    },
+                    child: Text(
+                      'label_version_semicolon'.l10nfmt({
+                        'version': Pubspec.ref,
+                      }),
+                      style: style.fonts.small.regular.secondary,
+                    ),
                   ),
                   const SizedBox(height: 4),
                 ],

--- a/lib/ui/page/work/widget/interactive_logo.dart
+++ b/lib/ui/page/work/widget/interactive_logo.dart
@@ -24,7 +24,10 @@ import '/ui/widget/svg/svg.dart';
 
 /// Interactive animated logo.
 class InteractiveLogo extends StatefulWidget {
-  const InteractiveLogo({super.key});
+  const InteractiveLogo({super.key, this.onEyePressed});
+
+  /// Callback, called when an eye of the logo is pressed.
+  final void Function()? onEyePressed;
 
   @override
   State<InteractiveLogo> createState() => _InteractiveLogoState();
@@ -54,13 +57,31 @@ class _InteractiveLogoState extends State<InteractiveLogo> {
   Widget build(BuildContext context) {
     return Listener(
       onPointerDown: (_) => _animate(),
-      child: SvgImage.asset(
-        'assets/images/logo/head_$_frame.svg',
-        height: 134,
-        fit: BoxFit.contain,
-        placeholderBuilder: (context) {
-          return const Center(child: CustomProgressIndicator());
-        },
+      child: Stack(
+        children: [
+          SvgImage.asset(
+            'assets/images/logo/head_$_frame.svg',
+            height: 134,
+            fit: BoxFit.contain,
+            placeholderBuilder: (context) {
+              return const Center(child: CustomProgressIndicator());
+            },
+          ),
+
+          if (widget.onEyePressed != null)
+            Positioned(
+              left: 35,
+              top: 48,
+              child: GestureDetector(
+                onDoubleTap: widget.onEyePressed,
+                child: Container(
+                  color: Colors.transparent,
+                  width: 30,
+                  height: 36,
+                ),
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/ui/page/work/widget/project_block.dart
+++ b/lib/ui/page/work/widget/project_block.dart
@@ -24,7 +24,10 @@ import 'interactive_logo.dart';
 
 /// [Block] display the [InteractiveLogo].
 class ProjectBlock extends StatelessWidget {
-  const ProjectBlock({super.key, this.children = const []});
+  const ProjectBlock({super.key, this.onPressed, this.children = const []});
+
+  /// Callback, called when logo is pressed.
+  final void Function()? onPressed;
 
   /// [Widget]s to display under the [InteractiveLogo], if any.
   final List<Widget> children;
@@ -51,7 +54,7 @@ class ProjectBlock extends StatelessWidget {
           maxLines: 1,
         ),
         const SizedBox(height: 20),
-        const InteractiveLogo(),
+        InteractiveLogo(onEyePressed: onPressed),
         const SizedBox(height: 7),
         ...children,
       ],

--- a/lib/util/log.dart
+++ b/lib/util/log.dart
@@ -16,6 +16,7 @@
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
 import 'package:flutter/foundation.dart';
+import 'package:get/get.dart';
 import 'package:log_me/log_me.dart' as me;
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -24,39 +25,47 @@ import 'new_type.dart';
 
 /// Utility logging messages to console.
 class Log {
+  /// List of [String]s representing the logs kept in the variable.
+  static final RxList<LogEntry> logs = RxList();
+
+  /// Amount of [logs] to keep in the variable.
+  ///
+  /// If set to zero, then no [logs] will be kept at all in the variable.
+  static int maxLogs = 0;
+
   /// Prints the fatal [message] with [tag] to the [me.Log].
   static void fatal(String message, [String? tag]) {
-    me.Log.fatal('${tag != null ? '[$tag]' : ''} $message');
+    _print(me.LogLevel.fatal, '${tag != null ? '[$tag]' : ''} $message');
     _breadcrumb(message, tag, SentryLevel.fatal);
   }
 
   /// Prints the error [message] with [tag] to the [me.Log].
   static void error(String message, [String? tag]) {
-    me.Log.error('${tag != null ? '[$tag]' : ''} $message');
+    _print(me.LogLevel.error, '${tag != null ? '[$tag]' : ''} $message');
     _breadcrumb(message, tag, SentryLevel.error);
   }
 
   /// Prints the warning [message] with [tag] to the [me.Log].
   static void warning(String message, [String? tag]) {
-    me.Log.warning('${tag != null ? '[$tag]' : ''} $message');
+    _print(me.LogLevel.warning, '${tag != null ? '[$tag]' : ''} $message');
     _breadcrumb(message, tag, SentryLevel.warning);
   }
 
   /// Prints the information [message] with [tag] to the [me.Log].
   static void info(String message, [String? tag]) {
-    me.Log.info('${tag != null ? '[$tag]' : ''} $message');
+    _print(me.LogLevel.info, '${tag != null ? '[$tag]' : ''} $message');
     _breadcrumb(message, tag, SentryLevel.info);
   }
 
   /// Prints the debug [message] with [tag] to the [me.Log].
   static void debug(String message, [String? tag]) {
-    me.Log.debug('${tag != null ? '[$tag]' : ''} $message');
+    _print(me.LogLevel.debug, '${tag != null ? '[$tag]' : ''} $message');
     _breadcrumb(message, tag, SentryLevel.debug);
   }
 
   /// Prints the trace [message] with [tag] to the [me.Log].
   static void trace(String message, [String? tag]) {
-    me.Log.trace(message, tag);
+    _print(me.LogLevel.trace, '${tag != null ? '[$tag]' : ''} $message');
     _breadcrumb(message, tag, SentryLevel.debug);
   }
 
@@ -91,6 +100,65 @@ class Log {
       }
     }
   }
+
+  /// Stores the provided [text] to the [logs].
+  static void _print(me.LogLevel level, String text) {
+    switch (level) {
+      case me.LogLevel.fatal:
+        me.Log.fatal(text);
+        break;
+
+      case me.LogLevel.error:
+        me.Log.error(text);
+        break;
+
+      case me.LogLevel.warning:
+        me.Log.warning(text);
+        break;
+
+      case me.LogLevel.info:
+        me.Log.info(text);
+        break;
+
+      case me.LogLevel.debug:
+        me.Log.debug(text);
+        break;
+
+      case me.LogLevel.trace:
+        me.Log.trace(text);
+        break;
+
+      case me.LogLevel.off:
+      case me.LogLevel.all:
+        // No-op.
+        break;
+    }
+
+    if (maxLogs > 0) {
+      if (level == me.LogLevel.trace) {
+        return;
+      }
+
+      logs.add(LogEntry(level, text, DateTime.now()));
+      while (logs.length > maxLogs) {
+        logs.removeAt(0);
+      }
+    }
+  }
+}
+
+/// Entity representing a log in the log entries.
+class LogEntry {
+  const LogEntry(this.level, this.text, this.at);
+
+  /// Level of this entry.
+  final me.LogLevel level;
+
+  /// Log itself.
+  final String text;
+
+  /// [DateTime] this entry is created at.
+  final DateTime at;
 }
 
 /// Extension adding obscured getter to [NewType]s.

--- a/lib/util/platform_utils.dart
+++ b/lib/util/platform_utils.dart
@@ -60,13 +60,6 @@ class PlatformUtilsImpl {
             .inMilliseconds;
 
         isDeltaSynchronized.value = difference <= 2200;
-
-        if (!isDeltaSynchronized.value) {
-          Log.debug(
-            'Delta not synchronized -> difference is $difference ms',
-            '$runtimeType',
-          );
-        }
       }
 
       _lastDeltaPing = DateTime.now();
@@ -803,6 +796,33 @@ class PlatformUtilsImpl {
     }
 
     return contents ?? (await rootBundle.load(asset));
+  }
+
+  /// Forms and downloads the provided [bytes] as a file.
+  Future<File?> createAndDownload(String name, Uint8List bytes) async {
+    if (isWeb) {
+      await WebUtils.downloadBlob(name, bytes);
+      return null;
+    }
+
+    String? to;
+
+    if (PlatformUtils.isDesktop) {
+      to = await FilePicker.platform.saveFile(
+        fileName: name,
+        lockParentWindow: true,
+      );
+    } else {
+      to = (await temporaryDirectory).path;
+    }
+
+    if (to != null) {
+      final File file = File(to);
+      await file.writeAsBytes(bytes);
+      return file;
+    }
+
+    return null;
   }
 }
 

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -18,6 +18,7 @@
 import 'dart:async';
 import 'dart:ffi' hide Size;
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:cupertino_http/cupertino_http.dart'
     show CupertinoClient, URLSessionConfiguration;
@@ -490,6 +491,11 @@ class WebUtils {
 
   /// Refreshes the current browser's page.
   static Future<void> refresh() async {
+    // No-op.
+  }
+
+  /// Downloads the provided [bytes] as a blob file.
+  static Future<void> downloadBlob(String name, Uint8List bytes) async {
     // No-op.
   }
 }

--- a/lib/util/web/web.dart
+++ b/lib/util/web/web.dart
@@ -126,6 +126,9 @@ external JSPromise<JSAny?> _getLocks();
 @JS('locksAvailable')
 external bool _locksAvailable();
 
+@JS('webSaveAs')
+external JSPromise<JSAny?> _webSaveAs(web.Blob blob, JSString name);
+
 /// Helper providing access to features having different implementations in
 /// browser and on native platforms.
 class WebUtils {
@@ -877,6 +880,24 @@ class WebUtils {
     }
   }
 
+  /// Refreshes the current browser's page.
+  static Future<void> refresh() async {
+    web.window.location.reload();
+  }
+
+  /// Downloads the provided [bytes] as a blob file.
+  static Future<void> downloadBlob(String name, Uint8List bytes) async {
+    final JSPromise promise = _webSaveAs(
+      web.Blob(
+        [bytes.toJS].toJS,
+        web.BlobPropertyBag(type: 'text/plain;charset=utf-8'),
+      ),
+      name.toJS,
+    );
+
+    await promise.toDart;
+  }
+
   /// Handles the [key] event to invoke [_keyHandlers] related to it.
   static bool _handleBindKeys(KeyEvent key) {
     if (key is KeyUpEvent) {
@@ -918,11 +939,6 @@ class WebUtils {
     }
 
     return false;
-  }
-
-  /// Refreshes the current browser's page.
-  static Future<void> refresh() async {
-    web.window.location.reload();
   }
 }
 

--- a/test/unit/noise_suppression_settings_test.dart
+++ b/test/unit/noise_suppression_settings_test.dart
@@ -17,7 +17,6 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-import 'package:log_me/log_me.dart';
 import 'package:medea_jason/medea_jason.dart';
 
 import 'package:messenger/domain/model/user.dart';
@@ -48,8 +47,6 @@ void main() {
   );
 
   test('Noise suppression settings are stored', () async {
-    Log.options = LogOptions(level: LogLevel.all);
-
     await repo.init();
 
     expect(repo.mediaSettings.value?.noiseSuppression, true);

--- a/web/index.html
+++ b/web/index.html
@@ -282,8 +282,8 @@
   <!-- TODO: Styles page related, should be removed at some point. -->
   <script defer src="/script/FileSaver.min.js"></script>
   <script>
-    function webSaveAs(url, name) {
-      saveAs(url, name);
+    async function webSaveAs(blob, name) {
+      return await saveAs(blob, name);
     }
   </script>
 


### PR DESCRIPTION
## Synopsis

Sometimes for development reasons we need to known some technical details: IDs, logs, etc.




## Solution

This PR implements a modal which displays the information needed.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
