### PR TITLE
Add missing `Session` fragment to `RefreshSession` mutation in NSE on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ All user visible changes to this project will be documented in this file. This p
 ### Fixed
 
 - iOS:
-    - Authorization sometimes being lost when receiving push notifications. ([#1326])
+    - Authorization sometimes being lost when receiving push notifications. ([#1331], [#1326])
 
 [#1326]: /../../pull/1326
 [#1327]: /../../pull/1327
 [#1330]: /../../pull/1330
+[#1331]: /../../pull/1331
 
 
 

--- a/ios/NotificationServiceExtension/NotificationService.swift
+++ b/ios/NotificationServiceExtension/NotificationService.swift
@@ -164,6 +164,12 @@ class NotificationService: UNNotificationServiceExtension {
                           secret
                           expiresAt
                       }
+                      session {
+                        id
+                        userAgent
+                        ip
+                        lastActivatedAt
+                      }
                       user {
                           id
                       }
@@ -206,6 +212,12 @@ class NotificationService: UNNotificationServiceExtension {
             refresh: Token(
               secret: response.data.refreshSession.refreshToken.secret,
               expireAt: DateType(val: response.data.refreshSession.refreshToken.expiresAt)
+            ),
+            session: Session(
+              id: response.data.refreshSession.session.id,
+              userAgent: response.data.refreshSession.session.userAgent,
+              ip: response.data.refreshSession.session.ip,
+              lastActivatedAt: DateType(val: response.data.refreshSession.session.lastActivatedAt)
             ),
             userId: response.data.refreshSession.user.id
           )
@@ -260,6 +272,7 @@ class NotificationService: UNNotificationServiceExtension {
   struct Credentials: Codable {
     let access: Token
     let refresh: Token
+    let session: Session
     let userId: String
   }
 
@@ -270,6 +283,13 @@ class NotificationService: UNNotificationServiceExtension {
 
   struct DateType: Codable {
     let val: Date
+  }
+
+  struct Session: Codable {
+    let id: String
+    let userAgent: String
+    let ip: String
+    let lastActivatedAt: DateType
   }
 
   struct RefreshSessionResponse: Decodable {
@@ -283,12 +303,20 @@ class NotificationService: UNNotificationServiceExtension {
   struct RefreshSessionResponseDataCredentials: Decodable {
     let accessToken: RefreshSessionResponseDataToken
     let refreshToken: RefreshSessionResponseDataToken
+    let session: RefreshSessionResponseDataSession
     let user: RefreshSessionResponseDataCredentialsUser
   }
 
   struct RefreshSessionResponseDataToken: Decodable {
     let secret: String
     let expiresAt: Date
+  }
+
+  struct RefreshSessionResponseDataSession: Decodable {
+    let id: String
+    let userAgent: String
+    let ip: String
+    let lastActivatedAt: Date
   }
 
   struct RefreshSessionResponseDataCredentialsUser: Decodable {

--- a/lib/provider/drift/credentials.dart
+++ b/lib/provider/drift/credentials.dart
@@ -80,11 +80,15 @@ class CredentialsDriftProvider extends DriftProviderBase {
     final result = await safe((db) async {
       final stmt = await db.select(db.tokens).get();
       return stmt
-          .map((e) {
+          .map((c) {
             try {
-              return _CredentialsDb.fromDb(e);
+              return _CredentialsDb.fromDb(c);
             } catch (e) {
               Log.error('Unable to decode `Credentials`: $e', '$runtimeType');
+              Log.error(
+                'The credentials stored are: `${c.credentials}`',
+                '$runtimeType',
+              );
               return null;
             }
           })

--- a/lib/ui/page/home/page/my_profile/widget/session_tile.dart
+++ b/lib/ui/page/home/page/my_profile/widget/session_tile.dart
@@ -24,6 +24,7 @@ import '/l10n/l10n.dart';
 import '/themes.dart';
 import '/ui/page/home/page/my_profile/session/controller.dart';
 import '/ui/page/home/page/user/controller.dart';
+import '/ui/page/home/tab/chats/widget/periodic_builder.dart';
 import '/ui/widget/svg/svg.dart';
 
 /// Visual representation of a [RxSession].
@@ -90,13 +91,18 @@ class SessionTileWidget extends StatelessWidget {
                     style: style.fonts.small.regular.onBackground,
                   ),
                   SizedBox(height: 4),
-                  Text(
-                    'label_city_country_activated_at'.l10nfmt({
-                      'city': geo?.city ?? '',
-                      'country': geo?.country ?? '',
-                      'at': session.lastActivatedAt.val.toDifferenceAgo(),
-                    }),
-                    style: style.fonts.small.regular.secondary,
+                  PeriodicBuilder(
+                    period: Duration(minutes: 1),
+                    builder: (_) {
+                      return Text(
+                        'label_city_country_activated_at'.l10nfmt({
+                          'city': geo?.city ?? '',
+                          'country': geo?.country ?? '',
+                          'at': session.lastActivatedAt.val.toDifferenceAgo(),
+                        }),
+                        style: style.fonts.small.regular.secondary,
+                      );
+                    },
                   ),
                 ],
               ),


### PR DESCRIPTION
## Synopsis

`Mutation.refreshSession` on the client expects response to contain `Session`. NSE does not include `Session` during its refreshes.




## Solution

This PR adds `Session` fragment to NSE as well.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
