### PR TITLE
Refactor chats tab now scrolls to top, when tab pressed during opened (#1513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All user visible changes to this project will be documented in this file. This p
     - Chats tab:
         - Redesigned chats appearing animation. ([#1514])
         - Redesigned unread messages counter. ([#1512], [#1507])
+        - Added scroll-to-top behavior when tapping the Chats tab button on the navigation bar. ([#1520], [#1513])
 
 ### Fixed
 
@@ -29,6 +30,8 @@ All user visible changes to this project will be documented in this file. This p
 [#1507]: /../../issues/1507
 [#1512]: /../../pull/1512
 [#1514]: /../../pull/1514
+[#1513]: /../../issues/1513
+[#1520]: /../../pull/1520
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ All user visible changes to this project will be documented in this file. This p
 [#1504]: /../../pull/1504
 [#1507]: /../../issues/1507
 [#1512]: /../../pull/1512
-[#1514]: /../../pull/1514
 [#1513]: /../../issues/1513
+[#1514]: /../../pull/1514
 [#1520]: /../../pull/1520
 
 

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -82,8 +82,9 @@ class ChatsTabController extends GetxController {
     this._userService,
     this._contactService,
     this._myUserService,
-    this._sessionService,
-  );
+    this._sessionService, {
+    required this.chatsController,
+  });
 
   /// Reactive list of sorted [Chat]s.
   final RxList<ChatEntry> chats = RxList();
@@ -101,7 +102,7 @@ class ChatsTabController extends GetxController {
   final RxBool archivedOnly = RxBool(false);
 
   /// [ScrollController] to pass to a [Scrollbar] of recent [RxChat]s.
-  final ScrollController chatsController = ScrollController();
+  final ScrollController chatsController;
 
   /// [ScrollController] to pass to a [Scrollbar] of archived [RxChat]s.
   final ScrollController archiveController = ScrollController();

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -50,183 +50,11 @@ import 'widget/recent_chat.dart';
 import 'widget/search_user_tile.dart';
 
 /// View of the [HomeTab.chats] tab.
-class ChatsTabView extends StatefulWidget {
-  const ChatsTabView({super.key});
+class ChatsTabView extends StatelessWidget {
+  const ChatsTabView({super.key, required this.chatsController});
 
-  @override
-  State<ChatsTabView> createState() => _ChatsTabViewState();
-
-  /// Builds a [BottomPaddedRow] for selecting the [Chat]s.
-  static Widget selectingBuilder(BuildContext context, ChatsTabController c) {
-    final style = Theme.of(context).style;
-
-    return BottomPaddedRow(
-      spacer: (_) {
-        return Container(
-          decoration: BoxDecoration(color: style.colors.onBackgroundOpacity13),
-          width: 1,
-          height: 24,
-        );
-      },
-      children: [
-        WidgetButton(
-          onPressed: c.readAll,
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
-              child: Text(
-                'btn_read_all'.l10n,
-                style: style.fonts.normal.regular.primary,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ),
-        ),
-        WidgetButton(
-          onPressed: c.selectedChats.isEmpty
-              ? null
-              : () => _archiveChats(context, c),
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
-              child: Text(
-                c.archivedOnly.value ? 'btn_unhide'.l10n : 'btn_hide'.l10n,
-                style: style.fonts.normal.regular.primary,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ),
-        ),
-        WidgetButton(
-          key: const Key('DeleteChatsButton'),
-          onPressed: c.selectedChats.isEmpty
-              ? null
-              : () => _hideChats(context, c),
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
-              child: Text(
-                'btn_delete'.l10n,
-                style: style.fonts.normal.regular.danger,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  /// Builds a [BottomPaddedRow] for creating a [Chat]-group.
-  static Widget createGroupBuilder(BuildContext context, ChatsTabController c) {
-    final style = Theme.of(context).style;
-
-    return BottomPaddedRow(
-      spacer: (_) {
-        return Container(
-          decoration: BoxDecoration(color: style.colors.onBackgroundOpacity13),
-          width: 1,
-          height: 24,
-        );
-      },
-      children: [
-        WidgetButton(
-          onPressed: c.closeGroupCreating,
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
-              child: Text(
-                'btn_cancel'.l10n,
-                style: style.fonts.normal.regular.primary,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ),
-        ),
-        WidgetButton(
-          onPressed: c.creatingStatus.value.isEmpty ? c.createGroup : null,
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
-              child: Text(
-                'btn_create'.l10n,
-                style: style.fonts.normal.regular.primary,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  /// Opens a popup window to confirm archiving or unarchiving the selected
-  /// chats.
-  static Future<void> _archiveChats(
-    BuildContext context,
-    ChatsTabController c,
-  ) async {
-    final bool? result = await MessagePopup.alert(
-      c.archivedOnly.value ? 'label_show_chats'.l10n : 'label_hide_chats'.l10n,
-      description: [
-        TextSpan(
-          text: c.archivedOnly.value
-              ? 'label_show_chats_modal_description'.l10n
-              : 'label_hide_chats_modal_description'.l10n,
-        ),
-      ],
-      button: (context) => MessagePopup.primaryButton(
-        context,
-        label: c.archivedOnly.value ? 'btn_unhide'.l10n : 'btn_hide'.l10n,
-        icon: c.archivedOnly.value
-            ? SvgIcons.visibleOffWhite
-            : SvgIcons.visibleOnWhite,
-      ),
-    );
-
-    if (result == true) {
-      await c.archiveChats(!c.archivedOnly.value);
-    }
-  }
-
-  /// Opens a confirmation popup hiding the selected chats.
-  static Future<void> _hideChats(
-    BuildContext context,
-    ChatsTabController c,
-  ) async {
-    final bool? result = await MessagePopup.alert(
-      'label_delete_chats'.l10n,
-      description: [TextSpan(text: 'label_to_restore_chats_use_search'.l10n)],
-      button: MessagePopup.deleteButton,
-    );
-
-    if (result == true) {
-      await c.hideChats();
-    }
-  }
-}
-
-class _ChatsTabViewState extends State<ChatsTabView> {
-  @override
-  void initState() {
-    Get.replace<ChatsTabController>(
-      ChatsTabController(
-        Get.find(),
-        Get.find(),
-        Get.find(),
-        Get.find(),
-        Get.find(),
-        Get.find(),
-        Get.find(),
-      ),
-    );
-    super.initState();
-  }
+  /// [ScrollController] for the chats list
+  final ScrollController chatsController;
 
   @override
   Widget build(BuildContext context) {
@@ -234,7 +62,16 @@ class _ChatsTabViewState extends State<ChatsTabView> {
 
     return GetBuilder(
       key: const Key('ChatsTab'),
-      init: Get.find<ChatsTabController>(),
+      init: ChatsTabController(
+        Get.find(),
+        Get.find(),
+        Get.find(),
+        Get.find(),
+        Get.find(),
+        Get.find(),
+        Get.find(),
+        chatsController: chatsController,
+      ),
       builder: (ChatsTabController c) {
         return Stack(
           children: [
@@ -1240,5 +1077,159 @@ class _ChatsTabViewState extends State<ChatsTabView> {
         ),
       ),
     );
+  }
+
+  /// Builds a [BottomPaddedRow] for selecting the [Chat]s.
+  static Widget selectingBuilder(BuildContext context, ChatsTabController c) {
+    final style = Theme.of(context).style;
+
+    return BottomPaddedRow(
+      spacer: (_) {
+        return Container(
+          decoration: BoxDecoration(color: style.colors.onBackgroundOpacity13),
+          width: 1,
+          height: 24,
+        );
+      },
+      children: [
+        WidgetButton(
+          onPressed: c.readAll,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
+              child: Text(
+                'btn_read_all'.l10n,
+                style: style.fonts.normal.regular.primary,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ),
+        WidgetButton(
+          onPressed: c.selectedChats.isEmpty
+              ? null
+              : () => _archiveChats(context, c),
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
+              child: Text(
+                c.archivedOnly.value ? 'btn_unhide'.l10n : 'btn_hide'.l10n,
+                style: style.fonts.normal.regular.primary,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ),
+        WidgetButton(
+          key: const Key('DeleteChatsButton'),
+          onPressed: c.selectedChats.isEmpty
+              ? null
+              : () => _hideChats(context, c),
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
+              child: Text(
+                'btn_delete'.l10n,
+                style: style.fonts.normal.regular.danger,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Builds a [BottomPaddedRow] for creating a [Chat]-group.
+  static Widget createGroupBuilder(BuildContext context, ChatsTabController c) {
+    final style = Theme.of(context).style;
+
+    return BottomPaddedRow(
+      spacer: (_) {
+        return Container(
+          decoration: BoxDecoration(color: style.colors.onBackgroundOpacity13),
+          width: 1,
+          height: 24,
+        );
+      },
+      children: [
+        WidgetButton(
+          onPressed: c.closeGroupCreating,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
+              child: Text(
+                'btn_cancel'.l10n,
+                style: style.fonts.normal.regular.primary,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ),
+        WidgetButton(
+          onPressed: c.creatingStatus.value.isEmpty ? c.createGroup : null,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(10, 6.5, 10, 6.5),
+              child: Text(
+                'btn_create'.l10n,
+                style: style.fonts.normal.regular.primary,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Opens a popup window to confirm archiving or unarchiving the selected
+  /// chats.
+  static Future<void> _archiveChats(
+    BuildContext context,
+    ChatsTabController c,
+  ) async {
+    final bool? result = await MessagePopup.alert(
+      c.archivedOnly.value ? 'label_show_chats'.l10n : 'label_hide_chats'.l10n,
+      description: [
+        TextSpan(
+          text: c.archivedOnly.value
+              ? 'label_show_chats_modal_description'.l10n
+              : 'label_hide_chats_modal_description'.l10n,
+        ),
+      ],
+      button: (context) => MessagePopup.primaryButton(
+        context,
+        label: c.archivedOnly.value ? 'btn_unhide'.l10n : 'btn_hide'.l10n,
+        icon: c.archivedOnly.value
+            ? SvgIcons.visibleOffWhite
+            : SvgIcons.visibleOnWhite,
+      ),
+    );
+
+    if (result == true) {
+      await c.archiveChats(!c.archivedOnly.value);
+    }
+  }
+
+  /// Opens a confirmation popup hiding the selected chats.
+  static Future<void> _hideChats(
+    BuildContext context,
+    ChatsTabController c,
+  ) async {
+    final bool? result = await MessagePopup.alert(
+      'label_delete_chats'.l10n,
+      description: [TextSpan(text: 'label_to_restore_chats_use_search'.l10n)],
+      button: MessagePopup.deleteButton,
+    );
+
+    if (result == true) {
+      await c.hideChats();
+    }
   }
 }

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -22,7 +22,6 @@ import 'package:flutter/scheduler.dart';
 import 'package:get/get.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-import '../../../util/get.dart';
 import '/domain/model/user.dart';
 import '/routes.dart';
 import '/themes.dart';
@@ -89,6 +88,9 @@ class _HomeViewState extends State<HomeView> {
     'ui',
     autoFinishAfter: const Duration(minutes: 2),
   )..startChild('ready');
+
+  /// We need a [ScrollController] to pass to the chats tab, so that we can scroll to top when reselecting the tab.
+  final ScrollController _chatsScrollController = ScrollController();
 
   @override
   void initState() {
@@ -209,9 +211,13 @@ class _HomeViewState extends State<HomeView> {
                         }
                       },
                       // [KeepAlivePage] used to keep the tabs' states.
-                      children: const [
+                      children: [
                         SizedBox(),
-                        KeepAlivePage(child: ChatsTabView()),
+                        KeepAlivePage(
+                          child: ChatsTabView(
+                            chatsController: _chatsScrollController,
+                          ),
+                        ),
                         KeepAlivePage(child: MenuTabView()),
                       ],
                     ),
@@ -354,12 +360,11 @@ class _HomeViewState extends State<HomeView> {
 
                 /// Scroll to top if the chat tab is reselected.
                 if (router.tab == tabs[i] && router.tab == HomeTab.chats) {
-                  Get.findOrNull<ChatsTabController>()?.chatsController
-                      .animateTo(
-                        0,
-                        duration: Duration(milliseconds: 250),
-                        curve: Curves.easeIn,
-                      );
+                  _chatsScrollController.animateTo(
+                    0,
+                    duration: Duration(milliseconds: 250),
+                    curve: Curves.easeIn,
+                  );
                 }
 
                 c.pages.jumpToPage(tabs[i].index);

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -22,6 +22,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:get/get.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import '../../../util/get.dart';
 import '/domain/model/user.dart';
 import '/routes.dart';
 import '/themes.dart';
@@ -349,6 +350,16 @@ class _HomeViewState extends State<HomeView> {
               onTap: (i) {
                 if (i == 0) {
                   return LinkView.show(context);
+                }
+
+                /// Scroll to top if the chat tab is reselected.
+                if (router.tab == tabs[i] && router.tab == HomeTab.chats) {
+                  Get.findOrNull<ChatsTabController>()?.chatsController
+                      .animateTo(
+                        0,
+                        duration: Duration(milliseconds: 250),
+                        curve: Curves.easeIn,
+                      );
                 }
 
                 c.pages.jumpToPage(tabs[i].index);

--- a/test/widget/chat_hide_test.dart
+++ b/test/widget/chat_hide_test.dart
@@ -414,7 +414,9 @@ void main() async {
     }
 
     await tester.pumpWidget(
-      createWidgetForTesting(child: const ChatsTabView()),
+      createWidgetForTesting(
+        child: ChatsTabView(chatsController: ScrollController()),
+      ),
     );
 
     expect(find.text('chatname'), findsOneWidget);


### PR DESCRIPTION
Resolves #1513 

## Synopsis

Scrolling behavior for the Chats tab when re-selecting the tab button.




## Solution

When the user taps the Chats tab button in the CustomNavigationBar, the Chats list should automatically scroll to the top.



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
