### PR TITLE
Use `preventDefault()` to disable page refreshing in `PopupCall`s in browsers

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -163,6 +163,17 @@
           );
         });
       }
+
+      // Disable refresh page behaviour, as it will break the call.
+      window.addEventListener('keydown', function (e) {
+        if (e.key === 'F5') {
+          e.preventDefault();
+        }
+
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'r') {
+          e.preventDefault();
+        }
+      });
     }
   </script>
 


### PR DESCRIPTION
## Synopsis

F5, Control/CMD + R cause page to be refreshed. This breaks the call, as it disconnects from the WebSocket.




## Solution

This PR prevents those actions to refresh the call page in browsers.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
