### PR TITLE
Restrict some `MyProfile` page and `Chats` tab related functions for `User`-supports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All user visible changes to this project will be documented in this file. This p
 ### Added
 
 - UI:
-    - Support chat. ([#1597], [#1595])
+    - Support chat. ([#1598], [#1597], [#1595])
     - Chat page:
         - Logs button in notes and support chats. ([#1595])
 - Mobile:
@@ -40,6 +40,7 @@ All user visible changes to this project will be documented in this file. This p
 [#1595]: /../../pull/1595
 [#1596]: /../../pull/1596
 [#1597]: /../../pull/1597
+[#1598]: /../../pull/1598
 
 
 

--- a/assets/conf.toml
+++ b/assets/conf.toml
@@ -211,14 +211,14 @@
 #   es-ES = ""
 
 [support]
-# User ID of the support user.
+# Primary user ID of the support user that is always present in chats list.
 #
 # Default:
-#   id = "7GgdGcrEEuLRWMDJakuDkI"
+#   primary = "7GgdGcrEEuLRWMDJakuDkI"
 
 # User IDs of the users that should be considered supports.
 #
 # IDs should be separated by commas.
 #
 # Default:
-#   ids = ""
+#   secondary = ""

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -342,13 +342,13 @@ class Config {
       Log.warning('init() -> announcements failed: $e', 'Config');
     }
 
-    supportId = const bool.hasEnvironment('SOCAPP_SUPPORT_ID')
-        ? const String.fromEnvironment('SOCAPP_SUPPORT_ID')
-        : (document['support']?['id'] ?? supportId);
+    supportId = const bool.hasEnvironment('SOCAPP_SUPPORT_PRIMARY')
+        ? const String.fromEnvironment('SOCAPP_SUPPORT_PRIMARY')
+        : (document['support']?['primary'] ?? supportId);
 
-    final String? ids = const bool.hasEnvironment('SOCAPP_SUPPORT_IDS')
-        ? const String.fromEnvironment('SOCAPP_SUPPORT_IDS')
-        : document['support']?['ids'];
+    final String? ids = const bool.hasEnvironment('SOCAPP_SUPPORT_SECONDARY')
+        ? const String.fromEnvironment('SOCAPP_SUPPORT_SECONDARY')
+        : document['support']?['secondary'];
 
     supportIds = ids == null ? [supportId] : ids.split(',');
 
@@ -450,8 +450,8 @@ class Config {
               Log.warning('init() -> announcements failed: $e', 'Config');
             }
 
-            supportId = remote['support']?['id'] ?? supportId;
-            final String? ids = remote['support']?['ids'];
+            supportId = remote['support']?['primary'] ?? supportId;
+            final String? ids = remote['support']?['secondary'];
             if (ids != null) {
               supportIds = ids.split(',');
             }

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -3349,6 +3349,10 @@ class ChatRepository extends DisposableInterface
   Future<void> _initMonolog() async {
     Log.debug('_initMonolog()', '$runtimeType');
 
+    if (me.isSupport) {
+      return;
+    }
+
     try {
       Log.debug('_initMonolog() -> _monologGuard.protect()...', '$runtimeType');
 
@@ -3431,6 +3435,10 @@ class ChatRepository extends DisposableInterface
     Log.debug('_initSupport()', '$runtimeType');
 
     if (_supportId.val.isEmpty) {
+      return;
+    }
+
+    if (me.isSupport) {
       return;
     }
 

--- a/lib/ui/page/call/component/common.dart
+++ b/lib/ui/page/call/component/common.dart
@@ -285,9 +285,7 @@ class ParticipantsButton extends CallButton {
       expanded: expanded,
       big: big,
       constrained: c.isMobile,
-      onPressed: c.isMonolog || c.isSupport
-          ? null
-          : () => c.openAddMember(router.context!),
+      onPressed: c.isMonolog ? null : () => c.openAddMember(router.context!),
     );
   }
 }

--- a/lib/ui/page/call/controller.dart
+++ b/lib/ui/page/call/controller.dart
@@ -533,10 +533,6 @@ class CallController extends GetxController {
   /// Indicates whether the [chat] is a monolog.
   bool get isMonolog => chat.value?.chat.value.isMonolog ?? false;
 
-  /// Indicates whether the [chat] is a support.
-  bool get isSupport =>
-      !me.id.userId.isSupport && (chat.value?.chat.value.isSupport ?? false);
-
   /// Reactive map of the current call [CallMember]s.
   RxObsMap<CallMemberId, CallMember> get members => _currentCall.value.members;
 

--- a/lib/ui/page/call/participant/controller.dart
+++ b/lib/ui/page/call/participant/controller.dart
@@ -124,6 +124,9 @@ class ParticipantController extends GetxController {
   /// Returns the currently authenticated [MyUser].
   Rx<MyUser?> get myUser => _myUserService.myUser;
 
+  /// Indicates whether currently authenticated [MyUser] is a [User]-support.
+  bool get isSupport => me?.isSupport == true;
+
   @override
   void onInit() {
     scrollController.addListener(_scrollListener);

--- a/lib/ui/page/call/participant/view.dart
+++ b/lib/ui/page/call/participant/view.dart
@@ -103,7 +103,6 @@ class ParticipantView extends StatelessWidget {
                                 ParticipantsFlowStage.participants
                           : null,
                     ),
-
                     Flexible(
                       child: SearchView(
                         categories: const [
@@ -111,7 +110,6 @@ class ParticipantView extends StatelessWidget {
                           SearchCategory.contact,
                           SearchCategory.user,
                         ],
-
                         submit: 'btn_add'.l10n,
                         onSubmit: c.addMembers,
                         enabled: c.status.value.isEmpty,
@@ -221,10 +219,12 @@ class ParticipantView extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.fromLTRB(20, 0, 20, 10),
                         child: PrimaryButton(
-                          onPressed: () {
-                            c.status.value = RxStatus.empty();
-                            c.stage.value = ParticipantsFlowStage.search;
-                          },
+                          onPressed: c.isSupport
+                              ? null
+                              : () {
+                                  c.status.value = RxStatus.empty();
+                                  c.stage.value = ParticipantsFlowStage.search;
+                                },
                           title: 'btn_add_participants'.l10n,
                         ),
                       ),

--- a/lib/ui/page/call/search/controller.dart
+++ b/lib/ui/page/call/search/controller.dart
@@ -588,9 +588,7 @@ class SearchController extends GetxController {
       );
       bool localDialog(RxChat c) => c.id.isLocal && !c.id.isLocalWith(me);
       bool excludeSupports(RxChat c) =>
-          !this.excludeSupports ||
-          me?.isSupport != false ||
-          !c.chat.value.isSupport;
+          !this.excludeSupports || !c.chat.value.isSupport;
 
       final List<RxChat> filtered = allChats
           .whereNot(hidden)
@@ -621,9 +619,7 @@ class SearchController extends GetxController {
       bool isMember(RxUser u) => chat?.members.items.containsKey(u.id) ?? false;
       bool matchesQuery(RxUser user) => _matchesQuery(user: user);
       bool excludeSupports(RxChat c) =>
-          !this.excludeSupports ||
-          me?.isSupport != false ||
-          !c.chat.value.isSupport;
+          !this.excludeSupports || !c.chat.value.isSupport;
 
       Iterable<RxUser> filtered = allChats
           .where(remoteDialog)
@@ -702,9 +698,7 @@ class SearchController extends GetxController {
       bool remoteDialog(RxChat c) => c.chat.value.isDialog && !c.id.isLocal;
       bool hidden(RxChat c) => c.chat.value.isHidden;
       bool excludeSupports(RxChat c) =>
-          !this.excludeSupports ||
-          me?.isSupport != false ||
-          !c.chat.value.isSupport;
+          !this.excludeSupports || !c.chat.value.isSupport;
 
       // Predicates to filter [User]s by.
       bool matchesQuery(RxUser user) => _matchesQuery(user: user);
@@ -715,8 +709,7 @@ class SearchController extends GetxController {
         (c) => c.chat.value.isDialog && c.members.items.containsKey(u.id),
       );
       bool hasRemoteDialog(RxUser u) => !u.user.value.dialog.isLocal;
-      bool notSupport(RxUser u) =>
-          !this.excludeSupports || me?.isSupport != false || !u.id.isSupport;
+      bool notSupport(RxUser u) => !this.excludeSupports || !u.id.isSupport;
 
       RxUser? toUser(RxChat c) =>
           c.members.values.firstWhereOrNull((u) => u.user.id != me)?.user;

--- a/lib/ui/page/erase/controller.dart
+++ b/lib/ui/page/erase/controller.dart
@@ -57,6 +57,9 @@ class EraseController extends GetxController {
   /// Returns the authenticated [MyUser].
   Rx<MyUser?>? get myUser => _myUserService?.myUser;
 
+  /// Indicates whether currently authenticated [MyUser] is a support.
+  bool get isSupport => _authService.userId?.isSupport == true;
+
   /// Signs in and redirects to the [Routes.erase] page.
   ///
   /// Username is [login]'s text and the password is [password]'s text.

--- a/lib/ui/page/erase/view.dart
+++ b/lib/ui/page/erase/view.dart
@@ -158,7 +158,7 @@ class EraseView extends StatelessWidget {
             PrimaryButton(
               key: const Key('ConfirmDelete'),
               title: 'btn_delete_account'.l10n,
-              onPressed: () => _deleteAccount(context, c),
+              onPressed: c.isSupport ? null : () => _deleteAccount(context, c),
               danger: true,
             ),
           ),

--- a/lib/ui/page/home/controller.dart
+++ b/lib/ui/page/home/controller.dart
@@ -133,6 +133,9 @@ class HomeController extends GetxController {
   /// Returns the [ReleaseDownload] being active, if any.
   Rx<ReleaseDownload?> get activeDownload => _upgradeWorker.activeDownload;
 
+  /// Indicates whether currently authenticated [MyUser] is a support.
+  bool get isSupport => _auth.userId?.isSupport == true;
+
   @override
   void onInit() {
     super.onInit();

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -143,6 +143,7 @@ class MyProfileController extends GetxController {
   /// [MyUser.name] field state.
   late final TextFieldState name = TextFieldState(
     text: myUser.value?.name?.val,
+    editable: !isSupport,
     onFocus: (s) async {
       s.error.value = null;
 
@@ -168,6 +169,7 @@ class MyProfileController extends GetxController {
   /// [MyUser.login] field state.
   late final TextFieldState login = TextFieldState(
     text: myUser.value?.login?.val,
+    editable: !isSupport,
     onFocus: (s) async {
       s.error.value = null;
 
@@ -333,6 +335,9 @@ class MyProfileController extends GetxController {
   int get mutedChatsCount => _chatService.paginated.values
       .where((e) => e.chat.value.muted != null)
       .length;
+
+  /// Indicates whether currently authenticated [MyUser] is a support.
+  bool get isSupport => _authService.userId?.isSupport == true;
 
   @override
   void onInit() {

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -270,20 +270,27 @@ Widget _block(BuildContext context, MyProfileController c, int i) {
       });
 
     case ProfileTab.link:
+      if (c.isSupport) {
+        return const SizedBox();
+      }
+
       return block(
         title: 'label_your_direct_link'.l10n,
         children: [
           Obx(() {
-            return DirectLinkField(
-              c.myUser.value?.chatDirectLink,
-              onSubmit: (s) async {
-                if (s == null) {
-                  await c.deleteChatDirectLink();
-                } else {
-                  await c.createChatDirectLink(s);
-                }
-              },
-              background: c.background.value,
+            return IgnorePointer(
+              ignoring: c.isSupport,
+              child: DirectLinkField(
+                c.myUser.value?.chatDirectLink,
+                onSubmit: (s) async {
+                  if (s == null) {
+                    await c.deleteChatDirectLink();
+                  } else {
+                    await c.createChatDirectLink(s);
+                  }
+                },
+                background: c.background.value,
+              ),
             );
           }),
         ],
@@ -431,9 +438,13 @@ Widget _profile(BuildContext context, MyProfileController c) {
             c.myUser.value,
             loading: c.avatarUpload.value.isLoading,
             error: c.avatarUpload.value.errorMessage,
-            onUpload: c.uploadAvatar,
-            onEdit: c.myUser.value?.avatar != null ? c.editAvatar : null,
-            onDelete: c.myUser.value?.avatar != null ? c.deleteAvatar : null,
+            onUpload: c.isSupport ? null : c.uploadAvatar,
+            onEdit: c.myUser.value?.avatar != null && !c.isSupport
+                ? c.editAvatar
+                : null,
+            onDelete: c.myUser.value?.avatar != null && !c.isSupport
+                ? c.deleteAvatar
+                : null,
           );
         }),
       ),
@@ -534,7 +545,7 @@ Widget _addInfo(BuildContext context, MyProfileController c) {
           label: 'label_email'.l10n,
           trailing: WidgetButton(
             key: Key('DeleteEmail_$i'),
-            onPressed: () => _deleteEmail(c, context, e),
+            onPressed: c.isSupport ? null : () => _deleteEmail(c, context, e),
             child: Center(child: SvgIcon(SvgIcons.delete)),
           ),
           spellCheck: false,
@@ -556,8 +567,9 @@ Widget _addInfo(BuildContext context, MyProfileController c) {
             color: style.colors.danger,
           ),
           trailing: WidgetButton(
-            onPressed: () =>
-                _deleteEmail(c, context, unconfirmed, confirmed: false),
+            onPressed: c.isSupport
+                ? null
+                : () => _deleteEmail(c, context, unconfirmed, confirmed: false),
             child: Center(child: SvgIcon(SvgIcons.delete)),
           ),
           spellCheck: false,
@@ -592,7 +604,7 @@ Widget _addInfo(BuildContext context, MyProfileController c) {
             floatingLabelBehavior: FloatingLabelBehavior.always,
             formatters: [LengthLimitingTextInputFormatter(100)],
             spellCheck: false,
-            trailing: c.myUser.value?.login == null
+            trailing: c.myUser.value?.login == null || c.isSupport
                 ? null
                 : WidgetButton(
                     onPressed: () {},
@@ -608,10 +620,11 @@ Widget _addInfo(BuildContext context, MyProfileController c) {
           );
         }),
 
-        const SizedBox(height: 21),
+        if (widgets.isNotEmpty || !c.isSupport) const SizedBox(height: 21),
         ...widgets,
+
         // Don't display the button when there's already 2 added emails.
-        if (unconfirmed != null || emails.length < 2)
+        if (!c.isSupport && (unconfirmed != null || emails.length < 2))
           FieldButton(
             key: Key(
               unconfirmed == null ? 'AddEmailButton' : 'VerifyEmailButton',

--- a/lib/ui/page/home/tab/chats/controller.dart
+++ b/lib/ui/page/home/tab/chats/controller.dart
@@ -202,6 +202,9 @@ class ChatsTabController extends GetxController {
       !connected.value ||
       (fetching.value == null && status.value.isLoadingMore);
 
+  /// Indicates whether currently authenticated [MyUser] is a support.
+  bool get isSupport => me?.isSupport == true;
+
   @override
   void onInit() {
     chatsController.addListener(_chatsListener);

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -326,13 +326,14 @@ class ChatsTabView extends StatelessWidget {
             trailing: const SvgIcon(SvgIcons.select),
             inverted: const SvgIcon(SvgIcons.selectWhite),
           ),
-          ContextMenuButton(
-            key: const Key('CreateGroupButton'),
-            label: 'btn_create_group'.l10n,
-            onPressed: c.startGroupCreating,
-            trailing: const SvgIcon(SvgIcons.group),
-            inverted: const SvgIcon(SvgIcons.groupWhite),
-          ),
+          if (!c.isSupport)
+            ContextMenuButton(
+              key: const Key('CreateGroupButton'),
+              label: 'btn_create_group'.l10n,
+              onPressed: c.startGroupCreating,
+              trailing: const SvgIcon(SvgIcons.group),
+              inverted: const SvgIcon(SvgIcons.groupWhite),
+            ),
           ContextMenuDivider(),
           ContextMenuButton(
             key: const Key('ArchiveChatsButton'),
@@ -353,14 +354,16 @@ class ChatsTabView extends StatelessWidget {
                   )
                 : null,
           ),
-          ContextMenuDivider(),
-          ContextMenuButton(
-            key: const Key('MonologChatButton'),
-            label: 'label_chat_monolog'.l10n,
-            onPressed: () => router.chat(c.monolog),
-            trailing: const SvgIcon(SvgIcons.notesSmall),
-            inverted: const SvgIcon(SvgIcons.notesSmallWhite),
-          ),
+          if (!c.isSupport) ...[
+            ContextMenuDivider(),
+            ContextMenuButton(
+              key: const Key('MonologChatButton'),
+              label: 'label_chat_monolog'.l10n,
+              onPressed: () => router.chat(c.monolog),
+              trailing: const SvgIcon(SvgIcons.notesSmall),
+              inverted: const SvgIcon(SvgIcons.notesSmallWhite),
+            ),
+          ],
         ],
         child: AnimatedButton(
           decorator: (child) {

--- a/lib/ui/page/home/view.dart
+++ b/lib/ui/page/home/view.dart
@@ -354,6 +354,10 @@ class _HomeViewState extends State<HomeView> {
                 currentIndex: tabs.indexOf(router.tab),
                 onTap: (i) {
                   if (i == 0) {
+                    if (c.isSupport) {
+                      return Future.value();
+                    }
+
                     return LinkView.show(context);
                   }
 


### PR DESCRIPTION
## Synopsis

`User`-support has limited functions available for them.




## Solution

This PR restricts the unavailable functions on frontend side.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
