### PR TITLE
Fix `_ensureReachable()` method using invalid `CancelToken` in `VideoThumbnail`

### DIFF
--- a/lib/ui/page/home/page/chat/widget/chat_gallery.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_gallery.dart
@@ -76,7 +76,6 @@ class PaginatedGallery extends StatefulWidget {
     this.paginated,
     this.resourceId,
     this.initial,
-    this.onForbidden,
     this.onReply,
     this.onShare,
     this.onScrollTo,
@@ -91,10 +90,6 @@ class PaginatedGallery extends StatefulWidget {
   /// Initial [Attachment] and a [ChatItem] containing it to display initially
   /// in a [PlayerView].
   final (String, int)? initial;
-
-  /// Callback, called when an [Attachment] loading fails with a forbidden
-  /// network error.
-  final FutureOr<void> Function(ChatItem?)? onForbidden;
 
   /// Callback, called when a reply action within [Post] is triggered.
   final void Function(Post)? onReply;

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -249,7 +249,6 @@ class ChatItemWidget extends StatefulWidget {
                       initial: item == null
                           ? null
                           : (item.key.toString(), initial),
-                      onForbidden: onError,
                       onReply: onReply,
                       onShare: onShare,
                       onScrollTo: onScrollTo,

--- a/lib/ui/page/home/page/chat/widget/video_thumbnail/video_thumbnail.dart
+++ b/lib/ui/page/home/page/chat/widget/video_thumbnail/video_thumbnail.dart
@@ -272,7 +272,12 @@ class _VideoThumbnailState extends State<VideoThumbnail> {
 
     try {
       _controller?.dispose();
+      _controller = null;
+    } catch (_) {
+      // No-op.
+    }
 
+    try {
       if (file != null) {
         _controller = VideoPlayerController.file(
           file,
@@ -311,7 +316,17 @@ class _VideoThumbnailState extends State<VideoThumbnail> {
 
         await Backoff.run(() async {
           try {
+            Log.debug(
+              '_initVideo(${widget.url}) -> await _controller?.initialize()...',
+              '$runtimeType',
+            );
+
             await _controller?.initialize();
+
+            Log.debug(
+              '_initVideo(${widget.url}) -> await _controller?.initialize()... done!',
+              '$runtimeType',
+            );
 
             if (mounted) {
               setState(() {});
@@ -344,7 +359,10 @@ class _VideoThumbnailState extends State<VideoThumbnail> {
         }, cancel: _cancelToken);
       }
     } on OperationCanceledException {
-      // No-op.
+      Log.debug(
+        '_initVideo(${widget.url}) -> OperationCanceledException',
+        '$runtimeType',
+      );
     } catch (e) {
       Log.error(
         'Unable to load thumbnail of `${widget.url}`: $e',
@@ -406,9 +424,12 @@ class _VideoThumbnailState extends State<VideoThumbnail> {
             rethrow;
           }
         }
-      }, cancel: _cancelToken);
+      }, cancel: _headerToken);
     } on OperationCanceledException {
-      // No-op.
+      Log.debug(
+        '_ensureReachable(${widget.url}) -> OperationCanceledException',
+        '$runtimeType',
+      );
     }
   }
 }


### PR DESCRIPTION
## Synopsis

During investigation on the reasons as to why `VideoThumbnail` widget seems to hang on loading, it was found that `_ensureReachable()` uses invalid `CancelToken`, which may cause `Backoff` during `_initVideo()` to cancel itself out.

Judging by the logs, it seems that `_initVideo()` is indeed called with proper URLs.




## Solution

This PR fixes invalid `CancelToken` in `_ensureReachable()` method.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
