### PR TITLE
Display "Deleted account" label in interfaces

### DIFF
--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -587,6 +587,7 @@ label_current_account = Current account
 label_current_password = Current password
 label_days_short = {$days} d
 label_delete_account = Delete account
+label_deleted_account = Deleted account
 label_delete_chat = Delete chat(s)
 label_delete_chats = Delete chat(s)
 label_delete_email = Delete E-mail

--- a/assets/l10n/es-ES.ftl
+++ b/assets/l10n/es-ES.ftl
@@ -588,6 +588,7 @@ label_current_account = Cuenta corriente
 label_current_password = Contrseña actual
 label_days_short = {$days} d
 label_delete_account = Eliminar la cuenta
+label_deleted_account = Cuenta eliminada
 label_delete_chat = Eliminar los chat(s)
 label_delete_chats = Eliminar los chat(s)
 label_delete_email = Eliminar el e-mail

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -600,6 +600,7 @@ label_current_account = Текущий аккаунт
 label_current_password = Текущий пароль
 label_days_short = {$days} д
 label_delete_account = Удалить аккаунт
+label_deleted_account = Удалённый аккаунт
 label_delete_chat = Удалить чат(ы)
 label_delete_chats = Удалить чат(ы)
 label_delete_email = Удалить E-mail

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -2553,9 +2553,12 @@ extension ChatViewExt on Chat {
         break;
 
       case ChatKind.dialog:
-        final String? name =
-            users.firstWhereOrNull((u) => u.id != me)?.title ??
-            members.firstWhereOrNull((e) => e.user.id != me)?.user.title;
+        final User? user =
+            users.firstWhereOrNull((u) => u.id != me)?.user.value ??
+            members.firstWhereOrNull((e) => e.user.id != me)?.user;
+
+        final String? name = user?.getTitle();
+
         if (name != null) {
           title = name;
         }
@@ -2566,9 +2569,9 @@ extension ChatViewExt on Chat {
           final Iterable<String> names;
 
           if (users.length < membersCount && users.length < 3) {
-            names = members.take(3).map((e) => e.user.title);
+            names = members.take(3).map((e) => e.user.getTitle());
           } else {
-            names = users.take(3).map((e) => e.title);
+            names = users.take(3).map((e) => e.user.value.getTitle());
           }
 
           title = names.join('comma_space'.l10n);

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -2571,7 +2571,7 @@ extension ChatViewExt on Chat {
           if (users.length < membersCount && users.length < 3) {
             names = members.take(3).map((e) => e.user.getTitle());
           } else {
-            names = users.take(3).map((e) => e.user.value.getTitle());
+            names = users.take(3).map((e) => e.getTitle());
           }
 
           title = names.join('comma_space'.l10n);

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -652,6 +652,9 @@ extension UserViewExt on User {
     }
   }
 
+  /// Returns the string representation of this [User] to display as a title.
+  String getTitle() => isDeleted ? 'label_deleted_account'.l10n : title;
+
   /// Returns the string representation of this [User] to display as a subtitle.
   String? getSubtitle([PreciseDateTime? lastSeen]) {
     switch (presence) {
@@ -684,6 +687,10 @@ extension UserViewExt on User {
         return null;
     }
   }
+}
+
+extension UserExt on RxUser{
+  String getTitle() => contact.value?.contact.value.name.val ?? user.value.getTitle();
 }
 
 /// Extension adding an ability to get text represented indication of how long

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -135,7 +135,7 @@ class UserView extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
               child: Text(
-                c.contact.value?.contact.value.name.val ?? c.name.text,
+                c.contact.value?.contact.value.name.val ?? c.name,
                 style: style.fonts.larger.regular.onBackground,
                 textAlign: TextAlign.center,
               ),

--- a/lib/ui/page/home/widget/avatar.dart
+++ b/lib/ui/page/home/widget/avatar.dart
@@ -34,6 +34,7 @@ import '/domain/repository/contact.dart';
 import '/domain/repository/user.dart';
 import '/themes.dart';
 import '/ui/page/home/page/chat/controller.dart';
+import '/ui/page/home/page/user/controller.dart';
 import '/ui/page/home/widget/retry_image.dart';
 import '/ui/widget/svg/svg.dart';
 
@@ -178,7 +179,7 @@ class AvatarWidget extends StatelessWidget {
   }) => AvatarWidget(
     key: key,
     avatar: user?.avatar,
-    title: user?.title,
+    title: user?.getTitle(),
     color: user?.num.val.sum(),
     radius: radius,
     opacity: opacity,

--- a/lib/ui/page/home/widget/contact_tile.dart
+++ b/lib/ui/page/home/widget/contact_tile.dart
@@ -25,6 +25,7 @@ import '/domain/repository/contact.dart';
 import '/domain/repository/user.dart';
 import '/l10n/l10n.dart';
 import '/themes.dart';
+import '/ui/page/home/page/user/controller.dart';
 import '/ui/page/home/tab/chats/widget/hovered_ink.dart';
 import '/ui/page/home/widget/avatar.dart';
 import '/ui/widget/context_menu/menu.dart';
@@ -215,7 +216,7 @@ class ContactTile extends StatelessWidget {
 
     return Text(
       contact?.name.val ??
-          user?.title ??
+          user?.getTitle() ??
           myUser?.name?.val ??
           myUser?.num.toString() ??
           'dot'.l10n,


### PR DESCRIPTION
Resolves #1419

## Synopsis

Deleted users were not visually distinguished in the chat interface. Their nickname was still displayed in the chat list, chat header, user profile, and group participants list.

## Solution

Implement a universal getTitle extension method in the UI layer that checks the isDeleted flag and, if true, substitutes the appropriate localized string instead of showing the user’s nickname.


## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed
