### PR TITLE
Fix `MigrationStrategy.onUpgrade()` clearing `drift` instead of applying migrations (#1366)

### DIFF
--- a/lib/provider/drift/drift.dart
+++ b/lib/provider/drift/drift.dart
@@ -87,23 +87,22 @@ class CommonDatabase extends _$CommonDatabase {
   @override
   MigrationStrategy get migration {
     return MigrationStrategy(
-      onUpgrade: (m, a, b) async {
-        Log.info('MigrationStrategy.onUpgrade($a, $b)', '$runtimeType');
+      onUpgrade: (m, from, to) async {
+        Log.info('MigrationStrategy.onUpgrade($from, $to)', '$runtimeType');
 
         if (_closed) {
           return;
         }
 
-        // TODO: Implement proper migrations.
-        if (a != b) {
+        if (from != to) {
           bool migrated = false;
 
-          if (a >= 7 && b <= 6) {
+          if (to >= 7 && from <= 6) {
             await m.addColumn(settings, settings.videoVolume);
             migrated = true;
           }
 
-          if (a >= 6 && b <= 5) {
+          if (to >= 6 && from <= 5) {
             await m.addColumn(settings, settings.noiseSuppression);
             await m.addColumn(settings, settings.noiseSuppressionLevel);
             await m.addColumn(settings, settings.echoCancellation);
@@ -112,31 +111,41 @@ class CommonDatabase extends _$CommonDatabase {
             migrated = true;
           }
 
-          if (a >= 5 && b <= 4) {
+          if (to >= 5 && from <= 4) {
             await m.addColumn(settings, settings.muteKeys);
             migrated = true;
           }
 
-          if (a >= 4 && b <= 3) {
+          if (to >= 4 && from <= 3) {
             await m.addColumn(versions, versions.blocklistVersion);
             await m.addColumn(versions, versions.blocklistCount);
             migrated = true;
           }
 
-          if (a >= 3 && b <= 2) {
+          if (to >= 3 && from <= 2) {
             await m.addColumn(myUsers, myUsers.welcomeMessage);
             migrated = true;
           }
 
-          if (a >= 2 && b <= 1) {
+          if (to >= 2 && from <= 1) {
             await m.addColumn(versions, versions.sessionsListVersion);
             migrated = true;
           }
 
           if (!migrated) {
+            Log.info(
+              'MigrationStrategy.onUpgrade($from, $to) -> migration did not succeed, thus deleting the tables',
+              '$runtimeType',
+            );
+
             for (var e in m.database.allTables) {
               await m.deleteTable(e.actualTableName);
             }
+          } else {
+            Log.info(
+              'MigrationStrategy.onUpgrade($from, $to) -> migration did succeed',
+              '$runtimeType',
+            );
           }
         }
 


### PR DESCRIPTION
Resolves #1366




## Synopsis

`MigrationStrategy.onUpgrade()` seems to clear the database every time version changes.




## Solution

This PR fixes that by changing the variables order.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
