### PR TITLE
Invoke `RoomHandle.disableAudio()` for `MediaSourceKind.display` during `_initLocalMedia()` of `OngoingCall`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All user visible changes to this project will be documented in this file. This p
 
 [Diff](/../../compare/v0.7.0...main) | [Milestone](/../../milestone/60)
 
+### Fixed
+
+- UI:
+    - Media panel:
+        - Empty screen sharing being displayed sometimes. ([#1566])
+
+[#1566]: /../../pull/1566
+
 
 
 

--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -1035,6 +1035,8 @@ class OngoingCall {
           try {
             await _room?.disableVideo(MediaSourceKind.display);
             _removeLocalTracks(MediaKind.video, MediaSourceKind.display);
+            await _room?.disableAudio(MediaSourceKind.display);
+            _removeLocalTracks(MediaKind.audio, MediaSourceKind.display);
             screenShareState.value = LocalTrackState.disabled;
             screenDevice.value = null;
           } on MediaStateTransitionException catch (_) {
@@ -2034,6 +2036,7 @@ class OngoingCall {
       if (screenShareState.value != LocalTrackState.enabled &&
           screenShareState.value != LocalTrackState.enabling) {
         await _room?.disableVideo(MediaSourceKind.display);
+        await _room?.disableAudio(MediaSourceKind.display);
       }
 
       try {


### PR DESCRIPTION
## Synopsis

New `medea_jason` version has introduced a new track that wasn't disabled during initialization, which caused remote peers to see that track.




## Solution

This PR ensures this new track is disabled.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
