### PR TITLE
Set `overscroll-behavior-x` to `none` in `index.html`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
           set -ex
           # TODO: Unpin when is flutterfire_cli/issues#372 fixed:
           #       https://github.com/invertase/flutterfire_cli/issues/372
-          npm install -g firebase-tools@13.30.0
+          npm install -g firebase-tools@14.14.0
           dart pub global activate flutterfire_cli
           echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' \
           > ${{ runner.temp }}/service_account.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
           set -ex
           # TODO: Unpin when is flutterfire_cli/issues#372 fixed:
           #       https://github.com/invertase/flutterfire_cli/issues/372
-          npm install -g firebase-tools@14.14.0
+          npm install -g firebase-tools@13.30.0
           dart pub global activate flutterfire_cli
           echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' \
           > ${{ runner.temp }}/service_account.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,14 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Chat page:
         - Text in forwarded messages not being selectable. ([#1367])
+- Web:
+    - Back/forward buttons appearing in Chrome when swiping back/forward. ([#1386])
 
 [#1356]: /../../pull/1356
 [#1367]: /../../pull/1367
 [#1368]: /../../pull/1368
 [#1369]: /../../pull/1369
+[#1386]: /../../pull/1386
 
 
 

--- a/web/index.html
+++ b/web/index.html
@@ -73,6 +73,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com/">
   <link href='https://fonts.googleapis.com/css?family=Noto Sans Display' rel='stylesheet'>
   <style type="text/css">
+    html {
+      overscroll-behavior-x: none;
+    }
+
     body {
       background-color: #FFFFFF;
       background-image: url('assets/assets/images/background_light.svg');
@@ -81,6 +85,7 @@
       background-size: cover;
       background-position: center;
       overflow-x: hidden;
+      overscroll-behavior-x: none;
     }
 
     .content {


### PR DESCRIPTION
## Synopsis

Chrome displays back/forward buttons when user swipes trackpad back or forward. This may cause some conflicts with horizontal scrolling.




## Solution

This PR removes those buttons by setting `overscroll-behavior-x` to `none` in `index.html`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
