### PR TITLE
Call `navigator.setAppBadge` in `firebase-messaging-sw.js` on push notifications

### DIFF
--- a/web/firebase-messaging-sw.js
+++ b/web/firebase-messaging-sw.js
@@ -59,6 +59,20 @@ messaging.onMessage(async (payload) => {
       }
     }
   }
+
+  // Otherwise that's a normal push notification.
+  else {
+    // Try to set a badge, if available.
+    if (navigator.setAppBadge) {
+      let unreadCount = 1;
+
+      if (unreadCount && unreadCount > 0) {
+        navigator.setAppBadge(unreadCount);
+      } else {
+        navigator.clearAppBadge();
+      }
+    }
+  }
 });
 
 messaging.onBackgroundMessage(async (payload) => {
@@ -89,6 +103,20 @@ messaging.onBackgroundMessage(async (payload) => {
 
       for (var notification of notifications) {
         notification.close();
+      }
+    }
+  }
+
+  // Otherwise that's a normal push notification.
+  else {
+    // Try to set a badge, if available.
+    if (navigator.setAppBadge) {
+      let unreadCount = 1;
+
+      if (unreadCount && unreadCount > 0) {
+        navigator.setAppBadge(unreadCount);
+      } else {
+        navigator.clearAppBadge();
       }
     }
   }


### PR DESCRIPTION
## Synopsis

PWA applications set no unread chats badges as of now.




## Solution

This PR fixes that by calling methods to set the badge manually when receiving push notifications in Firebase Service Worker in Web.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
