### PR TITLE
Add delay to `Session.lastActivatedAt` when comparing against `proceedIfRefreshBefore` during `refreshSession()`

### DIFF
--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -783,7 +783,9 @@ class AuthService extends DisposableService {
           final Credentials? creds = credentials.value;
           if (creds != null && proceedIfRefreshBefore != null) {
             shouldProceed = proceedIfRefreshBefore.isAfter(
-              creds.session.lastActivatedAt.val,
+              // Add a delay just to prevent possible races between old access
+              // token still being used in WebSocket connection.
+              creds.session.lastActivatedAt.val.add(Duration(seconds: 10)),
             );
           }
 
@@ -793,7 +795,7 @@ class AuthService extends DisposableService {
           }
 
           Log.debug(
-            'refreshSession($userId |-> $attempt): should refresh is `false`, yet proceeding as ${creds?.session.lastActivatedAt.val.toUtc()} is after ${proceedIfRefreshBefore?.toUtc()}',
+            'refreshSession($userId |-> $attempt): should refresh is `false`, yet proceeding as ${creds?.session.lastActivatedAt.val.toUtc()} (+10 seconds) is before ${proceedIfRefreshBefore?.toUtc()}',
             '$runtimeType',
           );
         }


### PR DESCRIPTION
## Synopsis

During sleep devices will experience a lot of `AuthorizationException`s when waken up. All of those exceptions will trigger `refreshSession()`. And to prevent those exceptions from spamming the session refreshment the `proceedIfRefreshBefore` parameter is used. However, some of subscriptions even after new access token is acquired may still use the old one. This causes a small delay, during which the session will be refreshed again, causing unauthorization. Delay is small enough, on practice it took only ~450 ms.




## Solution

This PR adds a delay of 10 seconds to `proceedIfRefreshBefore` parameter to prevent such things from happening.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
