### PR TITLE
Try using `DeviceDetails` with `default` ID for `audioDevice` and `outputDevice` by default in `Call`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Media panel:
         - Pending call notification being displayed when already joined on another device. ([#1605])
+        - Invalid microphone or output being used by default when joining call on Web. ([#1606])
 
 [#1605]: /../../pull/1605
+[#1606]: /../../pull/1606
 
 
 

--- a/lib/domain/model/ongoing_call.dart
+++ b/lib/domain/model/ongoing_call.dart
@@ -1967,6 +1967,7 @@ class OngoingCall {
               devices.output().firstWhereOrNull(
                 (e) => e.id() == _preferredOutputDevice,
               ) ??
+              devices.output().firstWhereOrNull((e) => e.id() == 'default') ??
               devices.output().firstOrNull;
 
           if (outputDevice.value != null) {
@@ -1978,6 +1979,7 @@ class OngoingCall {
             devices.audio().firstWhereOrNull(
               (e) => e.id() == _preferredAudioDevice,
             ) ??
+            devices.audio().firstWhereOrNull((e) => e.id() == 'default') ??
             devices.audio().firstOrNull;
 
         videoDevice.value ??= devices.video().firstWhereOrNull(


### PR DESCRIPTION
## Synopsis

Under web platforms, there's a device marked as `default` ID, which should be used by default. Previously, the first device in the list was the default one. Now this isn't true, which causes invalid behaviour.




## Solution

This PR tries using any device with `default` ID by default.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
