### PR TITLE
fix(iOS): prevent external audio from pausing on cold start [#1224]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ app.*.symbols
 /test/e2e/reports/
 /test_driver/build/
 /test_driver/report.json
+
+# FVM Version Cache
+.fvm/


### PR DESCRIPTION
[#1224 ](https://github.com/team113/messenger/issues/1224)


## Synopsis
On iOS, if the user is playing music (Safari/Apple Music/Spotify) and then opens Gapopa after a cold start, external audio pauses. This happens only on the first launch after the app was fully killed.

Evidence from launch logs:
- before plugins: `AVAudioSessionCategorySoloAmbient`, `otherAudio=true`
- after plugins: `AVAudioSessionCategoryPlayAndRecord`, `otherAudio=false`

This suggests something during startup switches the AVAudioSession to a non-mixing category, which stops other audio.

## Plan / Proposed Solution
Two safe approaches:

**Option A (preferred / clean):**
Update call/WebRTC audio-session handling so it does NOT set `PlayAndRecord` at app launch.
- keep a mixing-friendly session on idle (e.g. `.ambient` + `.mixWithOthers`)
- switch to `PlayAndRecord` only when a call starts
- restore mixing-friendly category when the call ends / is idle

**Option B (app-side mitigation):**
In `AppDelegate` right after `GeneratedPluginRegistrant.register(...)`, restore a mixing-friendly category only if there is no active call in progress (calls can still override when needed).

I’ll attempt Option A first; if it’s not feasible due to plugin behavior, I’ll implement Option B with guardrails so it won’t break call audio.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [ ] Has type and `k::` labels applied
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
