### PR TITLE
Forwarded messages can't be selected via double click and there's no Copy text option #1271

### DIFF
--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -812,16 +812,15 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
   /// Returns rounded rectangle of a [child] representing a message box.
   Widget _rounded(BuildContext context, Widget Function(bool) builder) {
     final style = Theme.of(context).style;
+    final ChatItem? note = widget.note.value?.value;
+    String? copyable = _text.values.where((e) => e.text != null).firstOrNull?.text;
 
-    final ChatItem? item = widget.note.value?.value;
-
-    String? copyable;
-    if (item is ChatMessage) {
-      copyable = item.text?.val;
+    if (note is ChatMessage) {
+      copyable = note.text?.val;
     }
 
     final Iterable<LastChatRead>? reads = widget.chat.value?.lastReads.where(
-      (e) => e.at.val.isAfter(_at.val) && e.memberId != widget.authorId,
+          (e) => e.at.val.isAfter(_at.val) && e.memberId != widget.authorId,
     );
 
     const int maxAvatars = 5;
@@ -842,7 +841,7 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 1),
             child: FutureOrBuilder<RxUser?>(
-              key: Key('${item?.id}_4_${m.memberId}'),
+              key: Key('${note?.id}_4_${m.memberId}'),
               futureOr: () => widget.getUser?.call(m.memberId),
               builder: (context, member) {
                 return Tooltip(


### PR DESCRIPTION
Resolves #1271 




## Synopsis

Text inside forwarded messages can be selected, but only manually by dragging the cursor. Double clicking on forwarded messages can't select the text. And clicking RMB doesn't display Copy text option, making impossible for the selected text to be copied this way.




## Solution

- Double-clicking text selection works.
- Check the context popup menu item display conditions.




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
