### PR TITLE
Draft: Redesign Erase page (#1297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ All user visible changes to this project will be documented in this file. This p
         - Slider with ticks. ([#1330])
     - Chats tab:
         - Group creating and chats selecting buttons. ([#1333])
-    - Redesigned delete account page. ([#1339])
+    - Delete account page:
+        - added missing l10n labels. ([#1339])
+        - redesigned confirmation modal. ([#])
     - Login modal:
         - Accept any identifier instead of e-mail only during sign in via e-mail. ([#1339])
 


### PR DESCRIPTION
Resolves team113/messenger#1297
Related to team113/messenger#1339

## Synopsis

Erase page should be redesigned. Animations are already fine since we removed blocks from `my_profile` page, the modal redesign is left.

## Solution

Check user's credentials and show modal based on them.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
