### PR TITLE
Don't resubscribe `SubscriptionHandle` when `hasListener` is `false` (#1348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,17 @@ All user visible changes to this project will be documented in this file. This p
     - Profile page:
         - Redesigned session delete modals. ([#1344])
 
+### Fixed
+
+- UI:
+    - Chats tab:
+        - Infinite typing indicator occurring sometimes. ([#1350], [#1348])
+
 [#1311]: /../../issue/1311
 [#1336]: /../../pull/1336
 [#1344]: /../../pull/1344
+[#1348]: /../../issue/1348
+[#1350]: /../../pull/1350
 
 
 

--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -726,6 +726,7 @@ class SubscriptionHandle {
     _backoff?.cancel();
     _backoffDuration = Duration.zero;
     _subscription?.cancel();
+    _cancel(_connection);
   }
 
   /// Subscribes to the events.
@@ -739,7 +740,16 @@ class SubscriptionHandle {
         _cancel(_connection);
         _connection = null;
 
+        if (!_controller.hasListener) {
+          return;
+        }
+
         _connection = await _listen(_options);
+
+        if (!_controller.hasListener) {
+          return cancel();
+        }
+
         _subscription = _connection?.stream.listen(
           (e) {
             if (_backoff != null) {

--- a/lib/store/auth.dart
+++ b/lib/store/auth.dart
@@ -282,9 +282,13 @@ class AuthRepository extends DisposableInterface
   Future<Chat> useChatDirectLink(ChatDirectLinkSlug slug) async {
     Log.debug('useChatDirectLink($slug)', '$runtimeType');
 
-    final response = await Backoff.run(() async {
-      return await _graphQlProvider.useChatDirectLink(slug);
-    }, retryIf: (e) => e.isNetworkRelated);
+    final response = await Backoff.run(
+      () async {
+        return await _graphQlProvider.useChatDirectLink(slug);
+      },
+      retryIf: (e) => e.isNetworkRelated,
+      retries: 10,
+    );
 
     return response.chat.toModel();
   }

--- a/lib/store/call.dart
+++ b/lib/store/call.dart
@@ -301,14 +301,18 @@ class CallRepository extends DisposableInterface
 
     calls[call.value.chatId.value] = call;
 
-    final response = await Backoff.run(() async {
-      return await _graphQlProvider.startChatCall(
-        call.value.chatId.value,
-        call.value.creds!,
-        call.value.videoState.value == LocalTrackState.enabling ||
-            call.value.videoState.value == LocalTrackState.enabled,
-      );
-    }, retryIf: (e) => e.isNetworkRelated);
+    final response = await Backoff.run(
+      () async {
+        return await _graphQlProvider.startChatCall(
+          call.value.chatId.value,
+          call.value.creds!,
+          call.value.videoState.value == LocalTrackState.enabling ||
+              call.value.videoState.value == LocalTrackState.enabled,
+        );
+      },
+      retryIf: (e) => e.isNetworkRelated,
+      retries: 10,
+    );
 
     call.value.deviceId = response.deviceId;
 
@@ -376,12 +380,16 @@ class CallRepository extends DisposableInterface
     }
 
     try {
-      final response = await Backoff.run(() async {
-        return await _graphQlProvider.joinChatCall(
-          ongoing!.value.chatId.value,
-          ongoing.value.creds!,
-        );
-      }, retryIf: (e) => e.isNetworkRelated);
+      final response = await Backoff.run(
+        () async {
+          return await _graphQlProvider.joinChatCall(
+            ongoing!.value.chatId.value,
+            ongoing.value.creds!,
+          );
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
 
       ongoing.value.deviceId = response.deviceId;
 
@@ -413,9 +421,13 @@ class CallRepository extends DisposableInterface
     Log.debug('leave($chatId, $deviceId)', '$runtimeType');
 
     try {
-      await Backoff.run(() async {
-        await _graphQlProvider.leaveChatCall(chatId, deviceId);
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.leaveChatCall(chatId, deviceId);
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } on LeaveChatCallException catch (e) {
       switch (e.code) {
         case LeaveChatCallErrorCode.unknownDevice:
@@ -434,9 +446,13 @@ class CallRepository extends DisposableInterface
     Log.debug('decline($chatId)', '$runtimeType');
 
     try {
-      await Backoff.run(() async {
-        await _graphQlProvider.declineChatCall(chatId);
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.declineChatCall(chatId);
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } on DeclineChatCallException catch (e) {
       switch (e.code) {
         case DeclineChatCallErrorCode.alreadyJoined:
@@ -460,9 +476,13 @@ class CallRepository extends DisposableInterface
     Log.debug('toggleHand($chatId, $raised)', '$runtimeType');
 
     try {
-      await Backoff.run(() async {
-        await _graphQlProvider.toggleChatCallHand(chatId, raised);
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.toggleChatCallHand(chatId, raised);
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } on ToggleChatCallHandException catch (e) {
       switch (e.code) {
         case ToggleChatCallHandErrorCode.notCallMember:
@@ -497,9 +517,13 @@ class CallRepository extends DisposableInterface
     }
 
     try {
-      await Backoff.run(() async {
-        await _graphQlProvider.redialChatCallMember(chatId, memberId);
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.redialChatCallMember(chatId, memberId);
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } on RedialChatCallMemberException catch (e) {
       switch (e.code) {
         case RedialChatCallMemberErrorCode.notCallMember:
@@ -529,9 +553,13 @@ class CallRepository extends DisposableInterface
 
     try {
       // TODO: Implement optimism, if possible.
-      await Backoff.run(() async {
-        await _graphQlProvider.removeChatCallMember(chatId, userId);
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.removeChatCallMember(chatId, userId);
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } on RemoveChatCallMemberException catch (e) {
       switch (e.code) {
         case RemoveChatCallMemberErrorCode.artemisUnknown:

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -416,9 +416,13 @@ class ChatRepository extends DisposableInterface
     Log.debug('ensureRemoteMonolog($name)', '$runtimeType');
 
     final ChatData chatData = _chat(
-      await Backoff.run(() async {
-        return await _graphQlProvider.createMonologChat(name: name);
-      }, retryIf: (e) => e.isNetworkRelated),
+      await Backoff.run(
+        () async {
+          return await _graphQlProvider.createMonologChat(name: name);
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      ),
     );
     final RxChatImpl chat = await _putEntry(chatData);
 
@@ -561,9 +565,13 @@ class ChatRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.renameChat(id, name);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.renameChat(id, name);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on RenameChatException catch (e) {
         switch (e.code) {
           case RenameChatErrorCode.unknownChat:
@@ -606,9 +614,13 @@ class ChatRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.addChatMember(chatId, userId);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.addChatMember(chatId, userId);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on AddChatMemberException catch (e) {
         switch (e.code) {
           case AddChatMemberErrorCode.artemisUnknown:
@@ -656,9 +668,13 @@ class ChatRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.removeChatMember(chatId, userId);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.removeChatMember(chatId, userId);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on RemoveChatMemberException catch (e) {
         switch (e.code) {
           case RemoveChatMemberErrorCode.artemisUnknown:
@@ -717,9 +733,13 @@ class ChatRepository extends DisposableInterface
       // [Chat.isHidden] will be changed by [RxChatImpl]'s own remote event
       // handler. Chat will be removed from [paginated] via [RxChatImpl].
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.hideChat(id);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.hideChat(id);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on HideChatException catch (e) {
         switch (e.code) {
           case HideChatErrorCode.artemisUnknown:
@@ -770,9 +790,13 @@ class ChatRepository extends DisposableInterface
   Future<void> readUntil(ChatId chatId, ChatItemId untilId) async {
     Log.debug('readUntil($chatId, $untilId)', '$runtimeType');
 
-    await Backoff.run(() async {
-      await _graphQlProvider.readChat(chatId, untilId);
-    }, retryIf: (e) => e.isNetworkRelated);
+    await Backoff.run(
+      () async {
+        await _graphQlProvider.readChat(chatId, untilId);
+      },
+      retryIf: (e) => e.isNetworkRelated,
+      retries: 10,
+    );
   }
 
   @override
@@ -838,22 +862,26 @@ class ChatRepository extends DisposableInterface
         );
       }
 
-      await Backoff.run(() async {
-        await _graphQlProvider.editChatMessage(
-          message.id,
-          text: text == null
-              ? null
-              : ChatMessageTextInput(kw$new: text.changed),
-          attachments: attachments == null
-              ? null
-              : ChatMessageAttachmentsInput(
-                  kw$new: attachments.changed.map((e) => e.id).toList(),
-                ),
-          repliesTo: repliesTo == null
-              ? null
-              : ChatMessageRepliesInput(kw$new: repliesTo.changed),
-        );
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.editChatMessage(
+            message.id,
+            text: text == null
+                ? null
+                : ChatMessageTextInput(kw$new: text.changed),
+            attachments: attachments == null
+                ? null
+                : ChatMessageAttachmentsInput(
+                    kw$new: attachments.changed.map((e) => e.id).toList(),
+                  ),
+            repliesTo: repliesTo == null
+                ? null
+                : ChatMessageRepliesInput(kw$new: repliesTo.changed),
+          );
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } on EditChatMessageException catch (e) {
       switch (e.code) {
         case EditChatMessageErrorCode.uneditable:
@@ -905,9 +933,13 @@ class ChatRepository extends DisposableInterface
 
       try {
         try {
-          await Backoff.run(() async {
-            await _graphQlProvider.deleteChatMessage(message.id);
-          }, retryIf: (e) => e.isNetworkRelated);
+          await Backoff.run(
+            () async {
+              await _graphQlProvider.deleteChatMessage(message.id);
+            },
+            retryIf: (e) => e.isNetworkRelated,
+            retries: 10,
+          );
         } on DeleteChatMessageException catch (e) {
           switch (e.code) {
             case DeleteChatMessageErrorCode.notAuthor:
@@ -959,9 +991,13 @@ class ChatRepository extends DisposableInterface
 
       try {
         try {
-          await Backoff.run(() async {
-            await _graphQlProvider.deleteChatForward(forward.id);
-          }, retryIf: (e) => e.isNetworkRelated);
+          await Backoff.run(
+            () async {
+              await _graphQlProvider.deleteChatForward(forward.id);
+            },
+            retryIf: (e) => e.isNetworkRelated,
+            retries: 10,
+          );
         } on DeleteChatForwardException catch (e) {
           switch (e.code) {
             case DeleteChatForwardErrorCode.artemisUnknown:
@@ -1008,9 +1044,13 @@ class ChatRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.hideChatItem(id);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.hideChatItem(id);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on HideChatItemException catch (e) {
         switch (e.code) {
           case HideChatItemErrorCode.unknownChatItem:
@@ -1123,9 +1163,13 @@ class ChatRepository extends DisposableInterface
     try {
       // Don't do optimism, as [slug] might be occupied, thus shouldn't set the
       // link right away.
-      await Backoff.run(() async {
-        await _graphQlProvider.createChatDirectLink(slug, groupId: chatId);
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.createChatDirectLink(slug, groupId: chatId);
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } on CreateChatDirectLinkException catch (e) {
       switch (e.code) {
         case CreateChatDirectLinkErrorCode.artemisUnknown:
@@ -1162,9 +1206,13 @@ class ChatRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.deleteChatDirectLink(groupId: groupId);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.deleteChatDirectLink(groupId: groupId);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on DeleteChatDirectLinkException catch (e) {
         switch (e.code) {
           case DeleteChatDirectLinkErrorCode.artemisUnknown:
@@ -1298,14 +1346,18 @@ class ChatRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.updateChatAvatar(
-            id,
-            file: file == null ? null : upload,
-            crop: crop,
-            onSendProgress: onSendProgress,
-          );
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.updateChatAvatar(
+              id,
+              file: file == null ? null : upload,
+              crop: crop,
+              onSendProgress: onSendProgress,
+            );
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on UpdateChatAvatarException catch (e) {
         switch (e.code) {
           case UpdateChatAvatarErrorCode.unknownChat:
@@ -1346,9 +1398,13 @@ class ChatRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.toggleChatMute(id, muting);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.toggleChatMute(id, muting);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on ToggleChatMuteException catch (e) {
         switch (e.code) {
           case ToggleChatMuteErrorCode.tooShort:
@@ -1564,9 +1620,13 @@ class ChatRepository extends DisposableInterface
       if (id.isLocalWith(me)) {
         _localMonologFavoritePosition = newPosition;
         final ChatData monolog = _chat(
-          await Backoff.run(() async {
-            return await _graphQlProvider.createMonologChat();
-          }, retryIf: (e) => e.isNetworkRelated),
+          await Backoff.run(
+            () async {
+              return await _graphQlProvider.createMonologChat();
+            },
+            retryIf: (e) => e.isNetworkRelated,
+            retries: 10,
+          ),
         );
 
         id = monolog.chat.value.id;
@@ -1623,9 +1683,13 @@ class ChatRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.unfavoriteChat(id);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.unfavoriteChat(id);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on UnfavoriteChatException catch (e) {
         switch (e.code) {
           case UnfavoriteChatErrorCode.unknownChat:
@@ -1679,9 +1743,13 @@ class ChatRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.clearChat(id, until);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.clearChat(id, until);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on ClearChatException catch (e) {
         switch (e.code) {
           case ClearChatErrorCode.artemisUnknown:

--- a/lib/store/my_user.dart
+++ b/lib/store/my_user.dart
@@ -190,9 +190,13 @@ class MyUserRepository extends DisposableInterface
       saved: () async => (await _active)?.value.name,
       value: name,
       mutation: (v, _) async {
-        return await Backoff.run(() async {
-          return await _graphQlProvider.updateUserName(v);
-        }, retryIf: (e) => e.isNetworkRelated);
+        return await Backoff.run(
+          () async {
+            return await _graphQlProvider.updateUserName(v);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       },
       update: (v, _) => myUser.update((u) => u?.name = v),
     );
@@ -208,9 +212,13 @@ class MyUserRepository extends DisposableInterface
       saved: () async => (await _active)?.value.status,
       value: status,
       mutation: (v, _) async {
-        return await Backoff.run(() async {
-          return await _graphQlProvider.updateUserStatus(v);
-        }, retryIf: (e) => e.isNetworkRelated);
+        return await Backoff.run(
+          () async {
+            return await _graphQlProvider.updateUserStatus(v);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       },
       update: (v, _) => myUser.update((u) => u?.status = v),
     );
@@ -226,9 +234,13 @@ class MyUserRepository extends DisposableInterface
       saved: () async => (await _active)?.value.bio,
       value: bio,
       mutation: (v, _) async {
-        return await Backoff.run(() async {
-          return await _graphQlProvider.updateUserBio(v);
-        }, retryIf: (e) => e.isNetworkRelated);
+        return await Backoff.run(
+          () async {
+            return await _graphQlProvider.updateUserBio(v);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       },
       update: (v, _) => myUser.update((u) => u?.bio = v),
     );
@@ -240,9 +252,13 @@ class MyUserRepository extends DisposableInterface
 
     // Don't do optimism, as [login] might be occupied, thus shouldn't set the
     // login right away.
-    await Backoff.run(() async {
-      await _graphQlProvider.updateUserLogin(login);
-    }, retryIf: (e) => e.isNetworkRelated);
+    await Backoff.run(
+      () async {
+        await _graphQlProvider.updateUserLogin(login);
+      },
+      retryIf: (e) => e.isNetworkRelated,
+      retries: 10,
+    );
   }
 
   @override
@@ -255,9 +271,13 @@ class MyUserRepository extends DisposableInterface
       saved: () async => (await _active)?.value.presence,
       value: presence,
       mutation: (v, _) async {
-        return await Backoff.run(() async {
-          return await _graphQlProvider.updateUserPresence(v ?? presence);
-        }, retryIf: (e) => e.isNetworkRelated);
+        return await Backoff.run(
+          () async {
+            return await _graphQlProvider.updateUserPresence(v ?? presence);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       },
       update: (v, _) => myUser.update((u) => u?.presence = v ?? presence),
     );
@@ -316,24 +336,28 @@ class MyUserRepository extends DisposableInterface
         );
       }
 
-      await Backoff.run(() async {
-        await _graphQlProvider.updateWelcomeMessage(
-          reset
-              ? null
-              : WelcomeMessageInput(
-                  text: text == null
-                      ? null
-                      : ChatMessageTextInput(
-                          kw$new: text.val.isEmpty ? null : text,
-                        ),
-                  attachments: attachments == null
-                      ? null
-                      : ChatMessageAttachmentsInput(
-                          kw$new: attachments.map((e) => e.id).toList(),
-                        ),
-                ),
-        );
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.updateWelcomeMessage(
+            reset
+                ? null
+                : WelcomeMessageInput(
+                    text: text == null
+                        ? null
+                        : ChatMessageTextInput(
+                            kw$new: text.val.isEmpty ? null : text,
+                          ),
+                    attachments: attachments == null
+                        ? null
+                        : ChatMessageAttachmentsInput(
+                            kw$new: attachments.map((e) => e.id).toList(),
+                          ),
+                  ),
+          );
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } catch (_) {
       myUser.update((u) => u?..welcomeMessage = previous);
       rethrow;
@@ -602,9 +626,13 @@ class MyUserRepository extends DisposableInterface
 
     // Don't do optimism, as [slug] might be occupied, thus shouldn't set the
     // link right away.
-    await Backoff.run(() async {
-      await _graphQlProvider.createUserDirectLink(slug);
-    }, retryIf: (e) => e.isNetworkRelated);
+    await Backoff.run(
+      () async {
+        await _graphQlProvider.createUserDirectLink(slug);
+      },
+      retryIf: (e) => e.isNetworkRelated,
+      retries: 10,
+    );
 
     myUser.update(
       (u) => u?.chatDirectLink = ChatDirectLink(
@@ -623,9 +651,13 @@ class MyUserRepository extends DisposableInterface
     myUser.update((u) => u?.chatDirectLink = null);
 
     try {
-      await Backoff.run(() async {
-        await _graphQlProvider.deleteUserDirectLink();
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.deleteUserDirectLink();
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } catch (_) {
       myUser.update((u) => u?.chatDirectLink = link);
       rethrow;
@@ -680,13 +712,17 @@ class MyUserRepository extends DisposableInterface
     }
 
     try {
-      await Backoff.run(() async {
-        await _graphQlProvider.updateUserAvatar(
-          upload,
-          crop,
-          onSendProgress: onSendProgress,
-        );
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.updateUserAvatar(
+            upload,
+            crop,
+            onSendProgress: onSendProgress,
+          );
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } catch (_) {
       if (file == null) {
         myUser.update((u) => u?.avatar = avatar);
@@ -705,15 +741,21 @@ class MyUserRepository extends DisposableInterface
       saved: () async => (await _active)?.value.muted,
       value: mute,
       mutation: (duration, _) async {
-        return await Backoff.run(() async {
-          return await _graphQlProvider.toggleMyUserMute(
-            duration == null
-                ? null
-                : Muting(
-                    duration: duration.forever == true ? null : duration.until,
-                  ),
-          );
-        }, retryIf: (e) => e.isNetworkRelated);
+        return await Backoff.run(
+          () async {
+            return await _graphQlProvider.toggleMyUserMute(
+              duration == null
+                  ? null
+                  : Muting(
+                      duration: duration.forever == true
+                          ? null
+                          : duration.until,
+                    ),
+            );
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       },
       update: (v, _) => myUser.update((u) => u?.muted = v),
     );
@@ -763,13 +805,17 @@ class MyUserRepository extends DisposableInterface
     }
 
     try {
-      await Backoff.run(() async {
-        await _graphQlProvider.updateUserCallCover(
-          upload,
-          null,
-          onSendProgress: onSendProgress,
-        );
-      }, retryIf: (e) => e.isNetworkRelated);
+      await Backoff.run(
+        () async {
+          await _graphQlProvider.updateUserCallCover(
+            upload,
+            null,
+            onSendProgress: onSendProgress,
+          );
+        },
+        retryIf: (e) => e.isNetworkRelated,
+        retries: 10,
+      );
     } catch (_) {
       if (file == null) {
         myUser.update((u) => u?.callCover = callCover);
@@ -782,9 +828,13 @@ class MyUserRepository extends DisposableInterface
   Future<void> refresh() async {
     Log.debug('refresh()', '$runtimeType');
 
-    final response = await Backoff.run(() async {
-      return await _graphQlProvider.getMyUser();
-    }, retryIf: (e) => e.isNetworkRelated);
+    final response = await Backoff.run(
+      () async {
+        return await _graphQlProvider.getMyUser();
+      },
+      retryIf: (e) => e.isNetworkRelated,
+      retries: 10,
+    );
 
     if (response.myUser != null) {
       _setMyUser(response.myUser!.toDto(), ignoreVersion: true);

--- a/lib/store/user.dart
+++ b/lib/store/user.dart
@@ -195,9 +195,13 @@ class UserRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.blockUser(id, reason);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.blockUser(id, reason);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on BlockUserException catch (e) {
         switch (e.code) {
           case BlockUserErrorCode.unknownUser:
@@ -232,9 +236,13 @@ class UserRepository extends DisposableInterface
 
     try {
       try {
-        await Backoff.run(() async {
-          await _graphQlProvider.unblockUser(id);
-        }, retryIf: (e) => e.isNetworkRelated);
+        await Backoff.run(
+          () async {
+            await _graphQlProvider.unblockUser(id);
+          },
+          retryIf: (e) => e.isNetworkRelated,
+          retries: 10,
+        );
       } on UnblockUserException catch (e) {
         switch (e.code) {
           case UnblockUserErrorCode.unknownUser:

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -1744,6 +1744,7 @@ class ChatController extends GetxController {
                   throw e;
                 }
               },
+              cancelOnError: true,
             );
       }
 

--- a/lib/util/backoff.dart
+++ b/lib/util/backoff.dart
@@ -37,11 +37,16 @@ class Backoff {
 
   /// Returns result of the provided [callback] using the exponential backoff
   /// algorithm on any errors.
+  ///
+  /// [retries] specified to `0` means infinite retrying.
   static Future<T> run<T>(
     FutureOr<T> Function() callback, {
     CancelToken? cancel,
     bool Function(Object e) retryIf = _defaultRetryIf,
+    int retries = 0,
   }) async {
+    int index = 0;
+
     final CancelableOperation operation = CancelableOperation.fromFuture(
       Future(() async {
         Duration backoff = Duration.zero;
@@ -56,6 +61,11 @@ class Backoff {
             return await callback();
           } catch (e, _) {
             if (!retryIf(e)) {
+              rethrow;
+            }
+
+            ++index;
+            if (retries > 0 && index >= retries) {
               rethrow;
             }
 


### PR DESCRIPTION
Resolves #1348




## Synopsis

Sometimes infinite `keepTyping` happens.




## Solution

This PR tries to fix that by looking at `hasListener` before resubscribing to `SubscriptionHandle`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
