### PR TITLE
Remove double embedded actions of `ContextMenuButton` for `MonologChatButton`

### DIFF
--- a/helm/messenger/Chart.yaml
+++ b/helm/messenger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: messenger
 description: Open-source front-end part of messenger by team113.
 version: 0.2.2
-appVersion: 0.10.2
+appVersion: 0.10.3
 type: application
 sources:
   - https://github.com/team113/messenger

--- a/lib/ui/page/home/tab/chats/view.dart
+++ b/lib/ui/page/home/tab/chats/view.dart
@@ -349,23 +349,7 @@ class ChatsTabView extends StatelessWidget {
                 ContextMenuButton(
                   key: const Key('MonologChatButton'),
                   label: 'label_chat_monolog'.l10n,
-                  // onPressed: () => router.chat(c.monolog),
-                  actions: [
-                    ContextMenuButton(
-                      key: const Key('SupportChatButton'),
-                      label: 'label_support_service'.l10n,
-                      onPressed: () => router.support(),
-                      trailing: const SvgIcon(SvgIcons.supportSmall),
-                      inverted: const SvgIcon(SvgIcons.supportSmallWhite),
-                    ),
-                    ContextMenuButton(
-                      key: const Key('MonologChatButton'),
-                      label: 'label_chat_monolog'.l10n,
-                      onPressed: () => router.chat(c.monolog),
-                      trailing: const SvgIcon(SvgIcons.notesSmall),
-                      inverted: const SvgIcon(SvgIcons.notesSmallWhite),
-                    ),
-                  ],
+                  onPressed: () => router.chat(c.monolog),
                   trailing: const SvgIcon(SvgIcons.notesSmall),
                   inverted: const SvgIcon(SvgIcons.notesSmallWhite),
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.10.2
+version: 0.10.3
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Synopsis

As a mistake, `ContextMenuButton` for `MonologChatButton` has two levels of submenus.




## Solution

This PR removes that mistake.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
