### PR TITLE
Remove `Query.myUser` from `AuthRepository.refreshSession()`

### DIFF
--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -692,9 +692,7 @@ class AuthService extends DisposableService {
     );
 
     LockIdentifier? dbLock;
-
-    final RefreshSessionSecrets secrets =
-        _failed ?? RefreshSessionSecrets.generate();
+    RefreshSessionSecrets? secrets;
 
     try {
       // Acquire a database lock to prevent multiple refreshes of the same
@@ -887,6 +885,7 @@ class AuthService extends DisposableService {
         }
 
         try {
+          secrets = _failed ?? RefreshSessionSecrets.generate();
           final Credentials data = await _authRepository.refreshSession(
             oldCreds.refresh.secret,
             input: secrets,

--- a/lib/store/auth.dart
+++ b/lib/store/auth.dart
@@ -235,12 +235,6 @@ class AuthRepository extends DisposableInterface
     Log.debug('refreshSession($secret, input: $input)', '$runtimeType');
 
     return _graphQlProvider.clientGuard.protect(() async {
-      try {
-        await _graphQlProvider.getMyUser(raw: true);
-      } on AuthorizationException {
-        // No-op, as this is expected.
-      }
-
       final query = await _graphQlProvider.refreshSession(
         secret,
         input: input == null


### PR DESCRIPTION
## Synopsis

`Query.myUser` was used to ensure network connectivity. However, this is no longer necessary.




## Solution

This PR removes the query.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
