### PR TITLE
Fix AndroidManifest `android:launchMode` for correctly use `FilePicke…

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,7 @@ def hasProperties = propertiesFile.exists()
 android {
     namespace 'com.team113.messenger'
 
-    ndkVersion "27.0.12077973"
+    ndkVersion = "28.2.13676358"
     compileSdkVersion 36
 
     compileOptions {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
             android:exported="true"
             android:fitsSystemWindows="true"
             android:hardwareAccelerated="true"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTop"
             android:name=".MainActivity"
             android:showWhenLocked="true"
             android:theme="@style/LaunchTheme"


### PR DESCRIPTION
## Synopsis

On the Android platform, it was not possible to add media to the chat from the gallery




## Solution

Update `AndroidMainfest.xml`  change    `android:launchMode="singleInstance"` to `android:launchMode="singleTop"`

Additionally:
- bump `ndkVersion` to "28.2.13676358" in `android\build.gradle`




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
