### PR TITLE
Use `AudioContext` from Web Audio API in browsers for `AudioUtils`

### DIFF
--- a/lib/util/audio_utils.dart
+++ b/lib/util/audio_utils.dart
@@ -90,14 +90,10 @@ class AudioUtilsImpl {
     ensureInitialized();
 
     if (PlatformUtils.isWeb) {
-      final String url = switch (sound.kind) {
-        AudioSourceKind.asset => (sound as AssetAudioSource).asset,
-        AudioSourceKind.file => '',
-        AudioSourceKind.url => (sound as UrlAudioSource).url,
-      };
+      final String url = sound.direct;
 
       if (url.isNotEmpty) {
-        await WebUtils.play('$url?${Pubspec.ref}');
+        await (WebUtils.play('$url?${Pubspec.ref}')).listen((_) {}).asFuture();
       }
     } else if (_isMobile) {
       await _jaPlayer?.setAudioSource(sound.source);
@@ -118,6 +114,7 @@ class AudioUtilsImpl {
 
     StreamController? controller = _players[music];
     StreamSubscription? position;
+    StreamSubscription? playback;
 
     if (controller == null) {
       ja.AudioPlayer? jaPlayer;
@@ -126,6 +123,16 @@ class AudioUtilsImpl {
 
       controller = StreamController.broadcast(
         onListen: () async {
+          if (PlatformUtils.isWeb) {
+            playback?.cancel();
+            playback = WebUtils.play(
+              '${music.direct}?${Pubspec.ref}',
+              loop: true,
+            ).listen((_) {});
+
+            return;
+          }
+
           try {
             if (_isMobile) {
               jaPlayer = ja.AudioPlayer();
@@ -178,6 +185,11 @@ class AudioUtilsImpl {
           }
         },
         onCancel: () async {
+          if (PlatformUtils.isWeb) {
+            playback?.cancel();
+            return;
+          }
+
           _players.remove(music);
           position?.cancel();
           timer?.cancel();
@@ -443,5 +455,12 @@ extension on AudioSource {
     AudioSourceKind.url => ja.AudioSource.uri(
       Uri.parse((this as UrlAudioSource).url),
     ),
+  };
+
+  /// Returns an actual URL corresponding to this [AudioSource].
+  String get direct => switch (kind) {
+    AudioSourceKind.asset => (this as AssetAudioSource).asset,
+    AudioSourceKind.file => (this as FileAudioSource).file,
+    AudioSourceKind.url => (this as UrlAudioSource).url,
   };
 }

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -322,9 +322,11 @@ class WebUtils {
     }
   }
 
-  /// Plays the provided [asset].
-  static Future<void> play(String asset) async {
-    // No-op.
+  /// Plays the provided [asset] and returns a [Stream].
+  ///
+  /// If the returned [Stream] is canceled, then the playback stops.
+  static Stream<void> play(String asset, {bool loop = false}) {
+    return Stream.empty();
   }
 
   /// Returns the `User-Agent` header to put in the network queries.

--- a/web/index.html
+++ b/web/index.html
@@ -197,7 +197,7 @@
       if (audioContext == null) {
         try {
           audioContext = new AudioContext();
-          console.log('`AudioContext` is populated, thus `AudioUtils.once()` should play sounds via autoplay.');
+          console.log('`AudioContext` is populated, thus `AudioUtils` should play sounds via autoplay.');
         } catch (e) {
           console.log(`Failed to create "AudioContext" due to: ${e}`);
         }


### PR DESCRIPTION
## Synopsis

Playback of `AudioUtils.once()` recreates a new `AudioContext` each time `once()` is invoked. `AudioUtils.play()` doesn't use Web Audio API at all.




## Solution

This PR refactors `AudioUtils` to use Web Audio API to play all audio.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
