### PR TITLE
Trim `UserName`, `UserLogin` and some other scalars when constructing (#1443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,16 @@ All user visible changes to this project will be documented in this file. This p
     - Chat page:
         - Redesigned messages selection. ([#1416], [#1410])
 
+### Fixed
+
+- UI:
+    - Login modal:
+        - Meaningless formatting errors when leading/trailing spaces are present. ([#1448], [#1443])
+
 [#1410]: /../../issues/1410
 [#1416]: /../../pull/1416
+[#1443]: /../../issues/1443
+[#1448]: /../../issues/1448
 
 
 

--- a/lib/domain/model/chat.dart
+++ b/lib/domain/model/chat.dart
@@ -466,7 +466,7 @@ class ChatId extends NewType<String> implements Comparable<ChatId> {
 class ChatName extends NewType<String> {
   const ChatName._(super.val);
 
-  ChatName(String val) : super(val) {
+  ChatName(String value) : super(value.trim()) {
     if (!_regExp.hasMatch(val)) {
       throw FormatException('Does not match validation RegExp: `$val`');
     }

--- a/lib/domain/model/user.dart
+++ b/lib/domain/model/user.dart
@@ -234,7 +234,7 @@ class UserNum extends NewType<String> {
 class UserLogin extends NewType<String> {
   const UserLogin._(super.val);
 
-  UserLogin(String val) : super(val) {
+  UserLogin(String value) : super(value.trim().toLowerCase()) {
     if (val.isNumericOnly) {
       throw const FormatException('Can not contain only numbers');
     } else if (!_regExp.hasMatch(val)) {
@@ -271,7 +271,7 @@ class UserLogin extends NewType<String> {
 class UserName extends NewType<String> {
   const UserName._(super.val);
 
-  UserName(String val) : super(val) {
+  UserName(String value) : super(value.trim()) {
     if (!_regExp.hasMatch(val)) {
       throw FormatException('Does not match validation RegExp: `$val`');
     }
@@ -344,7 +344,7 @@ class UserPassword extends NewType<String> {
 class UserEmail extends NewType<String> {
   const UserEmail._(super.val);
 
-  UserEmail(String val) : super(val) {
+  UserEmail(String value) : super(value.trim()) {
     if (!EmailValidator.validate(val)) {
       throw FormatException('Does not match validation RegExp: `$val`');
     }
@@ -408,7 +408,7 @@ class UserBio extends NewType<String> {
 class UserPhone extends NewType<String> {
   const UserPhone._(super.val);
 
-  UserPhone(String val) : super(val) {
+  UserPhone(String value) : super(value.trim()) {
     if (!val.startsWith('+')) {
       throw const FormatException('Must start with plus');
     }
@@ -487,7 +487,7 @@ class ChatDirectLink {
 class ChatDirectLinkSlug extends NewType<String> {
   const ChatDirectLinkSlug._(super.val);
 
-  ChatDirectLinkSlug(String val) : super(val) {
+  ChatDirectLinkSlug(String value) : super(value.trim()) {
     if (val.length > 100) {
       throw const FormatException('Must contain no more than 100 characters');
     } else if (val.isEmpty) {

--- a/lib/ui/page/home/accounts_switcher/controller.dart
+++ b/lib/ui/page/home/accounts_switcher/controller.dart
@@ -43,7 +43,7 @@ class AccountsSwitcherController extends GetxController {
     onFocus: (s) async {
       s.error.value = null;
 
-      if (s.text.isNotEmpty) {
+      if (s.text.trim().isNotEmpty) {
         try {
           UserTextStatus(s.text);
         } on FormatException catch (_) {

--- a/lib/ui/page/home/introduction/controller.dart
+++ b/lib/ui/page/home/introduction/controller.dart
@@ -58,7 +58,7 @@ class IntroductionController extends GetxController {
     onFocus: (s) async {
       s.error.value = null;
 
-      if (s.text.isNotEmpty) {
+      if (s.text.trim().isNotEmpty) {
         try {
           UserName(s.text);
         } on FormatException catch (_) {

--- a/lib/ui/page/home/page/my_profile/add_email/controller.dart
+++ b/lib/ui/page/home/page/my_profile/add_email/controller.dart
@@ -55,7 +55,7 @@ class AddEmailController extends GetxController {
   /// [TextFieldState] for inputting the [email].
   late final TextFieldState emailField = TextFieldState(
     onFocus: (s) {
-      if (s.text.isNotEmpty) {
+      if (s.text.trim().isNotEmpty) {
         try {
           email = UserEmail(s.text);
 
@@ -69,7 +69,7 @@ class AddEmailController extends GetxController {
       }
     },
     onSubmitted: (s) async {
-      if (s.text.isEmpty ||
+      if (s.text.trim().isEmpty ||
           (s.error.value != null && s.resubmitOnError.isFalse)) {
         return;
       }
@@ -124,7 +124,7 @@ class AddEmailController extends GetxController {
   void onInit() {
     code = TextFieldState(
       onFocus: (s) {
-        if (s.text.isNotEmpty) {
+        if (s.text.trim().isNotEmpty) {
           try {
             ConfirmationCode(s.text);
           } on FormatException {

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -146,7 +146,7 @@ class MyProfileController extends GetxController {
     onFocus: (s) async {
       s.error.value = null;
 
-      if (s.text.isNotEmpty) {
+      if (s.text.trim().isNotEmpty) {
         try {
           UserName(s.text);
         } on FormatException catch (_) {
@@ -171,7 +171,7 @@ class MyProfileController extends GetxController {
     onFocus: (s) async {
       s.error.value = null;
 
-      if (s.text.isNotEmpty) {
+      if (s.text.trim().isNotEmpty) {
         try {
           UserLogin(s.text.toLowerCase());
         } on FormatException catch (_) {
@@ -198,7 +198,7 @@ class MyProfileController extends GetxController {
     onFocus: (s) async {
       s.error.value = null;
 
-      if (s.text.isNotEmpty) {
+      if (s.text.trim().isNotEmpty) {
         try {
           UserBio(s.text);
         } on FormatException catch (_) {
@@ -223,7 +223,7 @@ class MyProfileController extends GetxController {
     onFocus: (s) async {
       s.error.value = null;
 
-      if (s.text.isNotEmpty) {
+      if (s.text.trim().isNotEmpty) {
         try {
           UserTextStatus(s.text);
         } on FormatException catch (_) {
@@ -383,7 +383,7 @@ class MyProfileController extends GetxController {
     phone = TextFieldState(
       approvable: true,
       onFocus: (s) {
-        if (s.text.isNotEmpty) {
+        if (s.text.trim().isNotEmpty) {
           try {
             final phone = UserPhone(s.text.replaceAll(' ', ''));
 
@@ -397,7 +397,7 @@ class MyProfileController extends GetxController {
         }
       },
       onSubmitted: (s) async {
-        if (s.text.isEmpty ||
+        if (s.text.trim().isEmpty ||
             (s.error.value != null && s.resubmitOnError.isFalse)) {
           return;
         }
@@ -439,7 +439,7 @@ class MyProfileController extends GetxController {
     email = TextFieldState(
       approvable: true,
       onFocus: (s) {
-        if (s.text.isNotEmpty) {
+        if (s.text.trim().isNotEmpty) {
           try {
             final email = UserEmail(s.text);
 
@@ -453,7 +453,7 @@ class MyProfileController extends GetxController {
         }
       },
       onSubmitted: (s) async {
-        if (s.text.isEmpty ||
+        if (s.text.trim().isEmpty ||
             (s.error.value != null && s.resubmitOnError.isFalse)) {
           return;
         }

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -104,7 +104,7 @@ class UserController extends GetxController {
     onFocus: (s) {
       s.error.value = null;
 
-      if (s.text.isNotEmpty) {
+      if (s.text.trim().isNotEmpty) {
         try {
           BlocklistReason(s.text);
         } on FormatException {
@@ -195,7 +195,7 @@ class UserController extends GetxController {
   void onInit() {
     name = TextFieldState(
       onFocus: (s) {
-        if (s.text.isNotEmpty) {
+        if (s.text.trim().isNotEmpty) {
           try {
             UserName(s.text);
           } on FormatException {

--- a/lib/ui/page/home/tab/menu/accounts/controller.dart
+++ b/lib/ui/page/home/tab/menu/accounts/controller.dart
@@ -170,7 +170,7 @@ class AccountsController extends GetxController {
     email = TextFieldState(
       onFocus: (s) {
         try {
-          if (s.text.isNotEmpty) {
+          if (s.text.trim().isNotEmpty) {
             UserEmail(s.text.toLowerCase());
           }
 

--- a/lib/ui/page/home/widget/direct_link.dart
+++ b/lib/ui/page/home/widget/direct_link.dart
@@ -73,7 +73,7 @@ class _DirectLinkFieldState extends State<DirectLinkField> {
       text: widget.link?.slug.val,
       submitted: widget.link != null,
       onFocus: (s) {
-        if (s.text.isNotEmpty) {
+        if (s.text.trim().isNotEmpty) {
           try {
             ChatDirectLinkSlug(s.text);
           } on FormatException {

--- a/lib/ui/page/login/controller.dart
+++ b/lib/ui/page/login/controller.dart
@@ -262,7 +262,7 @@ class LoginController extends GetxController {
 
     email = TextFieldState(
       onFocus: (s) {
-        if (s.text.isNotEmpty) {
+        if (s.text.trim().isNotEmpty) {
           try {
             UserEmail(s.text.toLowerCase());
           } on FormatException {


### PR DESCRIPTION
Resolves #1443




## Synopsis

User can input to the name field something like: "Gabriel " <- and because of the space at end there will be an error of formatting errors.




## Solution

Trim the scalars.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
