### PR TITLE
Prevent displaying read status on received ChatForwardWidget

### DIFF
--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -229,21 +229,21 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
   /// [User].
   bool get _isRead {
     final Chat? chat = widget.chat.value;
-    if (chat == null) {
+    if (chat == null || !_fromMe) {
       return false;
     }
 
-    if (_fromMe) {
-      return chat.isRead(widget.forwards.first.value, widget.me, chat.members);
-    } else {
-      return chat.isReadBy(widget.forwards.first.value, widget.me);
-    }
+    // if (_fromMe) {
+    return chat.isRead(widget.forwards.first.value, widget.me, chat.members);
+    // } else {
+    //   return chat.isReadBy(widget.forwards.first.value, widget.me);
+    // }
   }
 
   /// Indicates whether this [ChatItem] was read only partially.
   bool get _isHalfRead {
     final Chat? chat = widget.chat.value;
-    if (chat == null) {
+    if (chat == null || !_fromMe) {
       return false;
     }
 
@@ -382,14 +382,15 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                                 'MessageStatus_${widget.note.value?.value.id ?? widget.forwards.firstOrNull?.value.id}',
                               ),
                               at: _at,
-                              status: SendingStatus.sent,
-                              read: _isRead,
-                              halfRead: _isHalfRead,
-                              delivered:
-                                  widget.chat.value?.lastDelivery.isBefore(
-                                    _at,
-                                  ) ==
-                                  false,
+                              status: _fromMe ? SendingStatus.sent : null,
+                              read: _fromMe ? _isRead : false,
+                              halfRead: _fromMe ? _isHalfRead : false,
+                              delivered: _fromMe
+                                  ? (widget.chat.value?.lastDelivery.isBefore(
+                                          _at,
+                                        ) ==
+                                        false)
+                                  : false,
                             ),
                           ],
                         ),


### PR DESCRIPTION
### Summary

Hide sending/read/halfRead/delivered indicators for forwarded messages not sent by the current user, so the UI doesn’t display my status on someone else’s forwarded messages.
**Additionally**, the _isRead getter logic was fixed to ensure proper status calculation for forwarded messages.

### Context / Problem

Forwarded messages that came from other users were displayed as if they had my own message status (sent/read/half-read/delivered).
This was misleading — it made it look like I was the one who sent them.

_isRead logic was also incorrect for non-my messages.
If chat is null or the message is not from me, it returns **false**.

### Solution

**Updated** _isRead code:
`if (chat == null || !_fromMe) {
    return false;
  }`

**Statuses** are now shown only **if _fromMe == true:**

```
If _fromMe == true: normal status behavior (sent, read, halfRead, delivered).

If _fromMe == false:
status: null, read: false, halfRead: false, delivered: false.
```