### PR TITLE
Fix `CallKit` VoIP notification still ringing despite already joined from another device 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,16 @@ All user visible changes to this project will be documented in this file. This p
     - Profile page:
         - Redesigned email and password popups. ([#1296], [#1293])
 
+### Fixed
+
+- iOS:
+    - [VoIP] [CallKit] notification still ringing despite already joined call on another device. ([#1320])
+
 [#1264]: /../../issue/1264
 [#1287]: /../../pull/1287
 [#1293]: /../../issue/1293
 [#1296]: /../../pull/1296
+[#1320]: /../../pull/1320
 
 
 

--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -534,7 +534,7 @@ class AuthService extends DisposableService {
       try {
         await _authRepository.deleteSession();
       } catch (e) {
-        printError(info: e.toString());
+        Log.warning('Failed to delete `Session`: $e');
       }
 
       _unauthorized();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,6 +68,7 @@ import 'store/model/window_preferences.dart';
 import 'themes.dart';
 import 'ui/worker/cache.dart';
 import 'ui/worker/call.dart';
+import 'ui/worker/log.dart';
 import 'ui/worker/upgrade.dart';
 import 'ui/worker/window.dart';
 import 'util/backoff.dart';
@@ -195,6 +196,7 @@ Future<void> main() async {
 
     Get.put(CacheWorker(Get.findOrNull(), Get.findOrNull()));
     Get.put(UpgradeWorker(Get.findOrNull()));
+    Get.put(LogWorker());
 
     WebUtils.deleteLoader();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -300,7 +300,11 @@ Future<void> handlePushNotification(RemoteMessage message) async {
   final bool isCall =
       tag?.endsWith('_call') == true || tag?.endsWith('-call') == true;
 
+  // Since tags are only working under Android, thus this code is related to
+  // Android platform only - iOS doesn't execute that.
   if (isCall && message.data['chatId'] != null) {
+    final ChatId chatId = message.data['chatId'];
+
     SharedPreferences? prefs;
     CredentialsDriftProvider? credentialsProvider;
     AccountDriftProvider? accountProvider;
@@ -311,11 +315,11 @@ Future<void> handlePushNotification(RemoteMessage message) async {
       FlutterCallkitIncoming.onEvent.listen((CallEvent? event) async {
         switch (event!.event) {
           case Event.actionCallAccept:
-            await prefs?.setString('answeredCall', message.data['chatId']);
+            await prefs?.setString('answeredCall', chatId.val);
             break;
 
           case Event.actionCallDecline:
-            await provider?.declineChatCall(ChatId(message.data['chatId']));
+            await provider?.declineChatCall(chatId);
             break;
 
           case Event.actionCallEnded:
@@ -338,16 +342,16 @@ Future<void> handlePushNotification(RemoteMessage message) async {
 
       await FlutterCallkitIncoming.showCallkitIncoming(
         CallKitParams(
-          id: message.data['chatId'],
+          id: chatId.val,
           nameCaller: message.notification?.title ?? 'gapopa',
           appName: 'Gapopa',
           avatar: '', // TODO: Add avatar to FCM notifications.
-          handle: message.data['chatId'],
+          handle: chatId.val,
           type: 0,
           textAccept: 'btn_accept'.l10n,
           textDecline: 'btn_decline'.l10n,
           duration: 30000,
-          extra: {'chatId': message.data['chatId']},
+          extra: {'chatId': chatId.val},
           headers: {'platform': 'flutter'},
           android: AndroidParams(
             isCustomNotification: true,
@@ -383,59 +387,110 @@ Future<void> handlePushNotification(RemoteMessage message) async {
         provider.token = credentials.access.secret;
         provider.reconnect();
 
-        subscription = provider
-            .chatEvents(ChatId(message.data['chatId']), null, () => null)
-            .listen((e) async {
-              var events = ChatEvents$Subscription.fromJson(e.data!).chatEvents;
-              if (events.$$typename == 'ChatEventsVersioned') {
-                var mixin =
-                    events
-                        as ChatEvents$Subscription$ChatEvents$ChatEventsVersioned;
+        subscription = provider.chatEvents(chatId, null, () => null).listen((
+          e,
+        ) async {
+          final events = ChatEvents$Subscription.fromJson(e.data!).chatEvents;
+          if (events.$$typename == 'Chat') {
+            final mixin = events as ChatEvents$Subscription$ChatEvents$Chat;
+            final call = mixin.ongoingCall;
 
-                for (var e in mixin.events) {
-                  if (e.$$typename == 'EventChatCallFinished') {
-                    await FlutterCallkitIncoming.endCall(
-                      (message.data['chatId'] as String).base62ToUuid(),
-                    );
-                  } else if (e.$$typename == 'EventChatCallMemberJoined') {
-                    var node =
-                        e
-                            as ChatEventsVersionedMixin$Events$EventChatCallMemberJoined;
-                    if (node.user.id == credentials.userId) {
-                      await FlutterCallkitIncoming.endCall(
-                        (message.data['chatId'] as String).base62ToUuid(),
-                      );
-                    }
-                  } else if (e.$$typename == 'EventChatCallDeclined') {
-                    var node =
-                        e as ChatEventsVersionedMixin$Events$EventChatCallDeclined;
-                    if (node.user.id == credentials.userId) {
-                      await FlutterCallkitIncoming.endCall(
-                        (message.data['chatId'] as String).base62ToUuid(),
-                      );
-                    }
-                  }
+            if (call != null) {
+              if (call.members.any((e) => e.user.id == credentials.userId)) {
+                await FlutterCallkitIncoming.endCall(chatId.val.base62ToUuid());
+              }
+            }
+          } else if (events.$$typename == 'ChatEventsVersioned') {
+            final mixin =
+                events
+                    as ChatEvents$Subscription$ChatEvents$ChatEventsVersioned;
+
+            for (var e in mixin.events) {
+              if (e.$$typename == 'EventChatCallFinished') {
+                await FlutterCallkitIncoming.endCall(chatId.val.base62ToUuid());
+              } else if (e.$$typename == 'EventChatCallStarted') {
+                final node =
+                    e as ChatEventsVersionedMixin$Events$EventChatCallStarted;
+
+                if (node.call.members.any(
+                  (e) => e.user.id == credentials.userId,
+                )) {
+                  await FlutterCallkitIncoming.endCall(
+                    chatId.val.base62ToUuid(),
+                  );
+                }
+              } else if (e.$$typename == 'EventChatCallConversationStarted') {
+                final node =
+                    e
+                        as ChatEventsVersionedMixin$Events$EventChatCallConversationStarted;
+
+                if (node.call.members.any(
+                  (e) => e.user.id == credentials.userId,
+                )) {
+                  await FlutterCallkitIncoming.endCall(
+                    chatId.val.base62ToUuid(),
+                  );
+                }
+              } else if (e.$$typename == 'EventChatCallAnswerTimeoutPassed') {
+                var node =
+                    e
+                        as ChatEventsVersionedMixin$Events$EventChatCallAnswerTimeoutPassed;
+                if (node.userId == credentials.userId) {
+                  await FlutterCallkitIncoming.endCall(
+                    chatId.val.base62ToUuid(),
+                  );
+                }
+              } else if (e.$$typename == 'EventChatCallMemberJoined') {
+                var node =
+                    e as ChatEventsVersionedMixin$Events$EventChatCallMemberJoined;
+                if (node.user.id == credentials.userId) {
+                  await FlutterCallkitIncoming.endCall(
+                    chatId.val.base62ToUuid(),
+                  );
+                }
+              } else if (e.$$typename == 'EventChatCallMemberLeft') {
+                var node =
+                    e as ChatEventsVersionedMixin$Events$EventChatCallMemberLeft;
+                if (node.user.id == credentials.userId) {
+                  await FlutterCallkitIncoming.endCall(
+                    chatId.val.base62ToUuid(),
+                  );
+                }
+              } else if (e.$$typename == 'EventChatCallDeclined') {
+                var node =
+                    e as ChatEventsVersionedMixin$Events$EventChatCallDeclined;
+                if (node.user.id == credentials.userId) {
+                  await FlutterCallkitIncoming.endCall(
+                    chatId.val.base62ToUuid(),
+                  );
                 }
               }
-            });
+            }
+          }
+        });
 
         prefs = await SharedPreferences.getInstance();
         await prefs.remove('answeredCall');
+
+        // Ensure that we haven't already joined the call.
+        final query = await provider.getChat(chatId);
+        final call = query.chat?.ongoingCall;
+        if (call != null) {
+          if (call.members.any((e) => e.user.id == credentials.userId)) {
+            await FlutterCallkitIncoming.endCall(chatId.val.base62ToUuid());
+          }
+        }
       }
 
       // Remove the incoming call notification after a reasonable amount of
       // time for a better UX.
       await Future.delayed(30.seconds);
 
-      await FlutterCallkitIncoming.endCall(
-        (message.data['chatId'] as String).base62ToUuid(),
-      );
+      await FlutterCallkitIncoming.endCall(chatId.val.base62ToUuid());
     } catch (_) {
       provider?.disconnect();
       subscription?.cancel();
-      await FlutterCallkitIncoming.endCall(
-        (message.data['chatId'] as String).base62ToUuid(),
-      );
+      await FlutterCallkitIncoming.endCall(chatId.val.base62ToUuid());
     }
   } else {
     // If message contains no notification (it's a background notification),

--- a/lib/ui/page/support/log/view.dart
+++ b/lib/ui/page/support/log/view.dart
@@ -27,6 +27,7 @@ import '/domain/service/notification.dart';
 import '/domain/service/session.dart';
 import '/l10n/l10n.dart';
 import '/pubspec.g.dart';
+import '/routes.dart';
 import '/themes.dart';
 import '/ui/widget/modal_popup.dart';
 import '/ui/widget/primary_button.dart';
@@ -43,8 +44,24 @@ class LogView extends StatelessWidget {
   const LogView({super.key});
 
   /// Displays a [LogView] wrapped in a [ModalPopup].
-  static Future<T?> show<T>(BuildContext context) {
-    return showDialog(context: context, builder: (_) => LogView());
+  static Future<T?> show<T>(BuildContext context) async {
+    final route = DialogRoute<T>(
+      context: context,
+      builder: (_) => LogView(),
+      settings: RouteSettings(name: 'LogView'),
+      barrierColor:
+          DialogTheme.of(context).barrierColor ??
+          Theme.of(context).dialogTheme.barrierColor ??
+          Colors.black54,
+    );
+
+    router.obscuring.add(route);
+
+    try {
+      return await Navigator.of(context, rootNavigator: true).push<T>(route);
+    } finally {
+      router.obscuring.remove(route);
+    }
   }
 
   @override

--- a/lib/ui/widget/text_field.dart
+++ b/lib/ui/widget/text_field.dart
@@ -605,6 +605,12 @@ class TextFieldState extends ReactiveFieldState {
     this.focus.addListener(() async {
       isFocused.value = this.focus.hasFocus;
 
+      if (this.focus.hasFocus) {
+        focuses.add(this);
+      } else {
+        focuses.remove(this);
+      }
+
       if (onFocus != null) {
         if (controller.text != _previousText &&
             (_previousText != null || controller.text.isNotEmpty)) {
@@ -653,6 +659,9 @@ class TextFieldState extends ReactiveFieldState {
 
   @override
   late final FocusNode focus;
+
+  /// [TextFieldState]s that currently have focus.
+  static List<TextFieldState> focuses = [];
 
   /// Previous [TextEditingController]'s text used to determine if the [text]
   /// was modified on any [focus] change.

--- a/lib/ui/worker/log.dart
+++ b/lib/ui/worker/log.dart
@@ -1,0 +1,60 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import '/domain/service/disposable_service.dart';
+import '/routes.dart';
+import '/ui/page/support/log/view.dart';
+import '/ui/widget/text_field.dart';
+
+/// Worker opening [LogView] modal.
+class LogWorker extends DisposableService {
+  LogWorker();
+
+  @override
+  void onInit() {
+    HardwareKeyboard.instance.addHandler(_consoleListener);
+    super.onInit();
+  }
+
+  @override
+  void onClose() {
+    HardwareKeyboard.instance.removeHandler(_consoleListener);
+    super.onClose();
+  }
+
+  /// Opens the [LogView] modal on tilde key presses.
+  bool _consoleListener(KeyEvent event) {
+    if (event is KeyDownEvent) {
+      if (event.logicalKey == LogicalKeyboardKey.tilde) {
+        if (TextFieldState.focuses.isEmpty) {
+          if (router.obscuring.any((e) => e.settings.name == 'LogView')) {
+            Navigator.of(router.context!).pop();
+          } else {
+            LogView.show(router.context!);
+          }
+
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## Synopsis

CallKit VoIP notifications are still ringing even when user joins the call from another device.




## Solution

This is caused by CallKit not checking whether the call is already joined when first displayed. This PR fixes that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
