### PR TITLE
Draft: User page folded tip if in favorites (#1274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Chat page:
         - Text in forwarded messages not being selectable. ([#1367])
+    - User page:
+        - User page folded tip if in favorites.
 
 [#1356]: /../../pull/1356
 [#1367]: /../../pull/1367

--- a/lib/domain/repository/chat.dart
+++ b/lib/domain/repository/chat.dart
@@ -73,6 +73,9 @@ abstract class AbstractChatRepository {
   /// Returns an [RxChat] by the provided [id].
   FutureOr<RxChat?> get(ChatId id);
 
+  /// Returns an [RxChat] by the provided user [id].
+  FutureOr<RxChat?> getChatByUserId(UserId id);
+
   /// Removes a [Chat] identified by the provided [id] from the [chats].
   Future<void> remove(ChatId id);
 

--- a/lib/domain/service/chat.dart
+++ b/lib/domain/service/chat.dart
@@ -102,6 +102,12 @@ class ChatService extends DisposableService {
     return _chatRepository.get(id);
   }
 
+  /// Returns a [RxChat] by the provided user [id].
+  FutureOr<RxChat?> getChatByUserId(UserId id) {
+    Log.debug('getChatByUserId($id)', '$runtimeType');
+    return _chatRepository.getChatByUserId(id);
+  }
+
   /// Fetches the next [paginated] page.
   FutureOr<void> next() async {
     if (_chatRepository.hasNext.value) {

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -365,6 +365,24 @@ class ChatRepository extends DisposableInterface
   }
 
   @override
+  FutureOr<RxChat?> getChatByUserId(UserId id) {
+    Log.debug('getChatByUserId($id)', '$runtimeType');
+
+    RxChatImpl? chat = chats.values.firstWhereOrNull((chat) {
+      final members = chat.members;
+      // If there is only two members and the id is equals to one we are searching
+      if (members.items.keys.contains(id) && members.items.keys.length == 2) {
+        return true;
+      }
+      return false;
+    });
+    if (chat != null) {
+      return chat;
+    }
+    return null;
+  }
+
+  @override
   Future<void> remove(ChatId id, {bool force = false}) async {
     Log.debug('remove($id)', '$runtimeType');
 

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -187,6 +187,10 @@ class UserController extends GetxController {
   /// [contact] may be fetched with a delay.
   ChatContactId? get contactId => user?.user.value.contacts.firstOrNull?.id;
 
+  final Rx<bool> _isChatWithUserInFavorites = false.obs;
+
+  Rx<bool> get isChatWithUserInFavorites => _isChatWithUserInFavorites;
+
   @override
   void onInit() {
     name = TextFieldState(
@@ -221,6 +225,8 @@ class UserController extends GetxController {
       }
     });
 
+    checkIfTheChatWithUserInFavorites();
+
     super.onInit();
   }
 
@@ -245,6 +251,14 @@ class UserController extends GetxController {
       } finally {
         status.value = RxStatus.success();
       }
+    }
+  }
+
+  /// On init checking if the chat with this user is in favorites
+  Future<void> checkIfTheChatWithUserInFavorites() async {
+    final chat = await _chatService.getChatByUserId(user!.id);
+    if (chat != null && chat.chat.value.favoritePosition != null) {
+      _isChatWithUserInFavorites.value = true;
     }
   }
 
@@ -364,6 +378,7 @@ class UserController extends GetxController {
     try {
       if (dialog != null) {
         await _chatService.favoriteChat(dialog);
+        _isChatWithUserInFavorites.value = true;
       }
     } on FavoriteChatContactException catch (e) {
       MessagePopup.error(e);
@@ -379,6 +394,7 @@ class UserController extends GetxController {
     try {
       if (dialog != null) {
         await _chatService.unfavoriteChat(dialog);
+        _isChatWithUserInFavorites.value = false;
       }
     } on UnfavoriteChatContactException catch (e) {
       MessagePopup.error(e.toMessage());

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -256,6 +256,7 @@ class UserController extends GetxController {
 
   /// On init checking if the chat with this user is in favorites
   Future<void> checkIfTheChatWithUserInFavorites() async {
+    if (user == null) return;
     final chat = await _chatService.getChatByUserId(user!.id);
     if (chat != null && chat.chat.value.favoritePosition != null) {
       _isChatWithUserInFavorites.value = true;

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -15,6 +15,8 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'dart:developer';
+
 import 'package:expandable_text/expandable_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -124,8 +126,10 @@ class UserView extends StatelessWidget {
     final style = Theme.of(context).style;
 
     final UserBio? bio = c.user?.user.value.bio;
+    log(c.isChatWithUserInFavorites.value.toString());
 
     return Block(
+      folded: c.isChatWithUserInFavorites.value,
       padding: EdgeInsets.fromLTRB(32, 8, 32, 16),
       children: [
         Obx(() {

--- a/lib/ui/page/home/tab/chats/widget/hovered_ink.dart
+++ b/lib/ui/page/home/tab/chats/widget/hovered_ink.dart
@@ -18,7 +18,6 @@
 import 'package:flutter/material.dart';
 
 import '/themes.dart';
-import '/ui/page/home/widget/avatar.dart';
 
 /// [InkWell] button decorated differently based on the [selected] indicator.
 ///
@@ -36,7 +35,6 @@ class InkWellWithHover extends StatefulWidget {
     this.hoveredBorder,
     this.borderRadius,
     this.onTap,
-    this.folded = false,
     required this.child,
   });
 
@@ -67,9 +65,6 @@ class InkWellWithHover extends StatefulWidget {
   /// Callback, called when this [InkWellWithHover] is pressed.
   final void Function()? onTap;
 
-  /// Indicator whether this [InkWellWithHover] should have its corner folded.
-  final bool folded;
-
   /// [Widget] wrapped by this [InkWellWithHover].
   final Widget child;
 
@@ -86,79 +81,30 @@ class _InkWellWithHoverState extends State<InkWellWithHover> {
   Widget build(BuildContext context) {
     final style = Theme.of(context).style;
 
-    return ClipPath(
-      clipper: widget.folded
-          ? _Clipper(widget.borderRadius?.topLeft.y ?? 10)
-          : null,
-      child: DecoratedBox(
-        position: DecorationPosition.foreground,
-        decoration: BoxDecoration(
+    return DecoratedBox(
+      position: DecorationPosition.foreground,
+      decoration: BoxDecoration(
+        borderRadius: widget.borderRadius,
+        border: hovered ? widget.hoveredBorder : widget.border,
+      ),
+      child: Material(
+        type: MaterialType.card,
+        borderRadius: widget.borderRadius,
+        color: hovered
+            ? widget.selected
+                  ? widget.selectedHoverColor
+                  : widget.unselectedHoverColor
+            : widget.selected
+            ? widget.selectedColor
+            : widget.unselectedColor,
+        child: InkWell(
           borderRadius: widget.borderRadius,
-          border: hovered ? widget.hoveredBorder : widget.border,
-        ),
-        child: Material(
-          type: MaterialType.card,
-          borderRadius: widget.borderRadius,
-          color: hovered
-              ? widget.selected
-                    ? widget.selectedHoverColor
-                    : widget.unselectedHoverColor
-              : widget.selected
-              ? widget.selectedColor
-              : widget.unselectedColor,
-          child: InkWell(
-            borderRadius: widget.borderRadius,
-            onTap: widget.onTap,
-            onHover: (v) => setState(() => hovered = v),
-            hoverColor: style.colors.transparent,
-            child: Stack(
-              children: [
-                Center(child: widget.child),
-                if (widget.folded)
-                  Container(
-                    width: widget.borderRadius?.topLeft.y ?? 10,
-                    height: widget.borderRadius?.topLeft.y ?? 10,
-                    decoration: BoxDecoration(
-                      color: style.colors.primaryHighlightShiniest.darken(0.1),
-                      borderRadius: const BorderRadius.only(
-                        bottomRight: Radius.circular(4),
-                      ),
-                      boxShadow: [
-                        CustomBoxShadow(
-                          color: style.colors.secondaryHighlightDarkest,
-                          blurStyle: BlurStyle.outer.workaround,
-                          blurRadius: 4,
-                        ),
-                      ],
-                    ),
-                  ),
-              ],
-            ),
-          ),
+          onTap: widget.onTap,
+          onHover: (v) => setState(() => hovered = v),
+          hoverColor: style.colors.transparent,
+          child: Center(child: widget.child),
         ),
       ),
     );
   }
-}
-
-/// [CustomClipper] clipping a top-left corner.
-class _Clipper extends CustomClipper<Path> {
-  const _Clipper(this.radius);
-
-  /// Radius of the corner being clipped.
-  final double radius;
-
-  @override
-  Path getClip(Size size) {
-    final path = Path()
-      ..lineTo(size.width, 0)
-      ..lineTo(size.width, size.height)
-      ..lineTo(0, size.height)
-      ..lineTo(0, radius)
-      ..lineTo(radius, 0);
-    return path;
-  }
-
-  @override
-  bool shouldReclip(covariant CustomClipper<Path> oldClipper) => false;
 }

--- a/lib/ui/page/home/widget/block.dart
+++ b/lib/ui/page/home/widget/block.dart
@@ -21,6 +21,7 @@ import 'package:flutter/material.dart';
 
 import '/themes.dart';
 import '/util/platform_utils.dart';
+import 'folded_corner_wrapper.dart';
 import 'highlighted_container.dart';
 
 /// Stylized grouped section of the provided [children].
@@ -40,6 +41,7 @@ class Block extends StatelessWidget {
     this.headline,
     this.maxWidth = 400,
     this.clipHeight = false,
+    this.folded,
   });
 
   /// Optional header of this [Block].
@@ -93,6 +95,9 @@ class Block extends StatelessWidget {
 
   /// Default [Block.margin] to apply.
   static const EdgeInsets defaultMargin = EdgeInsets.fromLTRB(8, 4, 8, 4);
+
+  /// Indicate if the upper left corner has to be folded. Defaults to `false`.
+  final bool? folded;
 
   @override
   Widget build(BuildContext context) {
@@ -149,31 +154,35 @@ class Block extends StatelessWidget {
           constraints: (expanded ?? context.isNarrow)
               ? null
               : BoxConstraints(maxWidth: maxWidth),
-          child: InputDecorator(
-            decoration: InputDecoration(
-              filled: true,
-              fillColor: background ?? style.messageColor,
-              focusedBorder: border,
-              errorBorder: border,
-              enabledBorder: border,
-              disabledBorder: border,
-              focusedErrorBorder: border,
-              contentPadding: const EdgeInsets.symmetric(horizontal: 12),
-              border: border,
-            ),
-            child: Stack(
-              children: [
-                Container(
-                  width: double.infinity,
-                  padding: _aspected(context, padding),
-                  child: content,
-                ),
-                if (headline != null)
-                  Positioned(
-                    child: Text(headline!, style: _headlineStyle(context)),
+          child: FoldedCornerWrapper(
+            fold: folded ?? false,
+            radius: style.cardRadius.topLeft.y,
+            child: InputDecorator(
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: background ?? style.messageColor,
+                focusedBorder: border,
+                errorBorder: border,
+                enabledBorder: border,
+                disabledBorder: border,
+                focusedErrorBorder: border,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 12),
+                border: border,
+              ),
+              child: Stack(
+                children: [
+                  Container(
+                    width: double.infinity,
+                    padding: _aspected(context, padding),
+                    child: content,
                   ),
-                ...overlay,
-              ],
+                  if (headline != null)
+                    Positioned(
+                      child: Text(headline!, style: _headlineStyle(context)),
+                    ),
+                  ...overlay,
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/ui/page/home/widget/chat_tile.dart
+++ b/lib/ui/page/home/widget/chat_tile.dart
@@ -27,6 +27,7 @@ import '/ui/page/home/tab/chats/widget/hovered_ink.dart';
 import '/ui/page/home/widget/avatar.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
+import 'folded_corner_wrapper.dart';
 
 /// [Chat] visual representation.
 class ChatTile extends StatelessWidget {
@@ -116,88 +117,94 @@ class ChatTile extends StatelessWidget {
       enabled: enableContextMenu,
       child: Padding(
         padding: const EdgeInsets.fromLTRB(0, 1.5, 0, 1.5),
-        child: InkWellWithHover(
-          selectedColor: dimmed
-              ? style.colors.primary.darken(0.03)
-              : style.colors.primary,
-          unselectedColor: dimmed
-              ? style.colors.onPrimaryOpacity50
-              : style.cardColor.darken(darken),
-          selected: selected,
-          hoveredBorder: selected
-              ? style.cardSelectedBorder
-              : style.cardHoveredBorder,
-          border: selected ? style.cardSelectedBorder : style.cardBorder,
-          borderRadius: style.cardRadius,
-          onTap: onTap,
-          unselectedHoverColor: style.cardHoveredColor,
-          selectedHoverColor: dimmed
-              ? style.colors.primary.darken(0.03)
-              : style.colors.primary,
-          folded: chat?.chat.value.favoritePosition != null,
-          child: SizedBox(
-            height: height,
-            child: Padding(
-              key: chat?.chat.value.favoritePosition != null
-                  ? Key('FavoriteIndicator_${chat?.chat.value.id}')
-                  : null,
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-              child: Row(
-                children: [
-                  avatarBuilder(
-                    AvatarWidget.fromRxChat(
-                      chat,
-                      radius: AvatarRadius.large,
-                      onForbidden: onForbidden,
+        child: FoldedCornerWrapper(
+          fold: chat?.chat.value.favoritePosition != null,
+          radius: style.cardRadius.topLeft.y,
+          child: InkWellWithHover(
+            selectedColor: dimmed
+                ? style.colors.primary.darken(0.03)
+                : style.colors.primary,
+            unselectedColor: dimmed
+                ? style.colors.onPrimaryOpacity50
+                : style.cardColor.darken(darken),
+            selected: selected,
+            hoveredBorder: selected
+                ? style.cardSelectedBorder
+                : style.cardHoveredBorder,
+            border: selected ? style.cardSelectedBorder : style.cardBorder,
+            borderRadius: style.cardRadius,
+            onTap: onTap,
+            unselectedHoverColor: style.cardHoveredColor,
+            selectedHoverColor: dimmed
+                ? style.colors.primary.darken(0.03)
+                : style.colors.primary,
+            child: SizedBox(
+              height: height,
+              child: Padding(
+                key: chat?.chat.value.favoritePosition != null
+                    ? Key('FavoriteIndicator_${chat?.chat.value.id}')
+                    : null,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 4,
+                ),
+                child: Row(
+                  children: [
+                    avatarBuilder(
+                      AvatarWidget.fromRxChat(
+                        chat,
+                        radius: AvatarRadius.large,
+                        onForbidden: onForbidden,
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: 12),
-                  ...leading,
-                  Expanded(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            Expanded(
-                              child: Row(
-                                children: [
-                                  Flexible(
-                                    child: titleBuilder(
-                                      Obx(() {
-                                        return Text(
-                                          chat?.title ?? ('dot'.l10n * 3),
-                                          overflow: TextOverflow.ellipsis,
-                                          maxLines: 1,
-                                          style: selected
-                                              ? style
-                                                    .fonts
-                                                    .big
-                                                    .regular
-                                                    .onPrimary
-                                              : style
-                                                    .fonts
-                                                    .big
-                                                    .regular
-                                                    .onBackground,
-                                        );
-                                      }),
+                    const SizedBox(width: 12),
+                    ...leading,
+                    Expanded(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Row(
+                                  children: [
+                                    Flexible(
+                                      child: titleBuilder(
+                                        Obx(() {
+                                          return Text(
+                                            chat?.title ?? ('dot'.l10n * 3),
+                                            overflow: TextOverflow.ellipsis,
+                                            maxLines: 1,
+                                            style: selected
+                                                ? style
+                                                      .fonts
+                                                      .big
+                                                      .regular
+                                                      .onPrimary
+                                                : style
+                                                      .fonts
+                                                      .big
+                                                      .regular
+                                                      .onBackground,
+                                          );
+                                        }),
+                                      ),
                                     ),
-                                  ),
-                                  ...title,
-                                ],
+                                    ...title,
+                                  ],
+                                ),
                               ),
-                            ),
-                            ...status,
-                          ],
-                        ),
-                        ...subtitle,
-                      ],
+                              ...status,
+                            ],
+                          ),
+                          ...subtitle,
+                        ],
+                      ),
                     ),
-                  ),
-                  ...trailing,
-                ],
+                    ...trailing,
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/ui/page/home/widget/contact_tile.dart
+++ b/lib/ui/page/home/widget/contact_tile.dart
@@ -29,6 +29,7 @@ import '/ui/page/home/tab/chats/widget/hovered_ink.dart';
 import '/ui/page/home/widget/avatar.dart';
 import '/ui/widget/context_menu/menu.dart';
 import '/ui/widget/context_menu/region.dart';
+import 'folded_corner_wrapper.dart';
 
 /// Person ([ChatContact] or [User]) visual representation.
 ///
@@ -133,69 +134,75 @@ class ContactTile extends StatelessWidget {
       enabled: enableContextMenu,
       child: Padding(
         padding: margin,
-        child: InkWellWithHover(
-          selectedColor: style.colors.primary,
-          unselectedColor: style.cardColor.darken(darken),
-          selected: selected,
-          hoveredBorder: selected
-              ? style.cardSelectedBorder
-              : style.cardHoveredBorder,
-          border: selected ? style.cardSelectedBorder : style.cardBorder,
-          borderRadius: style.cardRadius,
-          onTap: onTap,
-          unselectedHoverColor: style.cardHoveredColor,
-          selectedHoverColor: style.colors.primary,
-          folded: contact?.contact.value.favoritePosition != null,
-          child: SizedBox(
-            height: dense ? 56 : height,
-            child: Padding(
-              key: contact?.contact.value.favoritePosition != null
-                  ? Key('FavoriteIndicator_${contact?.contact.value.id}')
-                  : null,
-              padding:
-                  padding ??
-                  EdgeInsets.symmetric(horizontal: 12, vertical: dense ? 4 : 6),
-              child: Row(
-                children: [
-                  ...leading,
-                  avatarBuilder(
-                    contact != null
-                        ? AvatarWidget.fromRxContact(
-                            contact,
-                            radius: dense ? AvatarRadius.medium : radius,
-                          )
-                        : user != null
-                        ? AvatarWidget.fromRxUser(
-                            user,
-                            radius: dense ? AvatarRadius.medium : radius,
-                          )
-                        : AvatarWidget.fromMyUser(
-                            myUser,
-                            radius: dense ? AvatarRadius.medium : radius,
-                          ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (contact != null || user != null)
-                          Obx(() {
-                            return _name(
-                              context,
-                              contact: contact?.contact.value,
-                              user: user,
-                            );
-                          })
-                        else
-                          _name(context),
-                        ...subtitle,
-                      ],
+        child: FoldedCornerWrapper(
+          fold: contact?.contact.value.favoritePosition != null,
+          radius: style.cardRadius.topLeft.y,
+          child: InkWellWithHover(
+            selectedColor: style.colors.primary,
+            unselectedColor: style.cardColor.darken(darken),
+            selected: selected,
+            hoveredBorder: selected
+                ? style.cardSelectedBorder
+                : style.cardHoveredBorder,
+            border: selected ? style.cardSelectedBorder : style.cardBorder,
+            borderRadius: style.cardRadius,
+            onTap: onTap,
+            unselectedHoverColor: style.cardHoveredColor,
+            selectedHoverColor: style.colors.primary,
+            child: SizedBox(
+              height: dense ? 56 : height,
+              child: Padding(
+                key: contact?.contact.value.favoritePosition != null
+                    ? Key('FavoriteIndicator_${contact?.contact.value.id}')
+                    : null,
+                padding:
+                    padding ??
+                    EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: dense ? 4 : 6,
                     ),
-                  ),
-                  ...trailing,
-                ],
+                child: Row(
+                  children: [
+                    ...leading,
+                    avatarBuilder(
+                      contact != null
+                          ? AvatarWidget.fromRxContact(
+                              contact,
+                              radius: dense ? AvatarRadius.medium : radius,
+                            )
+                          : user != null
+                          ? AvatarWidget.fromRxUser(
+                              user,
+                              radius: dense ? AvatarRadius.medium : radius,
+                            )
+                          : AvatarWidget.fromMyUser(
+                              myUser,
+                              radius: dense ? AvatarRadius.medium : radius,
+                            ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (contact != null || user != null)
+                            Obx(() {
+                              return _name(
+                                context,
+                                contact: contact?.contact.value,
+                                user: user,
+                              );
+                            })
+                          else
+                            _name(context),
+                          ...subtitle,
+                        ],
+                      ),
+                    ),
+                    ...trailing,
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/ui/page/home/widget/folded_corner_wrapper.dart
+++ b/lib/ui/page/home/widget/folded_corner_wrapper.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+import '../../../../themes.dart';
+import 'avatar.dart';
+
+class FoldedCornerWrapper extends StatelessWidget {
+  const FoldedCornerWrapper({
+    super.key,
+    required this.fold,
+    required this.child,
+    this.radius,
+  });
+
+  /// Whether to apply the folded-corner clipping.
+  final bool fold;
+
+  /// The widget that will be clipped or displayed as-is.
+  final Widget child;
+
+  /// The radius of the folded corner.
+  ///
+  /// Defaults to `10` when [fold] is `true` but [radius] is `null`.
+  final double? radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = Theme.of(context).style;
+
+    return ClipPath(
+      clipper: fold ? _FoldClipper(radius ?? 10) : null,
+      child: Stack(
+        children: [
+          child,
+          if (fold)
+            Container(
+              width: radius ?? 10,
+              height: radius ?? 10,
+              decoration: BoxDecoration(
+                color: style.colors.primaryHighlightShiniest.darken(0.1),
+                borderRadius: const BorderRadius.only(
+                  bottomRight: Radius.circular(4),
+                ),
+                boxShadow: [
+                  CustomBoxShadow(
+                    color: style.colors.secondaryHighlightDarkest,
+                    blurStyle: BlurStyle.outer.workaround,
+                    blurRadius: 4,
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// [CustomClipper] clipping a top-left corner.
+class _FoldClipper extends CustomClipper<Path> {
+  const _FoldClipper(this.radius);
+
+  /// Radius of the corner being clipped.
+  final double radius;
+
+  @override
+  Path getClip(Size size) {
+    final path = Path()
+      ..lineTo(size.width, 0)
+      ..lineTo(size.width, size.height)
+      ..lineTo(0, size.height)
+      ..lineTo(0, radius)
+      ..lineTo(radius, 0);
+    return path;
+  }
+
+  @override
+  bool shouldReclip(covariant CustomClipper<Path> oldClipper) => false;
+}


### PR DESCRIPTION
Resolves (https://github.com/team113/messenger/issues/1274)

## Synopsis
ChatInfo and User pages. Chats/users can be added to favorites. When Chat is in favorite, its RecentChatTile on Chats tab is folded.

## Solution
Add folded tip to ChatInfo widget

## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
