### PR TITLE
Report `Exception`s caught by `runZonedGuarded()` to `Sentry` manually

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -158,7 +158,7 @@ PODS:
     - SDWebImage/Core (= 5.21.1)
   - SDWebImage/Core (5.21.1)
   - Sentry/HybridSDK (8.52.1)
-  - sentry_flutter (9.5.0):
+  - sentry_flutter (9.6.0):
     - Flutter
     - FlutterMacOS
     - Sentry/HybridSDK (= 8.52.1)
@@ -386,7 +386,7 @@ SPEC CHECKSUMS:
   screen_brightness_ios: 28c5fbdb40634de44f86025d84470158ad4df48c
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   Sentry: 2cbbe3592f30050c60e916c63c7f5a2fa584005e
-  sentry_flutter: fcd61ad26b7890479c182deff29f1f0714319b52
+  sentry_flutter: 9b1e3e6934cb7040ffb71383c95a35f73523180c
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   SQLite.swift: a107c734115fea616a4ad31371d39f1637e8de56

--- a/lib/util/log.dart
+++ b/lib/util/log.dart
@@ -91,10 +91,7 @@ class Log {
     if (!kDebugMode && Config.sentryDsn.isNotEmpty) {
       try {
         await Sentry.addBreadcrumb(
-          Breadcrumb.console(
-            message: '[$tag] $message',
-            level: SentryLevel.debug,
-          ),
+          Breadcrumb.console(message: '[$tag] $message', level: level),
         );
       } catch (_) {
         // No-op.

--- a/lib/util/web/non_web.dart
+++ b/lib/util/web/non_web.dart
@@ -257,7 +257,8 @@ class WebUtils {
   /// Prints a string representation of the provided [object] to the console as
   /// an error.
   static void consoleError(Object? object) {
-    // No-op.
+    // ignore: avoid_print
+    print('\x1B[31m$object\x1B[0m');
   }
 
   /// Requests the permission to use a camera and holds it until unsubscribed.

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -120,7 +120,7 @@ PODS:
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
   - Sentry/HybridSDK (8.52.1)
-  - sentry_flutter (9.5.0):
+  - sentry_flutter (9.6.0):
     - Flutter
     - FlutterMacOS
     - Sentry/HybridSDK (= 8.52.1)
@@ -328,7 +328,7 @@ SPEC CHECKSUMS:
   screen_brightness_macos: 2a3ee243f8051c340381e8e51bcedced8360f421
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   Sentry: 2cbbe3592f30050c60e916c63c7f5a2fa584005e
-  sentry_flutter: fcd61ad26b7890479c182deff29f1f0714319b52
+  sentry_flutter: 9b1e3e6934cb7040ffb71383c95a35f73523180c
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1188,10 +1188,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: cfd663ec90d87ec6abd338da7e21189e503bf6753a0027c1862796f5826adba6
+      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.1"
+    version: "0.14.2"
   js:
     dependency: "direct overridden"
     description:
@@ -1956,10 +1956,10 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: e33638161982fb5deea36751800f7e83d9e4da79e2ff2e822dd92b6b6ddcee8b
+      sha256: d9f3dcf1ecdd600cf9ce134f622383adde5423ecfdaf0ca9b20fbc1c44849337
       url: "https://pub.dev"
     source: hosted
-    version: "9.5.0"
+    version: "9.6.0"
   sentry_dart_plugin:
     dependency: "direct dev"
     description:
@@ -1972,10 +1972,10 @@ packages:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "3abb443a6308504478c4b4061016ee8b7f83aa569f9f3c7f019de7ce91832ea6"
+      sha256: "37deb4ef8837d10b5c1f527ec18591f8d2d2da9c34f19b3d97ccbbe7f84077c0"
       url: "https://pub.dev"
     source: hosted
-    version: "9.5.0"
+    version: "9.6.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -93,7 +93,7 @@ dependencies:
       url: https://github.com/SleepySquash/scrollable_positioned_list
       path: packages/scrollable_positioned_list/
   screen_brightness: any
-  sentry_flutter: ^9.5.0
+  sentry_flutter: ^9.6.0
   share_plus: ^11.0.0
   shared_preferences: ^2.0.18
   sliding_up_panel: ^2.0.0+1


### PR DESCRIPTION
## Synopsis

Uncaught exceptions under Web platforms are now reported via JavaScript native Sentry SDK, which doesn't include breadcrumbs and logs.




## Solution

This PR implements our own `runZonedGuarded()` so that exceptions are sent to Sentry manually with the logs.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
