### PR TITLE
Zoom `InteractiveViewer` in `Player` only when control is pressed on Windows

### DIFF
--- a/lib/ui/page/player/controller.dart
+++ b/lib/ui/page/player/controller.dart
@@ -147,6 +147,10 @@ class PlayerController extends GetxController {
   /// [List] of the currently active [PlayerNotification]s.
   final RxList<PlayerNotification> notifications = RxList();
 
+  /// Indicator whether scrolling of pointer should zoom the
+  /// [transformationController] instead of scrolling.
+  final RxBool zoomInsteadOfScrolling = RxBool(false);
+
   /// [AbstractSettingsRepository] for storing the
   /// [ApplicationSettings.videoVolume].
   final AbstractSettingsRepository _settingsRepository;
@@ -737,7 +741,24 @@ class PlayerController extends GetxController {
 
           return true;
 
+        case LogicalKeyboardKey.controlLeft:
+        case LogicalKeyboardKey.controlRight:
+          zoomInsteadOfScrolling.value = true;
+          return true;
+
         default:
+          // No-op.
+          break;
+      }
+    } else if (event is KeyUpEvent) {
+      switch (event.logicalKey) {
+        case LogicalKeyboardKey.controlLeft:
+        case LogicalKeyboardKey.controlRight:
+          zoomInsteadOfScrolling.value = false;
+          return true;
+
+        default:
+          // No-op.
           break;
       }
     }

--- a/lib/ui/page/player/view.dart
+++ b/lib/ui/page/player/view.dart
@@ -187,9 +187,10 @@ class PlayerView extends StatelessWidget {
     return Obx(() {
       return PageView.builder(
         physics:
-            c.viewportIsTransformed.value || !c.zoomInsteadOfScrolling.value
-            ? NeverScrollableScrollPhysics()
-            : null,
+            !c.viewportIsTransformed.value &&
+                (!c.zoomInsteadOfScrolling.value || !PlatformUtils.isWindows)
+            ? null
+            : NeverScrollableScrollPhysics(),
         controller: c.vertical,
         scrollDirection: Axis.vertical,
         itemCount: c.posts.length,
@@ -199,7 +200,6 @@ class PlayerView extends StatelessWidget {
             child: _post(context, c, c.posts.elementAt(i)),
           );
         },
-        // children: [...c.posts.map((e) => _post(context, c, e))],
       );
     });
   }
@@ -209,9 +209,9 @@ class PlayerView extends StatelessWidget {
     return Obx(() {
       return PageView(
         physics:
-            c.viewportIsTransformed.value || !c.zoomInsteadOfScrolling.value
-            ? NeverScrollableScrollPhysics()
-            : null,
+            !c.viewportIsTransformed.value && !c.zoomInsteadOfScrolling.value
+            ? null
+            : NeverScrollableScrollPhysics(),
         controller: post.horizontal.value,
         children: [...post.items.map((e) => _attachment(context, c, post, e))],
       );

--- a/lib/ui/page/player/view.dart
+++ b/lib/ui/page/player/view.dart
@@ -186,7 +186,8 @@ class PlayerView extends StatelessWidget {
   Widget _content(BuildContext context, PlayerController c) {
     return Obx(() {
       return PageView.builder(
-        physics: c.viewportIsTransformed.value
+        physics:
+            c.viewportIsTransformed.value || !c.zoomInsteadOfScrolling.value
             ? NeverScrollableScrollPhysics()
             : null,
         controller: c.vertical,
@@ -207,7 +208,8 @@ class PlayerView extends StatelessWidget {
   Widget _post(BuildContext context, PlayerController c, Post post) {
     return Obx(() {
       return PageView(
-        physics: c.viewportIsTransformed.value
+        physics:
+            c.viewportIsTransformed.value || !c.zoomInsteadOfScrolling.value
             ? NeverScrollableScrollPhysics()
             : null,
         controller: post.horizontal.value,

--- a/lib/ui/page/player/view.dart
+++ b/lib/ui/page/player/view.dart
@@ -299,21 +299,25 @@ class PlayerView extends StatelessWidget {
               ),
           ],
         ],
-        child: InteractiveViewer(
-          transformationController: c.transformationController,
-          onInteractionStart: (_) {
-            c.viewportIsTransformed.value = true;
-          },
-          onInteractionEnd: (e) {
-            c.viewportIsTransformed.value =
-                c.transformationController.value.forward.z > 1;
-          },
-          child: child,
-        ),
+        child: Obx(() {
+          return InteractiveViewer(
+            scaleEnabled:
+                c.zoomInsteadOfScrolling.value || !PlatformUtils.isWindows,
+            transformationController: c.transformationController,
+            onInteractionStart: (_) {
+              c.viewportIsTransformed.value = true;
+            },
+            onInteractionEnd: (e) {
+              c.viewportIsTransformed.value =
+                  c.transformationController.value.forward.z > 1;
+            },
+            child: child ?? const SizedBox(),
+          );
+        }),
       );
     }
 
-    return SizedBox();
+    return const SizedBox();
   }
 
   /// Builds the interface to display over the [_content].


### PR DESCRIPTION
## Synopsis

`InteractiveViewer` conflicts with `PageView` when scrolling up or down.




## Solution

This PR resolves that by adding a flag that would fire up when control is pressed so that zooming requires it to be `true`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
