### PR TITLE
Replace relative links with absolute links in Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -60,6 +60,6 @@ Related to <paste issues/PRs references>
 
 
 [l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
-[l:2]: /CONTRIBUTING.md#code-style
-[l:3]: /CHANGELOG.md
+[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
+[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
 [l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests


### PR DESCRIPTION
## Synopsis

`CHANGELOG entry` and `code style` within Pull Request template lead to `/CHANGELOG.md` and `/CONTRIBUTING.md#code-style` respectably. However, the links used are relative ones and when clicked they actually go to:
- `/CHANGELOG.md` -> https://github.com/CHANGELOG.md
- `/CONTRIBUTING.md#code-style` -> https://github.com/CONTRIBUTING.md#code-style




## Solution

It seems that relative links don't work in GitHub templates: https://stackoverflow.com/questions/49242645/github-relative-internal-repository-links-in-pull-request-template-md

This PR replaces those with absolute ones.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
