### PR TITLE
Fix `BottomPaddedRow` introducing meaningless paddings on `Chats` tab

### DIFF
--- a/lib/domain/repository/chat.dart
+++ b/lib/domain/repository/chat.dart
@@ -136,7 +136,9 @@ abstract class AbstractChatRepository {
 
   /// Marks all the [chats] as read for the authenticated [MyUser] until their
   /// [Chat.lastItem]s available.
-  Future<void> readAll();
+  ///
+  /// If [ids] are provided, then only specified [Chat]s will be read.
+  Future<void> readAll(List<ChatId>? ids);
 
   /// Edits the specified [ChatMessage] posted by the authenticated [MyUser].
   Future<void> editChatMessage(

--- a/lib/domain/service/chat.dart
+++ b/lib/domain/service/chat.dart
@@ -240,9 +240,9 @@ class ChatService extends DisposableService {
 
   /// Marks all the [chats] as read for the authenticated [MyUser] until their
   /// [Chat.lastItem]s available.
-  Future<void> readAll() async {
+  Future<void> readAll(List<ChatId>? ids) async {
     Log.debug('readAll()', '$runtimeType');
-    await _chatRepository.readAll();
+    await _chatRepository.readAll(ids);
   }
 
   /// Edits the specified [ChatMessage] posted by the authenticated [MyUser].

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -733,12 +733,16 @@ class ChatRepository extends DisposableInterface
   }
 
   @override
-  Future<void> readAll() async {
-    Log.debug('readAll()', '$runtimeType');
+  Future<void> readAll(List<ChatId>? ids) async {
+    Log.debug('readAll($ids)', '$runtimeType');
 
     final List<Future> futures = [];
 
     for (var e in chats.values) {
+      if (ids?.contains(e.id) == false) {
+        continue;
+      }
+
       final ChatItem? last = e.lastItem ?? e.chat.value.lastItem;
       final int unread = e.unreadCount.value;
 

--- a/lib/ui/page/call/participant/controller.dart
+++ b/lib/ui/page/call/participant/controller.dart
@@ -274,7 +274,7 @@ class ParticipantController extends GetxController {
     chat.value = fetched is RxChat? ? fetched : await fetched;
 
     if (chat.value == null) {
-      MessagePopup.error('err_unknown_chat'.l10n);
+      MessagePopup.error('err_unknown_page'.l10n);
       pop?.call();
     } else {
       _membersSubscription = chat.value!.members.items.changes.listen((event) {

--- a/lib/ui/page/home/page/chat/info/add_member/controller.dart
+++ b/lib/ui/page/home/page/chat/info/add_member/controller.dart
@@ -152,7 +152,7 @@ class AddChatMemberController extends GetxController {
     chat.value = fetched is RxChat? ? fetched : await fetched;
 
     if (chat.value == null) {
-      MessagePopup.error('err_unknown_chat'.l10n);
+      MessagePopup.error('err_unknown_page'.l10n);
       pop?.call();
     }
   }

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -749,7 +749,7 @@ class ChatsTabController extends GetxController {
           : null,
     );
 
-    selecting.value = false;
+    toggleSelecting();
 
     try {
       await future;

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -741,7 +741,22 @@ class ChatsTabController extends GetxController {
 
   /// Reads all the [RxChat]s in the [chats] list.
   Future<void> readAll() async {
-    _chatService.readAll();
+    final Future<void> future = _chatService.readAll(
+      selecting.value
+          ? selectedChats.isEmpty
+                ? null
+                : selectedChats
+          : null,
+    );
+
+    selecting.value = false;
+
+    try {
+      await future;
+    } catch (e) {
+      MessagePopup.error('err_data_transfer'.l10n);
+      rethrow;
+    }
   }
 
   /// Enables and initializes or disables and disposes the [search].

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -391,11 +391,7 @@ class ChatsTabView extends StatelessWidget {
                       );
                     } else {
                       child = SafeScrollbar(
-                        bottom: false,
                         controller: c.search.value!.scrollController,
-                        borderRadius: const BorderRadius.vertical(
-                          top: Radius.circular(40),
-                        ),
                         child: ListView.builder(
                           key: const Key('GroupCreating'),
                           controller: c.search.value!.scrollController,
@@ -700,7 +696,6 @@ class ChatsTabView extends StatelessWidget {
                     } else {
                       child = SafeScrollbar(
                         controller: c.scrollController,
-                        bottom: c.selecting.isFalse,
                         child: AnimationLimiter(
                           key: const Key('Chats'),
                           child: Obx(() {
@@ -958,9 +953,7 @@ class ChatsTabView extends StatelessWidget {
                                 ),
                                 SliverPadding(
                                   padding: EdgeInsets.only(
-                                    bottom: c.selecting.isTrue
-                                        ? 0
-                                        : CustomNavigationBar.height,
+                                    bottom: CustomNavigationBar.height,
                                     left: 10,
                                     right: 10,
                                   ),
@@ -1015,132 +1008,134 @@ class ChatsTabView extends StatelessWidget {
                     ),
                   );
                 }),
-                bottomNavigationBar: SizedBox(
-                  height: 57,
-                  child: Obx(() {
-                    if (c.groupCreating.value) {
-                      return BottomPaddedRow(
-                        spacer: (_) {
-                          return Container(
-                            decoration: BoxDecoration(
-                              color: style.colors.onBackgroundOpacity13,
-                            ),
-                            width: 1,
-                            height: 24,
-                          );
-                        },
-                        children: [
-                          WidgetButton(
-                            onPressed: c.closeGroupCreating,
-                            child: Center(
-                              child: Padding(
-                                padding: const EdgeInsets.fromLTRB(
-                                  10,
-                                  6.5,
-                                  10,
-                                  6.5,
-                                ),
-                                child: Text(
-                                  'btn_cancel'.l10n,
-                                  style: style.fonts.normal.regular.primary,
+                extendBody: true,
+                bottomNavigationBar: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Obx(() {
+                      if (c.groupCreating.value) {
+                        return BottomPaddedRow(
+                          spacer: (_) {
+                            return Container(
+                              decoration: BoxDecoration(
+                                color: style.colors.onBackgroundOpacity13,
+                              ),
+                              width: 1,
+                              height: 24,
+                            );
+                          },
+                          children: [
+                            WidgetButton(
+                              onPressed: c.closeGroupCreating,
+                              child: Center(
+                                child: Padding(
+                                  padding: const EdgeInsets.fromLTRB(
+                                    10,
+                                    6.5,
+                                    10,
+                                    6.5,
+                                  ),
+                                  child: Text(
+                                    'btn_cancel'.l10n,
+                                    style: style.fonts.normal.regular.primary,
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
+                            WidgetButton(
+                              onPressed: c.createGroup,
+                              child: Center(
+                                child: Padding(
+                                  padding: const EdgeInsets.fromLTRB(
+                                    10,
+                                    6.5,
+                                    10,
+                                    6.5,
+                                  ),
+                                  child: Text(
+                                    'btn_create'.l10n,
+                                    style: style.fonts.normal.regular.primary,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      } else if (c.selecting.value) {
+                        return BottomPaddedRow(
+                          spacer: (_) {
+                            return Container(
+                              decoration: BoxDecoration(
+                                color: style.colors.onBackgroundOpacity13,
+                              ),
+                              width: 1,
+                              height: 24,
+                            );
+                          },
+                          children: [
+                            WidgetButton(
+                              onPressed: c.readAll,
+                              child: Center(
+                                child: Padding(
+                                  padding: const EdgeInsets.fromLTRB(
+                                    10,
+                                    6.5,
+                                    10,
+                                    6.5,
+                                  ),
+                                  child: Text(
+                                    'btn_read_all'.l10n,
+                                    style: style.fonts.normal.regular.primary,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            WidgetButton(
+                              onPressed: c.selectedChats.isEmpty
+                                  ? null
+                                  : () => _hideChats(context, c),
+                              child: Center(
+                                child: Padding(
+                                  padding: const EdgeInsets.fromLTRB(
+                                    10,
+                                    6.5,
+                                    10,
+                                    6.5,
+                                  ),
+                                  child: Text(
+                                    'btn_hide'.l10n,
+                                    style: style.fonts.normal.regular.primary,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            WidgetButton(
+                              key: const Key('DeleteChatsButton'),
+                              onPressed: c.selectedChats.isEmpty
+                                  ? null
+                                  : () => _hideChats(context, c),
+                              child: Center(
+                                child: Padding(
+                                  padding: const EdgeInsets.fromLTRB(
+                                    10,
+                                    6.5,
+                                    10,
+                                    6.5,
+                                  ),
+                                  child: Text(
+                                    'btn_delete'.l10n,
+                                    style: style.fonts.normal.regular.danger,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      }
 
-                          WidgetButton(
-                            onPressed: c.createGroup,
-                            child: Center(
-                              child: Padding(
-                                padding: const EdgeInsets.fromLTRB(
-                                  10,
-                                  6.5,
-                                  10,
-                                  6.5,
-                                ),
-                                child: Text(
-                                  'btn_create'.l10n,
-                                  style: style.fonts.normal.regular.primary,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      );
-                    } else if (c.selecting.value) {
-                      return BottomPaddedRow(
-                        spacer: (_) {
-                          return Container(
-                            decoration: BoxDecoration(
-                              color: style.colors.onBackgroundOpacity13,
-                            ),
-                            width: 1,
-                            height: 24,
-                          );
-                        },
-                        children: [
-                          WidgetButton(
-                            onPressed: c.readAll,
-                            child: Center(
-                              child: Padding(
-                                padding: const EdgeInsets.fromLTRB(
-                                  10,
-                                  6.5,
-                                  10,
-                                  6.5,
-                                ),
-                                child: Text(
-                                  'btn_read_all'.l10n,
-                                  style: style.fonts.normal.regular.primary,
-                                ),
-                              ),
-                            ),
-                          ),
-                          WidgetButton(
-                            onPressed: c.selectedChats.isEmpty
-                                ? null
-                                : () => _hideChats(context, c),
-                            child: Center(
-                              child: Padding(
-                                padding: const EdgeInsets.fromLTRB(
-                                  10,
-                                  6.5,
-                                  10,
-                                  6.5,
-                                ),
-                                child: Text(
-                                  'btn_hide'.l10n,
-                                  style: style.fonts.normal.regular.primary,
-                                ),
-                              ),
-                            ),
-                          ),
-                          WidgetButton(
-                            key: const Key('DeleteChatsButton'),
-                            onPressed: c.selectedChats.isEmpty
-                                ? null
-                                : () => _hideChats(context, c),
-                            child: Center(
-                              child: Padding(
-                                padding: const EdgeInsets.fromLTRB(
-                                  10,
-                                  6.5,
-                                  10,
-                                  6.5,
-                                ),
-                                child: Text(
-                                  'btn_delete'.l10n,
-                                  style: style.fonts.normal.regular.danger,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      );
-                    }
-
-                    return const SizedBox();
-                  }),
+                      return const SizedBox();
+                    }),
+                  ],
                 ),
               );
             }),

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -1038,6 +1038,8 @@ class ChatsTabView extends StatelessWidget {
                                   child: Text(
                                     'btn_cancel'.l10n,
                                     style: style.fonts.normal.regular.primary,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
                               ),
@@ -1055,6 +1057,8 @@ class ChatsTabView extends StatelessWidget {
                                   child: Text(
                                     'btn_create'.l10n,
                                     style: style.fonts.normal.regular.primary,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
                               ),
@@ -1086,6 +1090,8 @@ class ChatsTabView extends StatelessWidget {
                                   child: Text(
                                     'btn_read_all'.l10n,
                                     style: style.fonts.normal.regular.primary,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
                               ),
@@ -1105,6 +1111,8 @@ class ChatsTabView extends StatelessWidget {
                                   child: Text(
                                     'btn_hide'.l10n,
                                     style: style.fonts.normal.regular.primary,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
                               ),
@@ -1125,6 +1133,8 @@ class ChatsTabView extends StatelessWidget {
                                   child: Text(
                                     'btn_delete'.l10n,
                                     style: style.fonts.normal.regular.danger,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
                               ),

--- a/lib/ui/page/home/widget/bottom_padded_row.dart
+++ b/lib/ui/page/home/widget/bottom_padded_row.dart
@@ -21,17 +21,22 @@ import 'package:get/get.dart';
 import '/routes.dart';
 import '/themes.dart';
 import '/util/platform_utils.dart';
+import 'navigation_bar.dart';
 
 /// [Row] padded to be at the bottom of the screen expanding its [children].
 class BottomPaddedRow extends StatelessWidget {
   const BottomPaddedRow({
     super.key,
     this.children = const [],
+    this.height = CustomNavigationBar.height,
     this.spacer = _defaultSpacer,
   });
 
   /// [Widget]s to put in the [Row].
   final List<Widget> children;
+
+  /// Height of this [BottomPaddedRow].
+  final double? height;
 
   /// Builder building spacing between [children].
   final Widget Function(BuildContext) spacer;
@@ -51,6 +56,7 @@ class BottomPaddedRow extends StatelessWidget {
     }
 
     return Container(
+      height: height,
       decoration: BoxDecoration(
         color: style.colors.onPrimary,
         boxShadow: [

--- a/lib/ui/page/home/widget/bottom_padded_row.dart
+++ b/lib/ui/page/home/widget/bottom_padded_row.dart
@@ -21,22 +21,17 @@ import 'package:get/get.dart';
 import '/routes.dart';
 import '/themes.dart';
 import '/util/platform_utils.dart';
-import 'navigation_bar.dart';
 
 /// [Row] padded to be at the bottom of the screen expanding its [children].
 class BottomPaddedRow extends StatelessWidget {
   const BottomPaddedRow({
     super.key,
     this.children = const [],
-    this.height = CustomNavigationBar.height,
     this.spacer = _defaultSpacer,
   });
 
   /// [Widget]s to put in the [Row].
   final List<Widget> children;
-
-  /// Height of this [BottomPaddedRow].
-  final double? height;
 
   /// Builder building spacing between [children].
   final Widget Function(BuildContext) spacer;
@@ -56,7 +51,6 @@ class BottomPaddedRow extends StatelessWidget {
     }
 
     return Container(
-      height: height,
       decoration: BoxDecoration(
         color: style.colors.onPrimary,
         boxShadow: [

--- a/lib/ui/page/home/widget/safe_scrollbar.dart
+++ b/lib/ui/page/home/widget/safe_scrollbar.dart
@@ -33,7 +33,6 @@ class SafeScrollbar extends StatelessWidget {
     required this.child,
     this.top = true,
     this.bottom = true,
-    this.borderRadius,
     this.controller,
   });
 
@@ -44,9 +43,6 @@ class SafeScrollbar extends StatelessWidget {
   /// Indicator whether to avoid system intrusions on the bottom side of the
   /// screen.
   final bool bottom;
-
-  /// [BorderRadius] to clip the [child] with.
-  final BorderRadius? borderRadius;
 
   /// Optional [ScrollController] used in a [Scrollbar].
   ///
@@ -65,11 +61,11 @@ class SafeScrollbar extends StatelessWidget {
             top: top ? CustomAppBar.height - 5 : 0,
             bottom: bottom
                 ? CustomNavigationBar.height + (CustomSafeArea.isPwa ? 25 : 0)
-                : 0,
+                : 12,
           ),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 12),
+          padding: const EdgeInsets.only(top: 12, bottom: 8),
           child: child,
         ),
       );
@@ -88,14 +84,11 @@ class SafeScrollbar extends StatelessWidget {
         ),
       ),
       child: Container(
-        decoration: BoxDecoration(
-          borderRadius: borderRadius ?? BorderRadius.circular(40),
-        ),
         margin: EdgeInsets.only(
           top: top ? padding.top + 5 + 5 : 0,
           bottom: bottom ? padding.bottom + 5 + 5 : 0,
         ),
-        clipBehavior: Clip.hardEdge,
+        clipBehavior: Clip.none,
         child: controller == null
             ? child
             : Scrollbar(controller: controller, child: child),

--- a/lib/ui/page/support/log/view.dart
+++ b/lib/ui/page/support/log/view.dart
@@ -82,7 +82,10 @@ class LogView extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                ModalPopupHeader(text: 'Version: ${Pubspec.ref}'),
+                ModalPopupHeader(
+                  text: 'Version: ${Pubspec.ref}',
+                  onBack: context.isMobile ? Navigator.of(context).pop : null,
+                ),
                 Flexible(
                   child: Scrollbar(
                     controller: c.scrollController,


### PR DESCRIPTION
## Synopsis

Meaningless and ugly paddings:

<img width="378" height="137" alt="Screenshot 2025-07-23 at 16 25 43" src="https://github.com/user-attachments/assets/c34a1498-dfa2-43c9-b2be-a6721ffe71d6" />





## Solution

This PR fixes those paddings by using `extendBody` of `Scaffold` on `Chats` tab.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
