### PR TITLE
Fix status was not updating on `MyProfileView` (#1539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.7.0] · 2025-??-??
+[0.7.0]: /../../tree/v0.7.0
+
+[Diff](/../../compare/v0.6.12...v0.7.0) | [Milestone](/../../milestone/57)
+
+### Fixed
+
+- UI:
+    - Profile page:
+        - Presence status sometimes not being updated. ([#1540], [#1539])
+
+[#1539]: /../../issues/1539
+[#1540]: /../../pull/1540
+
+
+
+
 ## [0.6.12] · 2025-12-01
 [0.6.12]: /../../tree/v0.6.12
 

--- a/helm/messenger/Chart.yaml
+++ b/helm/messenger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: messenger
 description: Open-source front-end part of messenger by team113.
 version: 0.1.4
-appVersion: 0.6.12
+appVersion: 0.6.13
 type: application
 sources:
   - https://github.com/team113/messenger

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -440,14 +440,12 @@ Widget _profile(BuildContext context, MyProfileController c) {
       }),
       const SizedBox(height: 21),
       Obx(() {
-        final presence = c.myUser.value?.presence ?? Presence.present;
+        final Presence presence = c.myUser.value?.presence ?? Presence.present;
 
         return FieldButton(
           key: Key('StatusButton'),
           headline: Text('label_your_status'.l10n),
-          onPressed: () async {
-            await PresenceSwitchView.show(context);
-          },
+          onPressed: () async => await PresenceSwitchView.show(context),
           child: Row(
             children: [
               Container(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.6.12
+version: 0.6.13
 publish_to: none
 
 environment:


### PR DESCRIPTION
Resolves #1539 

## Synopsis

<Give a brief overview of the problem>

Changing your status to "away" or "online" changes the status under your avatars and in the status field in your profile, but when you refresh the page, the status always resets to "online," even if it says "away."


## Solution

`FieldButton` with key `StatusButton` in `MyProfileView` was wrapped with `Obx` widget

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
