### PR TITLE
Add described logs regarding `_shouldRefresh()` in `AuthService` for `refreshSession`

### DIFF
--- a/lib/domain/service/auth.dart
+++ b/lib/domain/service/auth.dart
@@ -774,12 +774,12 @@ class AuthService extends DisposableService {
 
         if (isLocked) {
           Log.debug(
-            'refreshSession($userId |-> $attempt): acquired the lock, while it was locked -> should refresh: ${_shouldRefresh(oldCreds)}',
+            'refreshSession($userId |-> $attempt): acquired the lock, while it was locked -> should refresh: ${_shouldRefresh(oldCreds)} (comparing oldCreds(${oldCreds?.access.expireAt.toUtc()}).subtract($_accessTokenMinTtl) = ${oldCreds?.access.expireAt.toUtc().subtract(_accessTokenMinTtl)} vs now(${PreciseDateTime.now().toUtc()}))',
             '$runtimeType',
           );
         } else {
           Log.debug(
-            'refreshSession($userId |-> $attempt): acquired the lock, while it was unlocked -> should refresh: ${_shouldRefresh(oldCreds)}',
+            'refreshSession($userId |-> $attempt): acquired the lock, while it was unlocked -> should refresh: ${_shouldRefresh(oldCreds)} (comparing oldCreds(${oldCreds?.access.expireAt.toUtc()}).subtract($_accessTokenMinTtl) = ${oldCreds?.access.expireAt.toUtc().subtract(_accessTokenMinTtl)} vs now(${PreciseDateTime.now().toUtc()}))',
             '$runtimeType',
           );
         }
@@ -1078,6 +1078,7 @@ class AuthService extends DisposableService {
     final Credentials? creds = credentials ?? this.credentials.value;
 
     return creds?.access.expireAt
+            .toUtc()
             .subtract(_accessTokenMinTtl)
             .isBefore(PreciseDateTime.now().toUtc()) ??
         false;

--- a/lib/util/log.dart
+++ b/lib/util/log.dart
@@ -137,7 +137,7 @@ class Log {
         return;
       }
 
-      final DateTime at = DateTime.now();
+      final DateTime at = DateTime.now().toUtc();
 
       // Fixes `setState() or markNeedsBuild() called during build`.
       SchedulerBinding.instance.addPostFrameCallback((_) {


### PR DESCRIPTION
## Synopsis

`refreshSession` might pass a required session refreshment due to `_shouldRefresh` returning `false` despite clear need for refresh:
```
access: AccessToken(secret: ***, expireAt: 2025-09-05 19:37:32.000Z)
[17:40:01.0348] [debug] [AuthService] refreshSession -> false
```




## Solution

This PR adds logs to determine the reason as to why this `_shouldRefresh()` check has failed.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
