### PR TITLE
Implement `bytes()` constructor for `VideoPlayerController` to use in `VideoThumbnail`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All user visible changes to this project will be documented in this file. This p
 ### Changed
 
 - UI:
-    - Redesigned media player. ([#1368], [#1367], [#1356])
+    - Redesigned media player. ([#1395], [#1368], [#1367], [#1356])
     - Chat info page:
         - Display folded indicator when chat is in favorites. ([#1391] [#1274])
     - User page:
@@ -38,6 +38,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1369]: /../../pull/1369
 [#1386]: /../../pull/1386
 [#1391]: /../../pull/1391
+[#1395]: /../../pull/1395
 
 
 

--- a/lib/util/video_extension.dart
+++ b/lib/util/video_extension.dart
@@ -1,0 +1,20 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+export 'video_extension/interface.dart'
+    if (dart.library.js_interop) 'video_extension/web.dart'
+    if (dart.library.ffi) 'video_extension/io.dart';

--- a/lib/util/video_extension/interface.dart
+++ b/lib/util/video_extension/interface.dart
@@ -1,0 +1,31 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:video_player/video_player.dart';
+
+/// Extension adding [VideoPlayerController] constructor from [Uint8List].
+extension VideoPlayerControllerExt on VideoPlayerController {
+  /// Creates a [VideoPlayerController] from the provided [bytes].
+  static FutureOr<VideoPlayerController> bytes(
+    Uint8List bytes, {
+    String? checksum,
+    VideoPlayerOptions? videoPlayerOptions,
+  }) => throw UnimplementedError();
+}

--- a/lib/util/video_extension/io.dart
+++ b/lib/util/video_extension/io.dart
@@ -1,0 +1,50 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:video_player/video_player.dart';
+
+import '../platform_utils.dart';
+
+/// Extension adding [VideoPlayerController] constructor from [Uint8List].
+extension VideoPlayerControllerExt on VideoPlayerController {
+  /// Creates a [VideoPlayerController] from the provided [bytes].
+  static FutureOr<VideoPlayerController> bytes(
+    Uint8List bytes, {
+    String? checksum,
+    VideoPlayerOptions? videoPlayerOptions,
+  }) async {
+    final String hash = checksum ?? sha256.convert(bytes).toString();
+
+    final File file = File(
+      '${(await PlatformUtils.temporaryDirectory).path}/$hash',
+    );
+
+    if (!file.existsSync() || file.lengthSync() != bytes.length) {
+      file.writeAsBytesSync(bytes);
+    }
+
+    return VideoPlayerController.file(
+      file,
+      videoPlayerOptions: videoPlayerOptions,
+    );
+  }
+}

--- a/lib/util/video_extension/web.dart
+++ b/lib/util/video_extension/web.dart
@@ -1,0 +1,44 @@
+// Copyright © 2022-2025 IT ENGINEERING MANAGEMENT INC,
+//                       <https://github.com/team113>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:video_player/video_player.dart';
+import 'package:web/web.dart' as web;
+
+/// Extension adding [VideoPlayerController] constructor from [Uint8List].
+extension VideoPlayerControllerExt on VideoPlayerController {
+  /// Creates a [VideoPlayerController] from the provided [bytes].
+  static FutureOr<VideoPlayerController> bytes(
+    Uint8List bytes, {
+    String? checksum,
+    VideoPlayerOptions? videoPlayerOptions,
+  }) {
+    final blob = web.Blob(
+      [bytes.toJS].toJS,
+      web.BlobPropertyBag(type: 'video/mp4'),
+    );
+
+    final String url = web.URL.createObjectURL(blob);
+    return VideoPlayerController.networkUrl(
+      Uri.parse(url),
+      videoPlayerOptions: videoPlayerOptions,
+    );
+  }
+}


### PR DESCRIPTION
## Synopsis

Currently `VideoPlayerController` is unable to be created from bytes. That's a limitation coming from `video_player` package.




## Solution

Workaround is create our own `bytes()` CTOR.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
