### PR TITLE
Disable `ParticipantsButton` for `Chat`-dialog calls during ringing

### DIFF
--- a/assets/conf.toml
+++ b/assets/conf.toml
@@ -123,8 +123,8 @@
 # tokens, etc).
 #
 # Default:
-#   obfuscated = true (if `kDebugMode`  is `true`)
-#   obfuscated = false" (if `kProfileMode` or `kReleaseMode` is `true`)
+#   obfuscated = false (if `kDebugMode`  is `true`)
+#   obfuscated = true (if `kProfileMode` or `kReleaseMode` is `true`)
 
 # Indicator whether logs should be also written to a `File` in temporary dir.
 #

--- a/lib/ui/page/call/component/common.dart
+++ b/lib/ui/page/call/component/common.dart
@@ -277,16 +277,23 @@ class ParticipantsButton extends CallButton {
 
   @override
   Widget build({bool hinted = true, bool big = false, bool expanded = false}) {
-    return CallButtonWidget(
-      hint: hint,
-      asset: SvgIcons.callParticipants,
-      offset: const Offset(2, 0),
-      hinted: hinted,
-      expanded: expanded,
-      big: big,
-      constrained: c.isMobile,
-      onPressed: c.isMonolog ? null : () => c.openAddMember(router.context!),
-    );
+    return Obx(() {
+      final OngoingCallState state = c.state.value;
+
+      return CallButtonWidget(
+        hint: hint,
+        asset: SvgIcons.callParticipants,
+        offset: const Offset(2, 0),
+        hinted: hinted,
+        expanded: expanded,
+        big: big,
+        constrained: c.isMobile,
+        onPressed:
+            c.isMonolog || (c.isDialog && state != OngoingCallState.active)
+            ? null
+            : () => c.openAddMember(router.context!),
+      );
+    });
   }
 }
 

--- a/lib/ui/worker/cache.dart
+++ b/lib/ui/worker/cache.dart
@@ -166,16 +166,25 @@ class CacheWorker extends Dependency {
                 onReceiveProgress: onReceiveProgress,
               );
             } on DioException catch (e) {
-              if (e.response?.statusCode == 403) {
-                await onForbidden?.call();
-                return null;
+              switch (e.type) {
+                case DioExceptionType.cancel:
+                  throw Exception('CacheWorker.get("$url") request canceled');
+
+                default:
+                  if (e.response?.statusCode == 403) {
+                    await onForbidden?.call();
+                    return null;
+                  }
+                  break;
               }
             }
 
             if (data?.data != null && data!.statusCode == 200) {
               return data.data as Uint8List;
             } else {
-              throw Exception('Data is not loaded');
+              throw Exception(
+                'CacheWorker.get("$url") expected non-`null` fetched data, yet the request failed',
+              );
             }
           }, cancel: cancelToken);
 


### PR DESCRIPTION
## Synopsis

`ParticipantsButton` shouldn't be enabled for `Chat`-dialog ringing calls, because adding a member isn't supported in this state.




## Solution

This PR disables the button for this state.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
