### PR TITLE
Prevent `CallWorker` to subscribe to `_eventsSubscriptions` when `OngoingCall` is local on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All user visible changes to this project will be documented in this file. This p
 
 [Diff](/../../compare/v0.8.1...main) | [Milestone](/../../milestone/64)
 
+### Fixed
+
+- UI:
+    - Media panel:
+        - Camera disabling for remote peers when disable screen sharing. ([#1594])
+- iOS:
+    - Dialogue calls not being connected sometimes. ([#1594])
+
+[#1594]: /../../pull/1594
+
 
 
 

--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -1748,34 +1748,12 @@ class OngoingCall {
 
             case TrackMediaDirection.sendOnly:
               members[id]?.tracks.addIf(!members[id]!.tracks.contains(t), t);
-
-              switch (kind) {
-                case MediaKind.audio:
-                  // No-op.
-                  break;
-
-                case MediaKind.video:
-                  members[id]?.hasVideo.value = false;
-                  break;
-              }
-
               await t.removeRenderer();
               break;
 
             case TrackMediaDirection.recvOnly:
             case TrackMediaDirection.inactive:
               members[id]?.tracks.remove(t);
-
-              switch (kind) {
-                case MediaKind.audio:
-                  // No-op.
-                  break;
-
-                case MediaKind.video:
-                  members[id]?.hasVideo.value = false;
-                  break;
-              }
-
               await t.removeRenderer();
               break;
           }

--- a/lib/ui/worker/call.dart
+++ b/lib/ui/worker/call.dart
@@ -878,6 +878,16 @@ class CallWorker extends Dependency {
       return;
     }
 
+    final OngoingCall? existing = _callService.calls[chatId]?.value;
+    if (existing?.state.value == OngoingCallState.local) {
+      Log.debug(
+        '_resubscribeTo($chatId) -> call is `local`, boys, let\'s ignore this request to do `_eventsSubscriptions`',
+        '$runtimeType',
+      );
+
+      return;
+    }
+
     _eventsSubscriptions[chatId]?.cancel();
     _eventsSubscriptions[chatId] = _graphQlProvider.chatEvents(chatId, null, () => null).listen((
       e,
@@ -994,7 +1004,10 @@ class CallWorker extends Dependency {
 
     // Ensure that we haven't already joined the call.
     final query = await _graphQlProvider.getChat(chatId);
-    Log.debug('_resubscribeTo($chatId) -> query is $query', '$runtimeType');
+    Log.debug(
+      '_resubscribeTo($chatId) -> query is ${query.toJson()}',
+      '$runtimeType',
+    );
 
     final call = query.chat?.ongoingCall;
     if (call != null) {


### PR DESCRIPTION
## Synopsis

Dialogue calls may disconnect rightaway due to `chatEvents` subscription returning `Chat(ongoingCall: null)` due to `Mutation.startChatCall` not being completed yet.




## Solution

This PR fixes that for local `OngoingCall`s, since when call is starting, there's no `OngoingCall` on `Chat` GraphQL object yet, thus we shouldn't query that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
