### PR TITLE
Use `RefreshSessionSecrets.generate()` in `AuthService.refreshSession()` (#1334)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -333,10 +333,22 @@ targets:
                 name: RefreshTokenSecret
                 imports:
                   - "package:messenger/domain/model/session.dart"
+            - graphql_type: RefreshTokenSecretInput
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/session.dart"
+              dart_type:
+                name: RefreshTokenSecretInput
+                imports:
+                  - "package:messenger/domain/model/session.dart"
             - graphql_type: AccessTokenSecret
               custom_parser_import: "package:messenger/api/backend/graphql/parsers/session.dart"
               dart_type:
                 name: AccessTokenSecret
+                imports:
+                  - "package:messenger/domain/model/session.dart"
+            - graphql_type: AccessTokenSecretInput
+              custom_parser_import: "package:messenger/api/backend/graphql/parsers/session.dart"
+              dart_type:
+                name: AccessTokenSecretInput
                 imports:
                   - "package:messenger/domain/model/session.dart"
             - graphql_type: SessionId

--- a/helm/messenger/Chart.yaml
+++ b/helm/messenger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: messenger
 description: Open-source front-end part of messenger by team113.
 version: 0.1.3
-appVersion: 0.6.0
+appVersion: 0.6.1
 type: application
 sources:
   - https://github.com/team113/messenger

--- a/lib/api/backend/graphql/mutation/user/RefreshSession.graphql
+++ b/lib/api/backend/graphql/mutation/user/RefreshSession.graphql
@@ -15,8 +15,14 @@
 # along with this program. If not, see
 # <https://www.gnu.org/licenses/agpl-3.0.html>.
 
-mutation RefreshSession($secret: RefreshTokenSecret!) {
-    refreshSession(secret: $secret) {
+mutation RefreshSession(
+    $secret: RefreshTokenSecret!
+    $new: RefreshSessionSecretsInput
+) {
+    refreshSession(
+        secret: $secret
+        new: $new
+    ) {
         __typename
         ... on CreateSessionOk {
             user {

--- a/lib/api/backend/graphql/parsers/session.dart
+++ b/lib/api/backend/graphql/parsers/session.dart
@@ -224,6 +224,104 @@ fromDartListNullableAccessTokenSecretNullableToGraphQLListNullableAccessTokenSec
     )
     .toList();
 
+// AccessTokenSecretInput
+
+AccessTokenSecretInput
+fromGraphQLAccessTokenSecretInputToDartAccessTokenSecretInput(String v) =>
+    AccessTokenSecretInput(v);
+String fromDartAccessTokenSecretInputToGraphQLAccessTokenSecretInput(
+  AccessTokenSecretInput v,
+) => v.toString();
+List<AccessTokenSecretInput>
+fromGraphQLListAccessTokenSecretInputToDartListAccessTokenSecretInput(
+  List<Object?> v,
+) => v
+    .map(
+      (e) => fromGraphQLAccessTokenSecretInputToDartAccessTokenSecretInput(
+        e as String,
+      ),
+    )
+    .toList();
+List<String>
+fromDartListAccessTokenSecretInputToGraphQLListAccessTokenSecretInput(
+  List<AccessTokenSecretInput> v,
+) => v
+    .map(
+      (e) => fromDartAccessTokenSecretInputToGraphQLAccessTokenSecretInput(e),
+    )
+    .toList();
+List<AccessTokenSecretInput>?
+fromGraphQLListNullableAccessTokenSecretInputToDartListNullableAccessTokenSecretInput(
+  List<Object?>? v,
+) => v
+    ?.map(
+      (e) => fromGraphQLAccessTokenSecretInputToDartAccessTokenSecretInput(
+        e as String,
+      ),
+    )
+    .toList();
+List<String>?
+fromDartListNullableAccessTokenSecretInputToGraphQLListNullableAccessTokenSecretInput(
+  List<AccessTokenSecretInput>? v,
+) => v
+    ?.map(
+      (e) => fromDartAccessTokenSecretInputToGraphQLAccessTokenSecretInput(e),
+    )
+    .toList();
+
+AccessTokenSecretInput?
+fromGraphQLAccessTokenSecretInputNullableToDartAccessTokenSecretInputNullable(
+  String? v,
+) => v == null ? null : AccessTokenSecretInput(v);
+String?
+fromDartAccessTokenSecretInputNullableToGraphQLAccessTokenSecretInputNullable(
+  AccessTokenSecretInput? v,
+) => v?.toString();
+List<AccessTokenSecretInput?>
+fromGraphQLListAccessTokenSecretInputNullableToDartListAccessTokenSecretInputNullable(
+  List<Object?> v,
+) => v
+    .map(
+      (e) =>
+          fromGraphQLAccessTokenSecretInputNullableToDartAccessTokenSecretInputNullable(
+            e as String?,
+          ),
+    )
+    .toList();
+List<String?>
+fromDartListAccessTokenSecretInputNullableToGraphQLListAccessTokenSecretInputNullable(
+  List<AccessTokenSecretInput?> v,
+) => v
+    .map(
+      (e) =>
+          fromDartAccessTokenSecretInputNullableToGraphQLAccessTokenSecretInputNullable(
+            e,
+          ),
+    )
+    .toList();
+List<AccessTokenSecretInput?>?
+fromGraphQLListNullableAccessTokenSecretInputNullableToDartListNullableAccessTokenSecretInputNullable(
+  List<Object?>? v,
+) => v
+    ?.map(
+      (e) =>
+          fromGraphQLAccessTokenSecretInputNullableToDartAccessTokenSecretInputNullable(
+            e as String?,
+          ),
+    )
+    .toList();
+List<String?>?
+fromDartListNullableAccessTokenSecretInputNullableToGraphQLListNullableAccessTokenSecretInputNullable(
+  List<AccessTokenSecretInput?>? v,
+) => v
+    ?.map(
+      (e) =>
+          fromDartAccessTokenSecretInputNullableToGraphQLAccessTokenSecretInputNullable(
+            e,
+          ),
+    )
+    .toList();
+
 // UserAgent
 
 UserAgent fromGraphQLUserAgentToDartUserAgent(String v) => UserAgent(v);
@@ -353,6 +451,104 @@ fromDartListNullableRefreshTokenSecretNullableToGraphQLListNullableRefreshTokenS
     ?.map(
       (e) =>
           fromDartRefreshTokenSecretNullableToGraphQLRefreshTokenSecretNullable(
+            e,
+          ),
+    )
+    .toList();
+
+// RefreshTokenSecretInput
+
+RefreshTokenSecretInput
+fromGraphQLRefreshTokenSecretInputToDartRefreshTokenSecretInput(String v) =>
+    RefreshTokenSecretInput(v);
+String fromDartRefreshTokenSecretInputToGraphQLRefreshTokenSecretInput(
+  RefreshTokenSecretInput v,
+) => v.val;
+List<RefreshTokenSecretInput>
+fromGraphQLListRefreshTokenSecretInputToDartListRefreshTokenSecretInput(
+  List<Object?> v,
+) => v
+    .map(
+      (e) => fromGraphQLRefreshTokenSecretInputToDartRefreshTokenSecretInput(
+        e as String,
+      ),
+    )
+    .toList();
+List<String>
+fromDartListRefreshTokenSecretInputToGraphQLListRefreshTokenSecretInput(
+  List<RefreshTokenSecretInput> v,
+) => v
+    .map(
+      (e) => fromDartRefreshTokenSecretInputToGraphQLRefreshTokenSecretInput(e),
+    )
+    .toList();
+List<RefreshTokenSecretInput>?
+fromGraphQLListNullableRefreshTokenSecretInputToDartListNullableRefreshTokenSecretInput(
+  List<Object?>? v,
+) => v
+    ?.map(
+      (e) => fromGraphQLRefreshTokenSecretInputToDartRefreshTokenSecretInput(
+        e as String,
+      ),
+    )
+    .toList();
+List<String>?
+fromDartListNullableRefreshTokenSecretInputToGraphQLListNullableRefreshTokenSecretInput(
+  List<RefreshTokenSecretInput>? v,
+) => v
+    ?.map(
+      (e) => fromDartRefreshTokenSecretInputToGraphQLRefreshTokenSecretInput(e),
+    )
+    .toList();
+
+RefreshTokenSecretInput?
+fromGraphQLRefreshTokenSecretInputNullableToDartRefreshTokenSecretInputNullable(
+  String? v,
+) => v == null ? null : RefreshTokenSecretInput(v);
+String?
+fromDartRefreshTokenSecretInputNullableToGraphQLRefreshTokenSecretInputNullable(
+  RefreshTokenSecretInput? v,
+) => v?.val;
+List<RefreshTokenSecretInput?>
+fromGraphQLListRefreshTokenSecretInputNullableToDartListRefreshTokenSecretInputNullable(
+  List<Object?> v,
+) => v
+    .map(
+      (e) =>
+          fromGraphQLRefreshTokenSecretInputNullableToDartRefreshTokenSecretInputNullable(
+            e as String?,
+          ),
+    )
+    .toList();
+List<String?>
+fromDartListRefreshTokenSecretInputNullableToGraphQLListRefreshTokenSecretInputNullable(
+  List<RefreshTokenSecretInput?> v,
+) => v
+    .map(
+      (e) =>
+          fromDartRefreshTokenSecretInputNullableToGraphQLRefreshTokenSecretInputNullable(
+            e,
+          ),
+    )
+    .toList();
+List<RefreshTokenSecretInput?>?
+fromGraphQLListNullableRefreshTokenSecretInputNullableToDartListNullableRefreshTokenSecretInputNullable(
+  List<Object?>? v,
+) => v
+    ?.map(
+      (e) =>
+          fromGraphQLRefreshTokenSecretInputNullableToDartRefreshTokenSecretInputNullable(
+            e as String?,
+          ),
+    )
+    .toList();
+List<String?>?
+fromDartListNullableRefreshTokenSecretInputNullableToGraphQLListNullableRefreshTokenSecretInputNullable(
+  List<RefreshTokenSecretInput?>? v,
+) => v
+    ?.map(
+      (e) =>
+          fromDartRefreshTokenSecretInputNullableToGraphQLRefreshTokenSecretInputNullable(
             e,
           ),
     )

--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -2525,7 +2525,10 @@ abstract class RtcRenderer {
 /// Convenience wrapper around a [webrtc.VideoRenderer].
 class RtcVideoRenderer extends RtcRenderer {
   RtcVideoRenderer(MediaTrack track) : super(track.getTrack()) {
-    Log.debug('RtcVideoRenderer()', '$runtimeType');
+    Log.debug(
+      'RtcVideoRenderer() -> ${_delegate.videoWidth}x${_delegate.videoHeight}',
+      '$runtimeType',
+    );
 
     if (track is LocalMediaTrack) {
       autoRotate = false;

--- a/lib/domain/model/session.dart
+++ b/lib/domain/model/session.dart
@@ -324,18 +324,20 @@ class RefreshSessionSecrets {
   factory RefreshSessionSecrets.generate() {
     return RefreshSessionSecrets._(
       RefreshTokenSecretInput(
-        base64Encode(
-          List.generate(32, (_) => Random.secure().nextInt(1 << 32)),
-        ),
+        base64Encode(List.generate(32, (_) => Random.secure().nextInt(255))),
       ),
       AccessTokenSecretInput(
-        base64Encode(
-          List.generate(32, (_) => Random.secure().nextInt(1 << 32)),
-        ),
+        base64Encode(List.generate(32, (_) => Random.secure().nextInt(255))),
       ),
     );
   }
 
+  /// [RefreshTokenSecretInput] itself.
   final RefreshTokenSecretInput refresh;
+
+  /// [AccessTokenSecretInput] itself.
   final AccessTokenSecretInput access;
+
+  @override
+  String toString() => 'RefreshSessionSecrets($refresh, $access)';
 }

--- a/lib/domain/model/session.dart
+++ b/lib/domain/model/session.dart
@@ -15,6 +15,9 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'dart:convert';
+import 'dart:math';
+
 import 'package:json_annotation/json_annotation.dart';
 
 import '/domain/model/my_user.dart';
@@ -174,6 +177,22 @@ class AccessTokenSecret extends NewType<String> {
   String toJson() => val;
 }
 
+/// Input for creating a [AccessTokenSecret].
+///
+/// Must represent 32 random bytes encoded as valid `Base64` string.
+///
+/// Use a cryptographically secure random generator to produce array of bytes
+/// for this value.
+class AccessTokenSecretInput extends NewType<String> {
+  const AccessTokenSecretInput(super.val);
+
+  /// Constructs a [AccessTokenSecretInput] from the provided [val].
+  factory AccessTokenSecretInput.fromJson(String val) = AccessTokenSecretInput;
+
+  /// Returns a [String] representing this [AccessTokenSecretInput].
+  String toJson() => val;
+}
+
 /// Token used for refreshing a [Session].
 @JsonSerializable()
 class RefreshToken {
@@ -218,6 +237,23 @@ class RefreshTokenSecret extends NewType<String> {
   factory RefreshTokenSecret.fromJson(String val) = RefreshTokenSecret;
 
   /// Returns a [String] representing this [RefreshTokenSecret].
+  String toJson() => val;
+}
+
+/// Input for creating a [RefreshTokenSecret].
+///
+/// Must represent 32 random bytes encoded as valid `Base64` string.
+///
+/// Use a cryptographically secure random generator to produce array of bytes
+/// for this value.
+class RefreshTokenSecretInput extends NewType<String> {
+  const RefreshTokenSecretInput(super.val);
+
+  /// Constructs a [RefreshTokenSecretInput] from the provided [val].
+  factory RefreshTokenSecretInput.fromJson(String val) =
+      RefreshTokenSecretInput;
+
+  /// Returns a [String] representing this [RefreshTokenSecretInput].
   String toJson() => val;
 }
 
@@ -279,4 +315,27 @@ class Credentials {
   @override
   String toString() =>
       'Credentials(userId: $userId, sessionId: ${session.id}, access: $access refresh: $refresh)';
+}
+
+/// [RefreshTokenSecretInput] and [AccessTokenSecretInput].
+class RefreshSessionSecrets {
+  RefreshSessionSecrets._(this.refresh, this.access);
+
+  factory RefreshSessionSecrets.generate() {
+    return RefreshSessionSecrets._(
+      RefreshTokenSecretInput(
+        base64Encode(
+          List.generate(32, (_) => Random.secure().nextInt(1 << 32)),
+        ),
+      ),
+      AccessTokenSecretInput(
+        base64Encode(
+          List.generate(32, (_) => Random.secure().nextInt(1 << 32)),
+        ),
+      ),
+    );
+  }
+
+  final RefreshTokenSecretInput refresh;
+  final AccessTokenSecretInput access;
 }

--- a/lib/domain/repository/auth.dart
+++ b/lib/domain/repository/auth.dart
@@ -99,6 +99,7 @@ abstract class AbstractAuthRepository {
   /// [token] right away.
   Future<Credentials> refreshSession(
     RefreshTokenSecret secret, {
+    RefreshSessionSecrets? input,
     bool reconnect,
   });
 

--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -687,7 +687,7 @@ class AuthService extends DisposableService {
     final bool areCurrent = userId == this.userId;
 
     Log.debug(
-      'refreshSession($userId |-> $attempt) with `isLocked`: $isLocked',
+      'refreshSession($userId |-> $attempt) with `isLocked` ($isLocked) and `failed` ($_failed)',
       '$runtimeType',
     );
 

--- a/lib/provider/gql/components/auth.dart
+++ b/lib/provider/gql/components/auth.dart
@@ -247,11 +247,12 @@ mixin AuthGraphQlMixin {
   /// Each time creates a new [AccessToken] and generates a new
   /// [RefreshTokenSecret] for the [RefreshToken].
   Future<RefreshSession$Mutation> refreshSession(
-    RefreshTokenSecret secret,
-  ) async {
-    Log.debug('refreshSession($secret)', '$runtimeType');
+    RefreshTokenSecret secret, {
+    RefreshSessionSecretsInput? input,
+  }) async {
+    Log.debug('refreshSession($secret, input: $input)', '$runtimeType');
 
-    final variables = RefreshSessionArguments(secret: secret);
+    final variables = RefreshSessionArguments(secret: secret, kw$new: input);
     final QueryResult result = await client.mutate(
       MutationOptions(
         operationName: 'RefreshSession',

--- a/lib/store/auth.dart
+++ b/lib/store/auth.dart
@@ -228,6 +228,7 @@ class AuthRepository extends DisposableInterface
   @override
   Future<Credentials> refreshSession(
     RefreshTokenSecret secret, {
+    RefreshSessionSecrets? input,
     bool reconnect = true,
   }) {
     Log.debug('refreshSession($secret)', '$runtimeType');
@@ -239,8 +240,18 @@ class AuthRepository extends DisposableInterface
         // No-op, as this is expected.
       }
 
+      final query = await _graphQlProvider.refreshSession(
+        secret,
+        input: input == null
+            ? null
+            : RefreshSessionSecretsInput(
+                accessToken: input.access,
+                refreshToken: input.refresh,
+              ),
+      );
+
       final response =
-          (await _graphQlProvider.refreshSession(secret)).refreshSession
+          query.refreshSession
               as RefreshSession$Mutation$RefreshSession$CreateSessionOk;
 
       if (reconnect) {

--- a/lib/store/auth.dart
+++ b/lib/store/auth.dart
@@ -16,6 +16,7 @@
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:get/get.dart';
@@ -231,7 +232,7 @@ class AuthRepository extends DisposableInterface
     RefreshSessionSecrets? input,
     bool reconnect = true,
   }) {
-    Log.debug('refreshSession($secret)', '$runtimeType');
+    Log.debug('refreshSession($secret, input: $input)', '$runtimeType');
 
     return _graphQlProvider.clientGuard.protect(() async {
       try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.6.0
+version: 0.6.1
 publish_to: none
 
 environment:


### PR DESCRIPTION
Resolves #1334




## Synopsis

`Mutation.refreshSession` can cause authorization to be lost because of network related issues.




## Solution

This PR uses client-side generated `RefreshSessionSecrets` in `AuthService.refreshSession()` to fix those problems. This way client can retry the refreshing as much as it wants until a confirmation is received from the backend side.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
