### PR TITLE
Don't display `ConfirmLogoutView` when `MyUser` has confirmed `UserEmail`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All user visible changes to this project will be documented in this file. This p
 
 [Diff](/../../compare/v0.10.1...v0.11.0) | [Milestone](/../../milestone/74)
 
+### Changed
+
+- UI:
+    - Menu tab:
+        - Don't display logout confirmation when e-mail is set. ([#1684])
+
 ### Fixed
 
 - UI:
@@ -21,6 +27,7 @@ All user visible changes to this project will be documented in this file. This p
 
 [#1680]: /../../pull/1680
 [#1683]: /../../pull/1683
+[#1684]: /../../pull/1684
 
 
 

--- a/assets/l10n/en-US.ftl
+++ b/assets/l10n/en-US.ftl
@@ -348,7 +348,7 @@ fcm_message =
             }:{" "}
     }{ $donation ->
         [x] {""}
-        *[other] [G{$donation}]{" "}
+        *[other] [τ{$donation}]{" "}
     }{ $attachmentsCount ->
           [0] {""}
           *[other] [{$attachmentsType ->

--- a/assets/l10n/es-ES.ftl
+++ b/assets/l10n/es-ES.ftl
@@ -345,7 +345,7 @@ fcm_message =
             }:{" "}
     }{ $donation ->
         [x] {""}
-        *[other] [G{$donation}]{" "}
+        *[other] [τ{$donation}]{" "}
     }{ $attachmentsCount ->
             [0] {""}
             *[other] [{$attachmentsType ->

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -343,7 +343,7 @@ fcm_message =
            }:{" "}
     }{ $donation ->
         [x] {""}
-        *[other] [G{$donation}]{" "}
+        *[other] [τ{$donation}]{" "}
     }{ $attachmentsCount ->
           [0] {""}
           *[other] [{$attachmentsType ->

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -766,182 +766,48 @@ class ChatView extends StatelessWidget {
         throw Exception('Unreachable');
       }
 
-      return HighlightedContainer(
-        highlight:
-            c.highlighted.value == element.id || c.selected.contains(element),
-        padding: const EdgeInsets.fromLTRB(8, 1.5, 8, 1.5),
-        child: Padding(
-          padding: EdgeInsets.only(
-            top: previousSame || previous is UnreadMessagesElement ? 0 : 9,
-            bottom: isLast ? ChatController.lastItemBottomOffset : 0,
-          ),
-          child: FutureOrBuilder<RxUser?>(
-            key: element.key,
-            futureOr: () => c.getUser(e.value.author.id),
-            builder: (_, user) => Obx(() {
-              return _selectable(
-                context,
-                c,
-                item: element,
-                child: ChatItemWidget(
-                  chat: c.chat!.chat,
-                  item: e,
-                  me: c.me!,
-                  withAvatar: !c.selecting.value && !previousSame,
-                  withName: !previousSame,
-                  appendAvatarPadding: !c.selecting.value,
-                  selectable: !c.selecting.value,
-                  reads: c.chat!.chat.value.membersCount > 10
-                      ? []
-                      : c.chat!.reads.where(
-                          (m) =>
-                              m.at == e.value.at &&
-                              m.memberId != c.me &&
-                              m.memberId != e.value.author.id,
-                        ),
-                  user: user,
-                  getUser: c.getUser,
-                  getItem: c.getItem,
-                  onHide: () => c.hideChatItem(e.value),
-                  onDelete: () => c.deleteMessage(e.value),
-                  onReply: (item) {
-                    final field = c.edit.value ?? c.send;
+      return Obx(() {
+        return HighlightedContainer(
+          highlight:
+              c.highlighted.value == element.id || c.selected.contains(element),
+          padding: const EdgeInsets.fromLTRB(8, 1.5, 8, 1.5),
+          child: Padding(
+            padding: EdgeInsets.only(
+              top: previousSame || previous is UnreadMessagesElement ? 0 : 9,
+              bottom: isLast ? ChatController.lastItemBottomOffset : 0,
+            ),
+            child: FutureOrBuilder<RxUser?>(
+              key: element.key,
+              futureOr: () => c.getUser(e.value.author.id),
+              builder: (_, user) => Obx(() {
+                return _selectable(
+                  context,
+                  c,
+                  item: element,
+                  child: ChatItemWidget(
+                    chat: c.chat!.chat,
+                    item: e,
+                    me: c.me!,
+                    withAvatar: !c.selecting.value && !previousSame,
+                    withName: !previousSame,
+                    appendAvatarPadding: !c.selecting.value,
+                    selectable: !c.selecting.value,
+                    reads: c.chat!.chat.value.membersCount > 10
+                        ? []
+                        : c.chat!.reads.where(
+                            (m) =>
+                                m.at == e.value.at &&
+                                m.memberId != c.me &&
+                                m.memberId != e.value.author.id,
+                          ),
+                    user: user,
+                    getUser: c.getUser,
+                    getItem: c.getItem,
+                    onHide: () => c.hideChatItem(e.value),
+                    onDelete: () => c.deleteMessage(e.value),
+                    onReply: (item) {
+                      final field = c.edit.value ?? c.send;
 
-                    if (field.replied.any((i) => i.value.id == item.id)) {
-                      field.replied.removeWhere((i) => i.value.id == item.id);
-                    } else {
-                      final ListElement? element =
-                          c.elements[ListElementId(item.at, item.id)];
-
-                      if (element is ChatMessageElement) {
-                        field.replied.add(element.item);
-                      } else if (element is ChatInfoElement) {
-                        field.replied.add(element.item);
-                      } else if (element is ChatCallElement) {
-                        field.replied.add(element.item);
-                      } else if (element is ChatForwardElement) {
-                        field.replied.add(
-                          element.note.value ?? element.forwards.first,
-                        );
-                      }
-                    }
-                  },
-                  onCopy: (text) {
-                    if (c.selection.value?.plainText.isNotEmpty == true) {
-                      c.copyText(c.selection.value!.plainText);
-                    } else {
-                      c.copyText(text);
-                    }
-                  },
-                  onAnimateTo: (item) async {
-                    await c.animateTo(item.id, item: item);
-                  },
-                  onRepliedTap: (q) async {
-                    if (q.original != null) {
-                      await c.animateTo(e.value.id, item: e.value, reply: q);
-                    }
-                  },
-                  onGallery: () => c.calculateGallery(e.value),
-                  onResend: () => c.resendItem(e.value),
-                  onEdit: () => c.editMessage(e.value),
-                  onFileTap: (a) => c.downloadFile(e.value, a),
-                  onAttachmentError: (item) async {
-                    await c.chat?.updateAttachments(item ?? e.value);
-                    await Future.delayed(Duration.zero);
-                  },
-                  onDownload: c.downloadMedia,
-                  onDownloadAs: c.downloadMediaAs,
-                  onSave: (a) => c.saveToGallery(a, e.value),
-                  onSelect: () {
-                    c.selecting.toggle();
-                    c.selected.add(element);
-                  },
-                  onSearch: c.toggleSearch,
-                  onUserPressed: (user) {
-                    ChatId chatId = ChatId.local(user.id);
-                    if (user.dialog.isLocalWith(c.me)) {
-                      chatId = c.monolog;
-                    }
-
-                    router.chat(chatId, mode: RouteAs.push);
-                  },
-                  onDragging: (e) => c.isDraggingItem.value = e,
-                ),
-              );
-            }),
-          ),
-        ),
-      );
-    } else if (element is ChatForwardElement) {
-      return Padding(
-        padding: EdgeInsets.only(
-          top: previousSame || previous is UnreadMessagesElement ? 0 : 9,
-          bottom: isLast ? ChatController.lastItemBottomOffset : 0,
-        ),
-        child: FutureOrBuilder<RxUser?>(
-          key: element.key,
-          futureOr: () => c.getUser(element.authorId),
-          builder: (_, user) => Obx(() {
-            return HighlightedContainer(
-              highlight:
-                  c.highlighted.value == element.id ||
-                  c.selected.contains(element),
-              padding: const EdgeInsets.fromLTRB(8, 1.5, 8, 1.5),
-              child: _selectable(
-                context,
-                c,
-                item: element,
-                child: ChatForwardWidget(
-                  key: Key('ChatForwardWidget_${element.id}'),
-                  chat: c.chat!.chat,
-                  forwards: element.forwards,
-                  note: element.note,
-                  authorId: element.authorId,
-                  me: c.me!,
-                  withAvatar: !c.selecting.value && !previousSame,
-                  withName: !previousSame,
-                  appendAvatarPadding: !c.selecting.value,
-                  selectable: !c.selecting.value,
-                  reads: c.chat!.chat.value.membersCount > 10
-                      ? []
-                      : c.chat!.reads.where(
-                          (m) =>
-                              m.at == element.forwards.last.value.at &&
-                              m.memberId != c.me &&
-                              m.memberId != element.authorId,
-                        ),
-                  user: user,
-                  getUser: c.getUser,
-                  onHide: () async {
-                    final List<Future> futures = [];
-
-                    for (Rx<ChatItem> f in element.forwards) {
-                      futures.add(c.hideChatItem(f.value));
-                    }
-
-                    if (element.note.value != null) {
-                      futures.add(c.hideChatItem(element.note.value!.value));
-                    }
-
-                    await Future.wait(futures);
-                  },
-                  onDelete: () async {
-                    final List<Future> futures = [];
-
-                    for (Rx<ChatItem> f in element.forwards) {
-                      futures.add(c.deleteMessage(f.value));
-                    }
-
-                    if (element.note.value != null) {
-                      futures.add(c.deleteMessage(element.note.value!.value));
-                    }
-
-                    await Future.wait(futures);
-                  },
-                  onReply: (item) {
-                    final MessageFieldController field = c.edit.value ?? c.send;
-
-                    if (item != null) {
                       if (field.replied.any((i) => i.value.id == item.id)) {
                         field.replied.removeWhere((i) => i.value.id == item.id);
                       } else {
@@ -960,91 +826,231 @@ class ChatView extends StatelessWidget {
                           );
                         }
                       }
-                      return;
-                    }
-
-                    if (element.forwards.any(
-                          (e) => field.replied.any(
-                            (i) => i.value.id == e.value.id,
-                          ),
-                        ) ||
-                        field.replied.any(
-                          (i) => i.value.id == element.note.value?.value.id,
-                        )) {
-                      for (Rx<ChatItem> e in element.forwards) {
-                        field.replied.removeWhere(
-                          (i) => i.value.id == e.value.id,
-                        );
-                      }
-
-                      if (element.note.value != null) {
-                        field.replied.removeWhere(
-                          (i) => i.value.id == element.note.value!.value.id,
-                        );
-                      }
-                    } else {
-                      if (element.note.value != null) {
-                        field.replied.add(element.note.value!);
-                      }
-
-                      for (Rx<ChatItem> e in element.forwards) {
-                        field.replied.add(e);
-                      }
-                    }
-                  },
-                  onCopy: (text) {
-                    if (c.selection.value?.plainText.isNotEmpty == true) {
-                      c.copyText(c.selection.value!.plainText);
-                    } else {
-                      c.copyText(text);
-                    }
-                  },
-                  onGallery: (m) => c.calculateGallery(m),
-                  onEdit: () => c.editMessage(element.note.value!.value),
-                  onForwardedTap: (item) {
-                    if (item.quote.original != null) {
-                      if (item.quote.original!.chatId == c.id) {
-                        c.animateTo(item.id, item: item, forward: item.quote);
+                    },
+                    onCopy: (text) {
+                      if (c.selection.value?.plainText.isNotEmpty == true) {
+                        c.copyText(c.selection.value!.plainText);
                       } else {
-                        router.chat(
-                          item.quote.original!.chatId,
-                          itemId: item.quote.original!.id,
-                          mode: RouteAs.push,
-                        );
+                        c.copyText(text);
                       }
-                    }
-                  },
-                  onFileTap: c.downloadFile,
-                  onAttachmentError: (item) async {
-                    if (item != null) {
-                      await c.chat?.updateAttachments(item);
+                    },
+                    onAnimateTo: (item) async {
+                      await c.animateTo(item.id, item: item);
+                    },
+                    onRepliedTap: (q) async {
+                      if (q.original != null) {
+                        await c.animateTo(e.value.id, item: e.value, reply: q);
+                      }
+                    },
+                    onGallery: () => c.calculateGallery(e.value),
+                    onResend: () => c.resendItem(e.value),
+                    onEdit: () => c.editMessage(e.value),
+                    onFileTap: (a) => c.downloadFile(e.value, a),
+                    onAttachmentError: (item) async {
+                      await c.chat?.updateAttachments(item ?? e.value);
                       await Future.delayed(Duration.zero);
-                      return;
-                    }
+                    },
+                    onDownload: c.downloadMedia,
+                    onDownloadAs: c.downloadMediaAs,
+                    onSave: (a) => c.saveToGallery(a, e.value),
+                    onSelect: () {
+                      c.selecting.toggle();
+                      c.selected.add(element);
+                    },
+                    onSearch: c.toggleSearch,
+                    onUserPressed: (user) {
+                      ChatId chatId = ChatId.local(user.id);
+                      if (user.dialog.isLocalWith(c.me)) {
+                        chatId = c.monolog;
+                      }
 
-                    for (ChatItem item in [
-                      element.note.value?.value,
-                      ...element.forwards.map((e) => e.value),
-                    ].nonNulls) {
-                      await c.chat?.updateAttachments(item);
-                    }
+                      router.chat(chatId, mode: RouteAs.push);
+                    },
+                    onDragging: (e) => c.isDraggingItem.value = e,
+                  ),
+                );
+              }),
+            ),
+          ),
+        );
+      });
+    } else if (element is ChatForwardElement) {
+      return Obx(() {
+        return HighlightedContainer(
+          highlight:
+              c.highlighted.value == element.id || c.selected.contains(element),
+          padding: const EdgeInsets.fromLTRB(8, 1.5, 8, 1.5),
+          child: Padding(
+            padding: EdgeInsets.only(
+              top: previousSame || previous is UnreadMessagesElement ? 0 : 9,
+              bottom: isLast ? ChatController.lastItemBottomOffset : 0,
+            ),
+            child: FutureOrBuilder<RxUser?>(
+              key: element.key,
+              futureOr: () => c.getUser(element.authorId),
+              builder: (_, user) => Obx(() {
+                return _selectable(
+                  context,
+                  c,
+                  item: element,
+                  child: ChatForwardWidget(
+                    key: Key('ChatForwardWidget_${element.id}'),
+                    chat: c.chat!.chat,
+                    forwards: element.forwards,
+                    note: element.note,
+                    authorId: element.authorId,
+                    me: c.me!,
+                    withAvatar: !c.selecting.value && !previousSame,
+                    withName: !previousSame,
+                    appendAvatarPadding: !c.selecting.value,
+                    selectable: !c.selecting.value,
+                    reads: c.chat!.chat.value.membersCount > 10
+                        ? []
+                        : c.chat!.reads.where(
+                            (m) =>
+                                m.at == element.forwards.last.value.at &&
+                                m.memberId != c.me &&
+                                m.memberId != element.authorId,
+                          ),
+                    user: user,
+                    getUser: c.getUser,
+                    onHide: () async {
+                      final List<Future> futures = [];
 
-                    await Future.delayed(Duration.zero);
-                  },
-                  onSelect: () {
-                    c.selecting.toggle();
-                    c.selected.add(element);
-                  },
-                  onDragging: (e) => c.isDraggingItem.value = e,
-                  onAnimateTo: (item) async {
-                    await c.animateTo(item.id, item: item);
-                  },
-                ),
-              ),
-            );
-          }),
-        ),
-      );
+                      for (Rx<ChatItem> f in element.forwards) {
+                        futures.add(c.hideChatItem(f.value));
+                      }
+
+                      if (element.note.value != null) {
+                        futures.add(c.hideChatItem(element.note.value!.value));
+                      }
+
+                      await Future.wait(futures);
+                    },
+                    onDelete: () async {
+                      final List<Future> futures = [];
+
+                      for (Rx<ChatItem> f in element.forwards) {
+                        futures.add(c.deleteMessage(f.value));
+                      }
+
+                      if (element.note.value != null) {
+                        futures.add(c.deleteMessage(element.note.value!.value));
+                      }
+
+                      await Future.wait(futures);
+                    },
+                    onReply: (item) {
+                      final MessageFieldController field =
+                          c.edit.value ?? c.send;
+
+                      if (item != null) {
+                        if (field.replied.any((i) => i.value.id == item.id)) {
+                          field.replied.removeWhere(
+                            (i) => i.value.id == item.id,
+                          );
+                        } else {
+                          final ListElement? element =
+                              c.elements[ListElementId(item.at, item.id)];
+
+                          if (element is ChatMessageElement) {
+                            field.replied.add(element.item);
+                          } else if (element is ChatInfoElement) {
+                            field.replied.add(element.item);
+                          } else if (element is ChatCallElement) {
+                            field.replied.add(element.item);
+                          } else if (element is ChatForwardElement) {
+                            field.replied.add(
+                              element.note.value ?? element.forwards.first,
+                            );
+                          }
+                        }
+                        return;
+                      }
+
+                      if (element.forwards.any(
+                            (e) => field.replied.any(
+                              (i) => i.value.id == e.value.id,
+                            ),
+                          ) ||
+                          field.replied.any(
+                            (i) => i.value.id == element.note.value?.value.id,
+                          )) {
+                        for (Rx<ChatItem> e in element.forwards) {
+                          field.replied.removeWhere(
+                            (i) => i.value.id == e.value.id,
+                          );
+                        }
+
+                        if (element.note.value != null) {
+                          field.replied.removeWhere(
+                            (i) => i.value.id == element.note.value!.value.id,
+                          );
+                        }
+                      } else {
+                        if (element.note.value != null) {
+                          field.replied.add(element.note.value!);
+                        }
+
+                        for (Rx<ChatItem> e in element.forwards) {
+                          field.replied.add(e);
+                        }
+                      }
+                    },
+                    onCopy: (text) {
+                      if (c.selection.value?.plainText.isNotEmpty == true) {
+                        c.copyText(c.selection.value!.plainText);
+                      } else {
+                        c.copyText(text);
+                      }
+                    },
+                    onGallery: (m) => c.calculateGallery(m),
+                    onEdit: () => c.editMessage(element.note.value!.value),
+                    onForwardedTap: (item) {
+                      if (item.quote.original != null) {
+                        if (item.quote.original!.chatId == c.id) {
+                          c.animateTo(item.id, item: item, forward: item.quote);
+                        } else {
+                          router.chat(
+                            item.quote.original!.chatId,
+                            itemId: item.quote.original!.id,
+                            mode: RouteAs.push,
+                          );
+                        }
+                      }
+                    },
+                    onFileTap: c.downloadFile,
+                    onAttachmentError: (item) async {
+                      if (item != null) {
+                        await c.chat?.updateAttachments(item);
+                        await Future.delayed(Duration.zero);
+                        return;
+                      }
+
+                      for (ChatItem item in [
+                        element.note.value?.value,
+                        ...element.forwards.map((e) => e.value),
+                      ].nonNulls) {
+                        await c.chat?.updateAttachments(item);
+                      }
+
+                      await Future.delayed(Duration.zero);
+                    },
+                    onSelect: () {
+                      c.selecting.toggle();
+                      c.selected.add(element);
+                    },
+                    onDragging: (e) => c.isDraggingItem.value = e,
+                    onAnimateTo: (item) async {
+                      await c.animateTo(item.id, item: item);
+                    },
+                  ),
+                );
+              }),
+            ),
+          ),
+        );
+      });
     } else if (element is DateTimeElement) {
       return SelectionContainer.disabled(
         child: Obx(() {

--- a/lib/ui/page/home/page/my_profile/controller.dart
+++ b/lib/ui/page/home/page/my_profile/controller.dart
@@ -875,6 +875,13 @@ class MyProfileController extends GetxController {
     await _myUserService.updateUserPresence(next ?? UserPresence.values.first);
   }
 
+  /// Logs out the current session and go to the [Routes.auth] page.
+  void logout() {
+    _authService.logout();
+    router.auth();
+    router.tab = HomeTab.chats;
+  }
+
   /// Records the provided [event] to the [_keysRecorded], if it's not a
   /// modifier.
   bool _hotKeyListener(KeyEvent event) {

--- a/lib/ui/page/home/page/my_profile/view.dart
+++ b/lib/ui/page/home/page/my_profile/view.dart
@@ -463,6 +463,11 @@ Widget _block(BuildContext context, MyProfileController c, int i) {
         children: [
           FieldButton(
             onPressed: () async {
+              // Don't show a confirmation when e-mail is set.
+              if (c.myUser.value?.emails.confirmed.isNotEmpty == true) {
+                return c.logout();
+              }
+
               await ConfirmLogoutView.show(router.context!);
             },
             child: Text('btn_logout'.l10n),

--- a/lib/ui/page/home/tab/menu/controller.dart
+++ b/lib/ui/page/home/tab/menu/controller.dart
@@ -23,6 +23,7 @@ import 'package:get/get.dart';
 import '/api/backend/schema.dart' show UserPresence;
 import '/domain/model/my_user.dart';
 import '/domain/model/user.dart';
+import '/domain/service/auth.dart';
 import '/domain/service/my_user.dart';
 import '/routes.dart';
 import '/util/obs/rxmap.dart';
@@ -31,7 +32,7 @@ export 'view.dart';
 
 /// Controller of the [HomeTab.menu] tab.
 class MenuTabController extends GetxController {
-  MenuTabController(this._myUserService);
+  MenuTabController(this._myUserService, this._authService);
 
   /// [ScrollController] to pass to a [Scrollbar].
   final ScrollController scrollController = ScrollController();
@@ -41,6 +42,9 @@ class MenuTabController extends GetxController {
 
   /// Service managing [MyUser].
   final MyUserService _myUserService;
+
+  /// [AuthService] to do logout.
+  final AuthService _authService;
 
   /// Returns the current [MyUser].
   Rx<MyUser?> get myUser => _myUserService.myUser;
@@ -57,4 +61,11 @@ class MenuTabController extends GetxController {
   /// Sets the [MyUser.presence] to the provided value.
   Future<void> setPresence(UserPresence presence) =>
       _myUserService.updateUserPresence(presence);
+
+  /// Logs out the current session and go to the [Routes.auth] page.
+  void logout() {
+    _authService.logout();
+    router.auth();
+    router.tab = HomeTab.chats;
+  }
 }

--- a/lib/ui/page/home/tab/menu/view.dart
+++ b/lib/ui/page/home/tab/menu/view.dart
@@ -48,7 +48,7 @@ class MenuTabView extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetBuilder(
       key: const Key('MenuTab'),
-      init: MenuTabController(Get.find()),
+      init: MenuTabController(Get.find(), Get.find()),
       builder: (MenuTabController c) {
         final style = Theme.of(context).style;
 
@@ -257,6 +257,11 @@ class MenuTabView extends StatelessWidget {
             ProfileTab.danger => () => router.erase(push: true),
             ProfileTab.support => router.support,
             ProfileTab.logout => () async {
+              // Don't show a confirmation when e-mail is set.
+              if (c.myUser.value?.emails.confirmed.isNotEmpty == true) {
+                return c.logout();
+              }
+
               await ConfirmLogoutView.show(router.context!);
             },
             (_) => () {


### PR DESCRIPTION
## Synopsis

It was discussed that `ConfirmLogoutView` shouldn't be displayed when `MyUser` has confirmed `UserEmail`s.




## Solution

This PR does that.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
