### PR TITLE
Look for last our `ChatMessage` to edit when pressing arrow up in `Chat`

### DIFF
--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -482,7 +482,9 @@ class ChatController extends GetxController {
 
         if (key == LogicalKeyboardKey.arrowUp) {
           final previous = chat?.messages.lastWhereOrNull((e) {
-            return e.value is ChatMessage && !e.value.id.isLocal;
+            return e.value is ChatMessage &&
+                !e.value.id.isLocal &&
+                e.value.author.id == me;
           });
 
           if (previous != null) {


### PR DESCRIPTION
## Synopsis

Currently when pressing up the last `ChatMessage` is being chosen. Instead we should search for last __our__ message.




## Solution

This PR adds the condition.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/team113/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/team113/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
