### PR TITLE
Trigger reconnection of `OngoingCall`s when `ConnectivityResult` changes (#1360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.7.0] · 2025-??-??
+[0.7.0]: /../../tree/v0.7.0
+
+[Diff](/../../compare/v0.6.0...v0.7.0) | [Milestone](/../../milestone/45)
+
+### Fixed
+
+- Network:
+    - Long reconnection when changing network configuration. ([#1362], [#1360])
+
+[#1360]: /../../issue/1360
+[#1362]: /../../pull/1362
+
+
+
+
 ## [0.6.0] · 2025-??-??
 [0.6.0]: /../../tree/v0.6.0
 

--- a/lib/domain/repository/session.dart
+++ b/lib/domain/repository/session.dart
@@ -15,6 +15,7 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:get/get.dart';
 
 import '/domain/model/session.dart';
@@ -26,6 +27,15 @@ abstract class AbstractSessionRepository {
 
   /// Indicates whether the current device is connected to any network.
   RxBool get connected;
+
+  /// [Stream] of [ConnectivityResult]s describing how this device is currently
+  /// connected to a network.
+  ///
+  /// Result is omitted again every time network is changed.
+  ///
+  /// Intended to be used to monitor network changes to trigger reconnects
+  /// before some ping-based systems notice that connection is lost.
+  Stream<Set<ConnectivityResult>> get connectivity;
 
   /// Fetches the [IpGeoLocation] of the provided [ip].
   ///

--- a/lib/provider/gql/base.dart
+++ b/lib/provider/gql/base.dart
@@ -379,7 +379,7 @@ class GraphQlClient {
     try {
       final T result = await fn();
 
-      if (_errored) {
+      if (_errored || !connected.value) {
         _reportException(null);
         _errored = false;
       }

--- a/lib/store/session.dart
+++ b/lib/store/session.dart
@@ -454,6 +454,14 @@ class SessionRepository extends DisposableInterface
     }
 
     try {
+      // TODO: Implement `WebUtils.connectivity` stream getter to check:
+      //       ```js
+      //       navigator.connection.addEventListener('change', () => {
+      //         console.log("Network connection changed", navigator.connection.type);
+      //       });
+      //       ```
+      //
+      // [Connectivity.onConnectivityChanged] only checks `navigator.onLine`.
       apply(await Connectivity().checkConnectivity());
       _connectivitySubscription = Connectivity().onConnectivityChanged.listen(
         apply,


### PR DESCRIPTION
Resolves #1360




## Synopsis

Reconnection can take too much time when network configuration is changed.




## Solution

This PR manually triggers the reconnection when configuration is changed.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
