### PR TITLE
Fix caret in `MessageFieldView` not moving when pressing up/down keys (#1493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.7.0] · 2025-??-??
+[0.7.0]: /../../tree/v0.7.0
+
+[Diff](/../../compare/v0.6.8...v0.7.0) | [Milestone](/../../milestone/53)
+
+### Fixed
+
+- UI:
+    - Chat page:
+        - Inability to move caret in message field up and down. ([#1494], [#1493])
+
+[#1493]: /../../issues/1493
+[#1494]: /../../pull/1494
+
+
+
+
 ## [0.6.8] · 2025-11-03
 [0.6.8]: /../../tree/v0.6.8
 

--- a/lib/ui/page/home/page/chat/message_field/controller.dart
+++ b/lib/ui/page/home/page/chat/message_field/controller.dart
@@ -214,9 +214,12 @@ class MessageFieldController extends GetxController {
 
   /// Handles the new lines for the provided [KeyEvent] in the [field].
   static KeyEventResult handleNewLines(KeyEvent e, TextFieldState field) {
-    if ((e.logicalKey == LogicalKeyboardKey.enter ||
-            e.logicalKey == LogicalKeyboardKey.numpadEnter) &&
-        e is KeyDownEvent) {
+    if (e is! KeyDownEvent) {
+      return KeyEventResult.ignored;
+    }
+
+    if (e.logicalKey == LogicalKeyboardKey.enter ||
+        e.logicalKey == LogicalKeyboardKey.numpadEnter) {
       final Set<PhysicalKeyboardKey> pressed =
           HardwareKeyboard.instance.physicalKeysPressed;
 

--- a/lib/ui/page/home/widget/scroll_keyboard_handler.dart
+++ b/lib/ui/page/home/widget/scroll_keyboard_handler.dart
@@ -188,14 +188,16 @@ class _ScrollKeyboardHandlerState extends State<ScrollKeyboardHandler> {
       case LogicalKeyboardKey.arrowUp:
         if (HardwareKeyboard.instance.isAltPressed) {
           _scrollPageUp(quick: quick);
+          return true;
         }
-        return true;
+        break;
 
       case LogicalKeyboardKey.arrowDown:
         if (HardwareKeyboard.instance.isAltPressed) {
           _scrollPageDown(quick: quick);
+          return true;
         }
-        return true;
+        break;
     }
 
     return false;


### PR DESCRIPTION
Resolves #1493




## Synopsis

Caret doesn't move in the `MessageFieldView` when pressing arrows up and down.




## Solution

This PR fixes that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
