### PR TITLE
Keep сhat scroll position when leaving and re-entering it #471

### DIFF
--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -98,6 +98,13 @@ import 'view.dart';
 
 export 'view.dart';
 
+class _ChatScrollPosition {
+  final ChatItemId? itemId;
+  final double itemOffset;
+
+  _ChatScrollPosition({this.itemId, this.itemOffset = 0});
+}
+
 /// Controller of the [Routes.chats] page.
 class ChatController extends GetxController {
   ChatController(
@@ -435,6 +442,8 @@ class ChatController extends GetxController {
   /// if any.
   ChatContactId? get _contactId => user?.user.value.contacts.firstOrNull?.id;
 
+  static final Map<String, _ChatScrollPosition> _scrollPositions = {};
+
   @override
   void onInit() {
     if (PlatformUtils.isMobile && !PlatformUtils.isWeb) {
@@ -591,6 +600,69 @@ class ChatController extends GetxController {
     }
 
     super.onReady();
+  }
+
+  void _saveCurrentScrollPosition() {
+    if (_lastVisibleItem != null && elements.isNotEmpty) {
+      final element = elements.values.elementAt(_lastVisibleItem!.index);
+
+      if (element is ChatMessageElement ||
+          element is ChatCallElement ||
+          element is ChatInfoElement ||
+          element is ChatForwardElement) {
+        ChatItemId? itemId;
+
+        if (element is ChatMessageElement) {
+          itemId = element.item.value.id;
+        } else if (element is ChatCallElement) {
+          itemId = element.item.value.id;
+        } else if (element is ChatInfoElement) {
+          itemId = element.item.value.id;
+        } else if (element is ChatForwardElement) {
+          itemId = element.forwards.first.value.id;
+        }
+
+        if (itemId != null) {
+          _scrollPositions[id.val] = _ChatScrollPosition(
+            itemId: itemId,
+            itemOffset: _lastVisibleItem!.offset,
+          );
+        }
+      }
+    }
+  }
+
+  void _restoreScrollPosition() {
+    final savedPosition = _scrollPositions[id.val];
+
+    if (savedPosition?.itemId == null || !status.value.isSuccess) {
+      return;
+    }
+
+    int itemIndex = -1;
+
+    for (int i = 0; i < elements.length; i++) {
+      final element = elements.values.elementAt(i);
+
+      if ((element is ChatMessageElement &&
+              element.item.value.id == savedPosition?.itemId) ||
+          (element is ChatCallElement &&
+              element.item.value.id == savedPosition?.itemId) ||
+          (element is ChatInfoElement &&
+              element.item.value.id == savedPosition?.itemId) ||
+          (element is ChatForwardElement &&
+              element.forwards.any(
+                (f) => f.value.id == savedPosition?.itemId,
+              ))) {
+        itemIndex = i;
+        break;
+      }
+    }
+
+    if (itemIndex >= 0 && savedPosition != null) {
+      initIndex = itemIndex;
+      initOffset = savedPosition.itemOffset;
+    }
   }
 
   @override
@@ -1058,6 +1130,10 @@ class ChatController extends GetxController {
 
         status.value = RxStatus.success();
 
+        if (_lastSeenItem.value != null) {
+          readChat(_lastSeenItem.value);
+        }
+
         if (_bottomLoader != null) {
           showLoaders.value = false;
 
@@ -1073,6 +1149,8 @@ class ChatController extends GetxController {
         if (_lastSeenItem.value != null) {
           readChat(_lastSeenItem.value);
         }
+
+        _restoreScrollPosition();
       }
 
       SchedulerBinding.instance.addPostFrameCallback((_) {
@@ -2092,6 +2170,7 @@ class ChatController extends GetxController {
       _updateSticky();
       _updateFabStates();
       _loadMessages();
+      _saveCurrentScrollPosition();
     }
   }
 


### PR DESCRIPTION
Resolves #471

## Synopsis

Messenger [Gapopa](https://gapopa.net). Chat page. Scroll in chat.

To do: save scroll position when re-entering chat.

For example: open chat and scroll, after that go to any otherr page or a different chat, then go back to the chat and make sure that the scroll stays exactly the same as it was when leaving the chat.

## Solution
Save the ID and `offset` of the top/bottom element in chat and reuse it. There should be no persist, since remembering the position is not required.

## Checklist
* Created PR:
  
  * [x]  In [draft mode](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
  * [x]  Name contains issue reference
  * [ ]  Has type and `k::` labels applied
* Before [review](https://help.github.com/en/articles/reviewing-changes-in-pull-requests):
  
  * [ ]  Documentation is updated (if required)
  * [ ]  Tests are updated (if required)
  * [ ]  Changes conform [code style](https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style)
  * [ ]  [CHANGELOG entry](https://github.com/team113/messenger/blob/main/CHANGELOG.md) is added (if required)
  * [ ]  FCM (final commit message) is posted or updated
  * [ ]  [Draft mode](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests) is removed
* [ ]  [Review](https://help.github.com/en/articles/reviewing-changes-in-pull-requests) is completed and changes are approved
  
  * [ ]  FCM (final commit message) is approved
* Before merge:
  
  * [ ]  Milestone is set
  * [ ]  PR's name and description are correct and up-to-date
  * [ ]  All temporary labels are removed

